### PR TITLE
Reduce replication memory

### DIFF
--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -21,10 +21,11 @@ use storage_proofs::error::Result;
 use storage_proofs::fr32::{bytes_into_fr, fr_into_bytes, Fr32Ary};
 use storage_proofs::hasher::Hasher;
 use storage_proofs::layered_drgporep;
+use storage_proofs::merkle::MerkleTree;
 use storage_proofs::parameter_cache::{
     parameter_cache_dir, parameter_cache_path, read_cached_params, write_params_to_cache,
 };
-use storage_proofs::porep::{replica_id, PoRep, ProverAux, Tau};
+use storage_proofs::porep::{replica_id, PoRep, Tau};
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::zigzag_drgporep::ZigZagDrgPoRep;
 use storage_proofs::zigzag_graph::ZigZagBucketGraph;
@@ -302,7 +303,7 @@ fn perform_replication(
     proof_sector_bytes: usize,
 ) -> Result<(
     layered_drgporep::Tau<<DefaultTreeHasher as Hasher>::Domain>,
-    Vec<ProverAux<DefaultTreeHasher>>,
+    Vec<MerkleTree<<DefaultTreeHasher as Hasher>::Domain, <DefaultTreeHasher as Hasher>::Function>>,
 )> {
     if fake {
         // When faking replication, we write the original data to disk, before replication.


### PR DESCRIPTION
When replicating, we generate `ProverAux` — a vector which contains a complete merkle tree for both the current layer's data and the resulting replica. This is redundant, since each layer's replica immediately becomes the next layer's data.

Therefore, instead of storing a vector of `porep::ProverAux`, we should just store a vector of merkle trees. This will have one more element, since the last replica tree generated is unpaired but still needs to be held.

This does indeed result in much lower memory usage. (Of course we can do better still by temporarily storing the trees on disk via explicit write/reads or mmap — but that is … another story.)

NOTE: the changeset here will appear noisy until #393 merges. I based my work off that branch in order to avoid a messy rebase of one or the other branch. It probably makes best sense to merge #393 first, in order to simplify review of this PR.