### PR TITLE
Only use one random seed for graph within a single test.

### DIFF
--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -638,9 +638,9 @@ mod tests {
         let params = &JubjubBls12::new();
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
-        let nodes = 2;
+        let nodes = 5;
         let degree = 2;
-        let challenge = 1;
+        let challenges = vec![1, 3];
         let sloth_iter = 1;
 
         let replica_id: Fr = rng.gen();
@@ -648,13 +648,16 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&Fr::rand(rng)))
             .collect();
 
+        // Only generate seed once. It would be bad if we used different seeds in the same test.
+        let seed = new_seed();
+
         let setup_params = compound_proof::SetupParams {
             vanilla_params: &drgporep::SetupParams {
                 drg: drgporep::DrgParams {
                     nodes,
                     degree,
                     expansion_degree: 0,
-                    seed: new_seed(),
+                    seed,
                 },
                 sloth_iter,
             },
@@ -676,20 +679,19 @@ mod tests {
 
         let public_inputs = drgporep::PublicInputs::<PedersenDomain> {
             replica_id: replica_id.into(),
-            challenges: vec![challenge],
+            challenges,
             tau: Some(tau),
         };
         let private_inputs = drgporep::PrivateInputs { aux: &aux };
 
         // This duplication is necessary so public_params don't outlive public_inputs and private_inputs.
-        // TODO: Abstract it.
         let setup_params = compound_proof::SetupParams {
             vanilla_params: &drgporep::SetupParams {
                 drg: drgporep::DrgParams {
                     nodes,
                     degree,
                     expansion_degree: 0,
-                    seed: new_seed(),
+                    seed,
                 },
                 sloth_iter,
             },


### PR DESCRIPTION
Fixes #298.

This ended up being silly, and it was tons of fun to track down.

The test in question managed lifetime thorniness by creating `SetupParams` twice. Unfortunately, it created a new random seed for the graph the second time. This problem doesn't surface when only challenging node 1, since the parents of the first node are always determined to be node 0. 

It's not entirely clear why #298 claims this does not happen with `nodes = 4`. The most likely explanation is that because this depends on randomness, the error only appears periodically even under the conditions which allow it. Therefore, it's most likely that the issue overfitted to a relatively small number of experimental observations.

In any event, this PR almost certainly fixes the underlying issue.