### PR TITLE
chore: add experimental CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# Global Owners
+* @porcuquine @dignifiedquire
+
+/storage-proofs/        @porcuquine @dignifiedquire
+/filecoin-proofs/       @porcuquine @dignifiedquire @laser
+/ffi-toolkit/           @laser
+/sector-base/           @porcuquine @laser
+/storage-backend/       @porcuquine @dignifiedquire


### PR DESCRIPTION
As discussed earlier today, an experimental CODEOWNERS file. 

See https://help.github.com/articles/about-code-owners/ for a description how this file works.