### PR TITLE
Add zigzag to bencher config.

### DIFF
--- a/bench.config.toml
+++ b/bench.config.toml
@@ -19,3 +19,12 @@ size = [ "1 KiB" ] #, "64 MiB", "128 MiB", "256 MiB", "512 MiB", "1024 MiB"]
 hasher = [ "pedersen", "blake2s", "sha256"]
 sloth = [ 0 ]
 m = [ 6 ]
+
+[zigzag]
+challenges = [ 1 ]
+size = ["1 KiB"]
+hasher = ["pedersen"]
+command = "--groth"
+sloth  = [ 0 ]
+m = [ 5 ]
+expansion = [ 6 ]

--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -400,8 +400,6 @@ fn main() {
     let circuit = matches.is_present("circuit");
     let extract = matches.is_present("extract");
 
-    println!("circuit: {:?}", circuit);
-
     info!(FCP_LOG, "hasher: {}", hasher; "target" => "config");
     match hasher.as_ref() {
         "pedersen" => {


### PR DESCRIPTION
Ensure zigzag runs and also generates circuit stats so they can be indexed for benchmark server.