### PR TITLE
don't install to /usr/local tree

### DIFF
--- a/filecoin-proofs/build.rs
+++ b/filecoin-proofs/build.rs
@@ -73,15 +73,10 @@ fn main() {
 
     write!(
         pc_file,
-        "prefix=/usr/local
-libdir=${{prefix}}/lib
-includedir=${{prefix}}/include
-
-Name: libfilecoin_proofs
+        "Name: libfilecoin_proofs
 Version: {version}
 Description: rust-proofs library
-Libs: -L${{libdir}} -lfilecoin_proofs {libs}
-Cflags: -I${{includedir}}
+Libs: {libs}
 ",
         version = git_hash.trim(),
         libs = libs


### PR DESCRIPTION
pkg-config file shall contain only linking instructions for system library-dependencies