### PR TITLE
Precompute log4 for feistel.

### DIFF
--- a/filecoin-proofs/examples/encoding.rs
+++ b/filecoin-proofs/examples/encoding.rs
@@ -133,7 +133,7 @@ where
     info!(FCP_LOG, "encoding");
 
     start_profile("encode");
-    vde::encode(&drgpp.graph, drgpp.sloth_iter, &replica_id, &mut data);
+    vde::encode(&drgpp.graph, drgpp.sloth_iter, &replica_id, &mut data).unwrap();
     stop_profile();
 
     let encoding_time = start.elapsed();

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -330,7 +330,7 @@ mod tests {
     use crate::layered_drgporep;
     use crate::porep::PoRep;
     use crate::proof::ProofScheme;
-    use crate::zigzag_graph::ZigZagGraph;
+    use crate::zigzag_graph::{ZigZag, ZigZagGraph};
     use pairing::Field;
     use rand::{Rng, SeedableRng, XorShiftRng};
     use sapling_crypto::jubjub::JubjubBls12;
@@ -475,7 +475,7 @@ mod tests {
 
         let public_params = layered_drgporep::PublicParams {
             drg_porep_public_params: drgporep::PublicParams::new(
-                ZigZagGraph::new(n, base_degree, expansion_degree, new_seed()),
+                ZigZagGraph::new_zigzag(n, base_degree, expansion_degree, new_seed()),
                 sloth_iter,
             ),
             layers: num_layers,


### PR DESCRIPTION
We have learned that the feistel permutation called when computing zigzag 'expansion' parents is now the replication bottleneck. This PR precomputes part of that operation and reduces replication time for 1GiB from 67 minutes to <60. The more we can reduce this, the more we can drive replication time down. Based on real numbers making this a no-op — the hard lower bound for times resulting from subsequent feistel optimizations is about ten minutes.

**UPDATE**: By changing the hash function feistel uses from sha256 to blake2s, we can do even better. That brings replication time for 1GiB down to 38.5 minutes. That brings the total replication speed-up of this PR to 1.75x.

```
➜  rust-proofs ✗ ./target/release/examples/zigzag --sloth 0 --size 1048576 --m 5 --expansion 6 --no-bench
Dec 20 13:21:06.694 INFO hasher: pedersen, target: config, place: filecoin-proofs/examples/zigzag.rs:399 zigzag, root: filecoin-proofs
Dec 20 13:21:06.695 INFO data size: 1 GB, target: config, place: filecoin-proofs/examples/zigzag.rs:107 zigzag, root: filecoin-proofs
Dec 20 13:21:06.695 INFO m: 5, target: config, place: filecoin-proofs/examples/zigzag.rs:108 zigzag, root: filecoin-proofs
Dec 20 13:21:06.695 INFO expansion_degree: 6, target: config, place: filecoin-proofs/examples/zigzag.rs:109 zigzag, root: filecoin-proofs
Dec 20 13:21:06.695 INFO sloth: 0, target: config, place: filecoin-proofs/examples/zigzag.rs:110 zigzag, root: filecoin-proofs
Dec 20 13:21:06.696 INFO challenge_count: 1, target: config, place: filecoin-proofs/examples/zigzag.rs:111 zigzag, root: filecoin-proofs
Dec 20 13:21:06.696 INFO layers: 10, target: config, place: filecoin-proofs/examples/zigzag.rs:112 zigzag, root: filecoin-proofs
Dec 20 13:21:06.696 INFO partitions: 1, target: config, place: filecoin-proofs/examples/zigzag.rs:113 zigzag, root: filecoin-proofs
Dec 20 13:21:06.696 INFO circuit: false, target: config, place: filecoin-proofs/examples/zigzag.rs:114 zigzag, root: filecoin-proofs
Dec 20 13:21:06.697 INFO groth: false, target: config, place: filecoin-proofs/examples/zigzag.rs:115 zigzag, root: filecoin-proofs
Dec 20 13:21:06.697 INFO bench: false, target: config, place: filecoin-proofs/examples/zigzag.rs:116 zigzag, root: filecoin-proofs
Dec 20 13:21:06.697 INFO generating fake data, target: status, place: filecoin-proofs/examples/zigzag.rs:118 zigzag, root: filecoin-proofs
Dec 20 13:21:39.322 INFO running setup, place: filecoin-proofs/examples/zigzag.rs:140 zigzag, root: filecoin-proofs
Dec 20 13:21:39.322 INFO running replicate, place: filecoin-proofs/examples/zigzag.rs:148 zigzag, root: filecoin-proofs
Dec 20 13:21:39.705 INFO encoding, layer {}: 0, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:23:18.200 INFO returning tree, layer: 0, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:25:29.507 INFO encoding, layer {}: 1, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:27:07.373 INFO returning tree, layer: 1, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:29:02.780 INFO encoding, layer {}: 2, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:30:40.716 INFO returning tree, layer: 2, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:32:50.130 INFO encoding, layer {}: 3, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:34:27.989 INFO returning tree, layer: 3, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:36:22.903 INFO encoding, layer {}: 4, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:38:00.798 INFO returning tree, layer: 4, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:40:11.911 INFO encoding, layer {}: 5, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:41:50.334 INFO returning tree, layer: 5, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:43:47.535 INFO encoding, layer {}: 6, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:45:25.559 INFO returning tree, layer: 6, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:47:36.253 INFO encoding, layer {}: 7, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:49:14.042 INFO returning tree, layer: 7, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:51:09.657 INFO encoding, layer {}: 8, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:52:47.600 INFO returning tree, layer: 8, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:54:57.778 INFO encoding, layer {}: 9, place: storage-proofs/src/layered_drgporep.rs:325 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 13:56:35.821 INFO returning tree, layer: 9, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:04.186 INFO returning tree, layer: 10, place: storage-proofs/src/layered_drgporep.rs:318 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:05.155 INFO setting tau/aux, layer: 0, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:06.105 INFO setting tau/aux, layer: 1, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:07.056 INFO setting tau/aux, layer: 2, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:08.004 INFO setting tau/aux, layer: 3, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:08.953 INFO setting tau/aux, layer: 4, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:09.900 INFO setting tau/aux, layer: 5, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:10.846 INFO setting tau/aux, layer: 6, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:11.795 INFO setting tau/aux, layer: 7, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:12.743 INFO setting tau/aux, layer: 8, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:13.692 INFO setting tau/aux, layer: 9, place: storage-proofs/src/layered_drgporep.rs:364 storage_proofs::layered_drgporep, root: storage-proofs
Dec 20 14:00:15.093 INFO replication_time: 2315.770714121s, target: stats, place: filecoin-proofs/examples/zigzag.rs:170 zigzag, root: filecoin-proofs
```