### PR TITLE
[WIP] Review and refactor the `fr32` module

### DIFF
--- a/sector-base/src/io/fr32-refactor-plan.md
+++ b/sector-base/src/io/fr32-refactor-plan.md
@@ -2,10 +2,14 @@
 
 - [x] `next_fr_end`, along with `target_offsets` it completes the methods that process the padded/unpadded position, which are always the first methods that call the write functions.
 
-- [ ] Refactor `write_padded_aux`. Move the call to `write_padded_aligned` at the end, unifying both cases, and setting the correct last two arguments (the first 3 are the same), that will prepare it to be merged with `write_padded_aligned`. Everything before the `write_padded_aligned` call should be the logic to align the persisted data.
+- [x] Refactor `write_padded_aux`. Move the call to `write_padded_aligned` at the end, unifying both cases, and setting the correct last two arguments (the first 3 are the same), that will prepare it to be merged with `write_padded_aligned`. Everything before the `write_padded_aligned` call should be the logic to align the persisted data.
 
-- [ ] Should we always call the `write_padded_aligned` function? Is there a case where we don't have enough to byte align the persisted padded data to prepare for it? It wouldn't seem so, the input raw data (byte-aligned) is always bigger than zero (check that), hence it's always bigger than 8 bits, with 7 being the maximum needed to byte align.
+- [x] Should we always call the `write_padded_aligned` function? Is there a case where we don't have enough to byte align the persisted padded data to prepare for it? It wouldn't seem so, the input raw data (byte-aligned) is always bigger than zero (check that), hence it's always bigger than 8 bits, with 7 being the maximum needed to byte align.
 
-- [ ] The whole concept of byte aligning may be unnecessary altogether, what we care about is reaching the element boundary, then we can write whole chunks of `data_chunk_bits` and pad directly (as its done at the end of `write_padded_aligned`), that should take the center of the write logic (the bye aligning, even if needed, could/should be handled separately).
+- [N] The whole concept of byte aligning may be unnecessary altogether, what we care about is reaching the element boundary, then we can write whole chunks of `data_chunk_bits` and pad directly (as its done at the end of `write_padded_aligned`), that should take the center of the write logic (the bye aligning, even if needed, could/should be handled separately). ANSWER: We need this because we operate (pad) at the bit level but we write at the byte level and we need an exclusive logic to handle that transition (incomplete last byte case).
+
+- [ ] Review `write_unpadded_aux`. Much of the logic and insight from `write_padded_aligned` should be applicable here.
 
 - [ ] Leave this for last: go to the lower levels of the of bit/byte positions transformation logic (only after resolving the higher level logic of the write functions), review and document `transform_bit_pos` and `transform_byte_pos` functions. It should be clear why the work the way they do, based on the `PaddingMap` invariants. They seem to be correct, but in a implicit and subtle way: they handle the padding case, and its inverse, unpadding, with the same logic; there's a symmetry that draws my attention that I'm not sure I can explain clearly.
+
+- [ ] Final review and formatting to the `PaddingMap` documentation.


### PR DESCRIPTION
*Work in progress, do not bother to review yet.*

As a first step towards optimizing the `fr32` module (https://github.com/filecoin-project/rust-proofs/issues/397) a full review of the code is being done to try to find the parts that should be clarified to simplify the logic and pave the way for an optimization plan.

As suggested in https://github.com/filecoin-project/rust-proofs/issues/397 this review and refactor aims at **retaining the existing functionality**. With that in mind, no test should be modified in this PR.

The priority right now is clarifying the logic around how we determine the offsets to write to, that is, there are some implicit invariants that should be clearly documented and an API boundary that should be defined:

1. Untangle byte and bit logic, make an explicit *byte* API and internally transform *everything* to bits (except where there is a clear need of the contrary).

2. Something that personally took me too much time to figure out is that since `PaddingMap` is exclusively used to write bytes we can deduce (in `target_offsets` and related) how many bits are "valid" in the last byte (without added metadata) because the "contracted" data in bits needs to be a multiple of 8. That logic is implicitly handled through undocumented `ceil`/`floor` calls and similar. The most confusing part is the relationship between `padded_bytes` and `padded_bit_bytes`, the difference is not the precision between the two but rather that the second one knows which part of the last byte is "valid" (written with actual data and not just zeros generated in the bit-stream-to-byte conversion) and hence needs to express this in a bit-precision size.

3. External functions like `transform_bit_pos` make a heavy use of the `PaddingMap` semantics, e.g., we directly add the remainder to the result (which would go against a transformation of abstract sizes) because we know that there is  padding only if we written the element fully (with padding at the end), that is, the remainder is *all* data, it can't include padding bits because that would imply a complete element that would have left a remainder of zero in the division.

