### PR TITLE
Move FFI regression tests to its own job and use --release.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,9 +43,6 @@ jobs:
           keys:
             - parameter-cache-{{ .Revision }}
       - run:
-          name: run regression tests (examples) against FFI-exposed filecoin-proofs API
-          command: cargo run --package filecoin-proofs --example ffi
-      - run:
           name: Test (stable)
           command: cargo +stable test --verbose --frozen --all
           no_output_timeout: 15m
@@ -77,6 +74,26 @@ jobs:
           command: |
             cargo +stable test --verbose --release --frozen --all
             cargo +stable build --examples --release --frozen --all
+
+  ffi_regression:
+    docker:
+      - image: sidke/rust:latest
+    working_directory: /mnt/crate
+    steps:
+      - checkout
+      - attach_workspace:
+          at: "."
+      - restore_cache:
+          keys:
+            - cargo-v5-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - parameter-cache-{{ .Revision }}
+      - restore_cache:
+          keys:
+            - parameter-cache-{{ .Revision }}
+      - run:
+          name: run regression tests (examples) against FFI-exposed filecoin-proofs API
+          command: cargo run --package filecoin-proofs --release --example ffi
+
 
   test_ignored_release:
     docker:
@@ -178,6 +195,9 @@ workflows:
           requires:
             - cargo_fetch
       - test_release:
+          requires:
+            - cargo_fetch
+      - ffi_regression:
           requires:
             - cargo_fetch
       - test_ignored_release:


### PR DESCRIPTION
The FFI regression tests are adding a lot of time to the `test` job on CI.

- Add the `--release` flag, which is important since circuit proofs are generated.
- Move it to its own job, since keeping it with others makes them run long.