### PR TITLE
[WIP] Handle the first node

### DIFF
--- a/storage-proofs/src/challenge_derivation.rs
+++ b/storage-proofs/src/challenge_derivation.rs
@@ -23,9 +23,8 @@ pub fn derive_challenges<D: Domain>(
             let hash = blake2s(bytes.as_slice());
             let big_challenge = BigUint::from_bytes_le(hash.as_slice());
 
-            // For now, we cannot try to prove the first or last node, so make sure the challenge can never be 0 or leaves - 1.
-            let big_mod_challenge = big_challenge % (leaves - 2);
-            big_mod_challenge.to_usize().unwrap() + 1
+            let big_mod_challenge = big_challenge % leaves;
+            big_mod_challenge.to_usize().unwrap()
         })
         .collect()
 }

--- a/storage-proofs/src/crypto/kdf.rs
+++ b/storage-proofs/src/crypto/kdf.rs
@@ -32,12 +32,4 @@ mod tests {
         let res = kdf::<Bls12>(&data, m);
         assert_eq!(res, expected);
     }
-
-    #[test]
-    #[should_panic]
-    fn kdf_invalid_block_len() {
-        let data = vec![2u8; 1234];
-
-        kdf::<Bls12>(&data, 44);
-    }
 }

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -239,7 +239,6 @@ where
 
         for i in 0..len {
             let challenge = pub_inputs.challenges[i] % pub_params.graph.size();
-            assert_ne!(challenge, 0, "cannot prove the first node");
 
             let tree_d = &priv_inputs.aux.tree_d;
             let tree_r = &priv_inputs.aux.tree_r;
@@ -340,7 +339,6 @@ where
             }
 
             let challenge = pub_inputs.challenges[i] % pub_params.graph.size();
-            assert_ne!(challenge, 0, "cannot prove the first node");
 
             if !proof.replica_nodes[i].proof.validate(challenge) {
                 println!("invalid replica node");
@@ -732,16 +730,20 @@ mod tests {
 
     table_tests! {
         prove_verify {
+            prove_verify_32_2_0(2, 0);
             prove_verify_32_2_1(2, 1);
 
+            prove_verify_32_3_0(3, 0);
             prove_verify_32_3_1(3, 1);
             prove_verify_32_3_2(3, 2);
 
+            prove_verify_32_10_0(10, 0);
             prove_verify_32_10_1(10, 1);
             prove_verify_32_10_2(10, 2);
             prove_verify_32_10_3(10, 3);
             prove_verify_32_10_4(10, 4);
             prove_verify_32_10_5(10, 5);
+            prove_verify_32_10_9(10, 9);
         }
     }
 

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -120,7 +120,9 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
 
         match node {
             // Special case for the first node, it self references.
-            0 => vec![0; m as usize],
+            // First node has no parents. NOTE: this means the returned array has fewer elements
+            // than that for other nodes.
+            0 => Vec::new(),
             // Special case for the second node, it references only the first one.
             1 => vec![0; m as usize],
             _ => {
@@ -210,7 +212,7 @@ mod tests {
 
                 assert_eq!(g.size(), size, "wrong nodes count");
 
-                assert_eq!(g.parents(0), vec![0; degree as usize]);
+                assert!(g.parents(0).is_empty());
                 assert_eq!(g.parents(1), vec![0; degree as usize]);
 
                 for i in 2..size {

--- a/storage-proofs/src/hasher/digest.rs
+++ b/storage-proofs/src/hasher/digest.rs
@@ -31,15 +31,7 @@ impl<D: Digester> Hasher for DigestHasher<D> {
     type Domain = DigestDomain;
     type Function = DigestFunction<D>;
 
-    fn kdf(data: &[u8], m: usize) -> Self::Domain {
-        assert_eq!(
-            data.len(),
-            32 * (1 + m),
-            "invalid input length: data.len(): {} m: {}",
-            data.len(),
-            m
-        );
-
+    fn kdf(data: &[u8], _m: usize) -> Self::Domain {
         <Self::Function as HashFunction<Self::Domain>>::hash(data)
     }
 

--- a/storage-proofs/src/vde.rs
+++ b/storage-proofs/src/vde.rs
@@ -33,7 +33,6 @@ where
         };
 
         let parents = graph.parents(node);
-        assert_eq!(parents.len(), graph.degree(), "wrong number of parents");
 
         let key = create_key::<H>(replica_id, node, &parents, data, degree)?;
         let start = data_at_node_offset(node);


### PR DESCRIPTION
Closes #50.

I suggest that we can handle the first node (or last node, when graph is reversed) by simply allowing it to have zero parents. The `kdf` will use the `replica_id`, and a unique-to-this-replica key can still be derived deterministically when encoding and decoding.

~This is a good solution since it does not require us to avoid challenging the first or last nodes.~

Unfortunately, this doesn't allow for uniform circuits, so it won't work.