### PR TITLE
generate native dependencies

### DIFF
--- a/filecoin-proofs/.gitignore
+++ b/filecoin-proofs/.gitignore
@@ -2,5 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .criterion
-**/libproofs.h
 heaptrack*

--- a/filecoin-proofs/build.rs
+++ b/filecoin-proofs/build.rs
@@ -27,7 +27,7 @@ fn main() {
     // but rather just tell the rest of the system we can't proceed.
     match c {
         Ok(res) => {
-            res.write_to_file("libfilecoin_proofs.h");
+            res.write_to_file(target_path.join("libfilecoin_proofs.h"));
         }
         Err(err) => {
             eprintln!("unable to generate bindings: {:?}", err);
@@ -36,7 +36,7 @@ fn main() {
     }
 
     let b = bindgen::builder()
-        .header("libfilecoin_proofs.h")
+        .header(target_path.join("libfilecoin_proofs.h").to_string_lossy())
         // Here, we tell Rust to link libfilecoin_proofs so that auto-generated
         // symbols are linked to symbols in the compiled dylib. For reasons
         // unbeknown to me, the link attribute needs to precede an extern block.

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -26,7 +26,7 @@ mkdir $RELEASE_PATH/include
 mkdir -p $RELEASE_PATH/lib/pkgconfig
 
 cp target/release/paramcache $RELEASE_PATH/bin/
-cp filecoin-proofs/libfilecoin_proofs.h $RELEASE_PATH/include/
+cp target/release/libfilecoin_proofs.h $RELEASE_PATH/include/
 cp target/release/libfilecoin_proofs.a $RELEASE_PATH/lib/
 cp target/release/libfilecoin_proofs.pc $RELEASE_PATH/lib/pkgconfig
 


### PR DESCRIPTION
this pr generates a .pc file for `go-filecoin` to consume via `pkg-config`
it is generated in the `build.rs` script so that it can be generated when doing `cargo build` and copied from the release directory
the tarball's directory structure works so that it can be extracted directly into `/usr/local`