### PR TITLE
publish with paramcache

### DIFF
--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -20,13 +20,19 @@ fi
 
 echo "preparing release file"
 
-# pack up compiled lib and header
 mkdir $RELEASE_PATH
-cp target/release/paramcache $RELEASE_PATH
-cp target/release/libfilecoin_proofs.a $RELEASE_PATH
-cp filecoin-proofs/libfilecoin_proofs.h $RELEASE_PATH
+mkdir $RELEASE_PATH/bin
+mkdir $RELEASE_PATH/include
+mkdir $RELEASE_PATH/lib
+
+cp target/release/paramcache $RELEASE_PATH/bin/
+cp filecoin-proofs/libfilecoin_proofs.h $RELEASE_PATH/include/
+cp target/release/libfilecoin_proofs.a $RELEASE_PATH/lib/
+
 pushd $RELEASE_PATH
+
 tar -czf $RELEASE_FILE ./*
+
 popd
 
 echo "release file created: $RELEASE_FILE"


### PR DESCRIPTION
paramcache is a necessary binary that `go-filecoin` needs to run for now