### PR TITLE
[WIP Do Not Merge] ErrorLogResult and swap out expects/unwraps for loggable calls

### DIFF
--- a/filecoin-proofs/src/api/sector_builder/mod.rs
+++ b/filecoin-proofs/src/api/sector_builder/mod.rs
@@ -5,6 +5,7 @@ use crate::api::sector_builder::metadata::*;
 use crate::api::sector_builder::scheduler::Request;
 use crate::api::sector_builder::scheduler::Scheduler;
 use crate::api::sector_builder::sealer::*;
+use crate::error::ErrorLogResult;
 use crate::error::Result;
 use crate::FCP_LOG;
 use sector_base::api::disk_backed_storage::new_sector_store;
@@ -147,9 +148,9 @@ impl SectorBuilder {
         self.scheduler_tx
             .clone()
             .send(with_sender(tx))
-            .expect(FATAL_NOSEND_TASK);
+            .expect_with_logging(FATAL_NOSEND_TASK);
 
-        rx.recv().expect(FATAL_NORECV_TASK)
+        rx.recv().expect_with_logging(FATAL_NORECV_TASK)
     }
 }
 

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -14,6 +14,7 @@ use crate::api::sector_builder::state::StagedState;
 use crate::api::sector_builder::SectorId;
 use crate::api::sector_builder::WrappedKeyValueStore;
 use crate::api::sector_builder::WrappedSectorStore;
+use crate::error::ErrorLogResult;
 use crate::error::Result;
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -60,7 +61,7 @@ impl Scheduler {
             // create it from scratch.
             let state = {
                 let loaded = load_snapshot(&kv_store, &prover_id)
-                    .expect(FATAL_NOLOAD)
+                    .expect_with_logging(FATAL_NOLOAD)
                     .map(|x| x.into());
 
                 loaded.unwrap_or_else(|| SectorBuilderState {
@@ -87,25 +88,30 @@ impl Scheduler {
             };
 
             loop {
-                let task = scheduler_input_rx.recv().expect(FATAL_NORECV);
+                let task = scheduler_input_rx.recv().expect_with_logging(FATAL_NORECV);
 
                 // Dispatch to the appropriate task-handler.
                 match task {
                     Request::AddPiece(key, bytes, tx) => {
-                        tx.send(m.add_piece(key, &bytes)).expect(FATAL_NOSEND);
+                        tx.send(m.add_piece(key, &bytes))
+                            .expect_with_logging(FATAL_NOSEND);
                     }
                     Request::GetSealStatus(sector_id, tx) => {
-                        tx.send(m.get_seal_status(sector_id)).expect(FATAL_NOSEND);
+                        tx.send(m.get_seal_status(sector_id))
+                            .expect_with_logging(FATAL_NOSEND);
                     }
                     Request::RetrievePiece(piece_key, tx) => m.retrieve_piece(piece_key, tx),
                     Request::GetSealedSectors(tx) => {
-                        tx.send(m.get_sealed_sectors()).expect(FATAL_NOSEND);
+                        tx.send(m.get_sealed_sectors())
+                            .expect_with_logging(FATAL_NOSEND);
                     }
                     Request::GetMaxUserBytesPerStagedSector(tx) => {
-                        tx.send(m.max_user_bytes()).expect(FATAL_NOSEND);
+                        tx.send(m.max_user_bytes())
+                            .expect_with_logging(FATAL_NOSEND);
                     }
                     Request::SealAllStagedSectors(tx) => {
-                        tx.send(m.seal_all_staged_sectors()).expect(FATAL_NOSEND);
+                        tx.send(m.seal_all_staged_sectors())
+                            .expect_with_logging(FATAL_NOSEND);
                     }
                     Request::HandleSealResult(sector_id, result) => {
                         m.handle_seal_result(sector_id, *result);
@@ -155,11 +161,14 @@ impl SectorMetadataManager {
             let sealed_sector = Box::new(sealed_sector.clone());
             let task = SealerInput::Unseal(piece_key, sealed_sector, return_channel);
 
-            self.sealer_input_tx.clone().send(task).expect(FATAL_SLRSND);
+            self.sealer_input_tx
+                .clone()
+                .send(task)
+                .expect_with_logging(FATAL_SLRSND);
         } else {
             return_channel
                 .send(Err(err_piecenotfound(piece_key.to_string()).into()))
-                .expect(FATAL_HUNGUP);
+                .expect_with_logging(FATAL_HUNGUP);
         }
     }
 
@@ -225,13 +234,13 @@ impl SectorMetadataManager {
                 let _ = staged_state.sectors.remove(&sector_id);
 
                 // Insert the newly-sealed sector into the other state map.
-                let sealed_sector = result.expect(FATAL_SECMAP);
+                let sealed_sector = result.expect_with_logging(FATAL_SECMAP);
 
                 sealed_state.sectors.insert(sector_id, sealed_sector);
             }
         }
 
-        self.checkpoint().expect(FATAL_SNPSHT);
+        self.checkpoint().expect_with_logging(FATAL_SNPSHT);
     }
 
     // Check for sectors which should no longer receive new user piece-bytes and
@@ -249,7 +258,10 @@ impl SectorMetadataManager {
         // Mark the to-be-sealed sectors as no longer accepting data and then
         // schedule sealing.
         for sector_id in to_be_sealed {
-            let mut sector = staged_state.sectors.get_mut(&sector_id).unwrap();
+            let mut sector = staged_state
+                .sectors
+                .get_mut(&sector_id)
+                .expect_with_logging("sector not in staged_sectors");
             sector.accepting_data = false;
 
             self.sealer_input_tx
@@ -258,7 +270,7 @@ impl SectorMetadataManager {
                     sector.clone(),
                     self.scheduler_input_tx.clone(),
                 ))
-                .expect(FATAL_SLRSND);
+                .expect_with_logging(FATAL_SLRSND);
         }
 
         Ok(())

--- a/filecoin-proofs/src/error.rs
+++ b/filecoin-proofs/src/error.rs
@@ -1,3 +1,30 @@
-use failure::Error;
+use crate::FCP_LOG;
+use failure::{Backtrace, Error};
+use slog::*;
 
 pub type Result<T> = ::std::result::Result<T, Error>;
+
+pub trait ErrorLogResult<T> {
+    fn expect_with_logging(self, msg: &str) -> T;
+}
+
+impl<T, E: std::fmt::Debug> ErrorLogResult<T> for ::std::result::Result<T, E> {
+    fn expect_with_logging(self, msg: &str) -> T {
+        if let Err(ref err) = self {
+            let err = format!("{:?}", err);
+            let backtrace = format!("{:?}", Backtrace::new());
+            error!(FCP_LOG, "expected Result to be Ok"; "error" => err, "backtrace" => backtrace);
+        }
+        self.expect(msg)
+    }
+}
+
+impl<T> ErrorLogResult<T> for Option<T> {
+    fn expect_with_logging(self, msg: &str) -> T {
+        if self.is_none() {
+            let backtrace = format!("{:?}", Backtrace::new());
+            error!(FCP_LOG, "expected Option to be Some"; "backtrace" => backtrace);
+        }
+        self.expect(msg)
+    }
+}


### PR DESCRIPTION
Fixes #267 

## What's in this PR?

- Add new trait which wraps calls to `expect` on both `Result` and `Option` types
- Wrapper method, `expect_with_logging`, logs a backtrace and an error with `error!`

## Notes

- Requires that environment variable/value pair `RUST_BACKTRACE=1` or `RUST_BACKTRACE=full` in order to see backtrace in logs