### PR TITLE
Initial implementation of generate_post.

### DIFF
--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -135,23 +135,69 @@ pub unsafe extern "C" fn generate_post(
 /// Verifies that a proof-of-spacetime is valid.
 ///
 #[no_mangle]
-pub extern "C" fn verify_post(
-    _flattened_comm_rs_ptr: *const u8,
-    _flattened_comm_rs_len: libc::size_t,
-    _challenge_seed: &[u8; 32],
+pub unsafe extern "C" fn verify_post(
+    flattened_comm_rs_ptr: *const u8,
+    flattened_comm_rs_len: libc::size_t,
+    challenge_seed: &[u8; 32],
     proof: &[u8; API_POST_PROOF_BYTES],
-    _faults_ptr: *const u64,
-    _faults_len: libc::size_t,
+    faults_ptr: *const u64,
+    faults_len: libc::size_t,
+    sector_bytes: u64,
 ) -> *mut responses::VerifyPoSTResponse {
-    let mut res: responses::VerifyPoSTResponse = Default::default();
+    let mut response: responses::VerifyPoSTResponse = Default::default();
 
     if proof[0] == 42 {
-        res.is_valid = true
+        response.is_valid = true;
     } else {
-        res.is_valid = false
+        response.is_valid = false;
     };
 
-    Box::into_raw(Box::new(res))
+    // Stay mocked for now — remove early return when ready to use.
+    return Box::into_raw(Box::new(response));
+
+    let comm_rs = from_raw_parts(flattened_comm_rs_ptr, flattened_comm_rs_len)
+        .iter()
+        .step_by(32)
+        .fold(Default::default(), |mut acc: Vec<[u8; 32]>, item| {
+            let sliced = from_raw_parts(item, 32);
+            let mut x: [u8; 32] = Default::default();
+            x.copy_from_slice(&sliced[..32]);
+            acc.push(x);
+            acc
+        });
+
+    let faults = from_raw_parts(faults_ptr, faults_len);
+
+    let safe_challenge_seed = {
+        let mut cs = [0; 32];
+        cs.copy_from_slice(challenge_seed);
+        cs[31] &= 0b00111111;
+        cs
+    };
+
+    match internal::verify_post(
+        sector_bytes,
+        &comm_rs,
+        &safe_challenge_seed,
+        proof,
+        faults.to_vec(),
+    ) {
+        Ok(true) => {
+            response.status_code = FCPResponseStatus::FCPNoError;
+            response.is_valid = true;
+        }
+        Ok(false) => {
+            response.status_code = FCPResponseStatus::FCPNoError;
+            response.is_valid = false;
+        }
+        Err(err) => {
+            let (code, ptr) = err_code_and_msg(&err);
+            response.status_code = code;
+            response.error_msg = ptr;
+        }
+    }
+
+    Box::into_raw(Box::new(response))
 }
 
 /// Initializes and returns a SectorBuilder.

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -187,10 +187,13 @@ impl SectorMetadataManager {
             });
         }
 
-        let output = internal::generate_post(PoStInput {
-            challenge_seed: *challenge_seed,
-            input_parts,
-        });
+        let output = internal::generate_post(
+            self.sector_store.inner.config().sector_bytes(),
+            PoStInput {
+                challenge_seed: *challenge_seed,
+                input_parts,
+            },
+        );
 
         // TODO: Where should this work be scheduled? New worker type?
         return_channel.send(output).expects(FATAL_HUNGUP);

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -3,19 +3,31 @@ extern crate rand;
 extern crate sector_base;
 extern crate storage_proofs;
 
-use rand::{SeedableRng, XorShiftRng};
-
 use filecoin_proofs::api::internal;
+use pairing::bls12_381::Bls12;
+
 use sector_base::api::disk_backed_storage::{FAST_SECTOR_SIZE, REAL_SECTOR_SIZE, SLOW_SECTOR_SIZE};
+use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::CompoundProof;
+use storage_proofs::hasher::pedersen::PedersenHasher;
 use storage_proofs::parameter_cache::CacheableParameters;
+use storage_proofs::vdf_post::VDFPoSt;
+use storage_proofs::vdf_sloth::Sloth;
 
 fn cache_params(sector_size: u64) {
     let public_params = internal::public_params(sector_size as usize);
     let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
-    let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
-    let _ = ZigZagCompound::get_groth_params(circuit, &public_params, rng);
+    let _ = ZigZagCompound::get_groth_params(circuit, &public_params);
+
+    let post_public_params = internal::post_public_params(sector_size as usize);
+    let post_circuit: VDFPoStCircuit<Bls12> =
+        <VDFPostCompound as CompoundProof<
+            Bls12,
+            VDFPoSt<PedersenHasher, Sloth>,
+            VDFPoStCircuit<Bls12>,
+        >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
+    let _ = VDFPostCompound::get_groth_params(post_circuit, &post_public_params);
 }
 
 // Run this from the command-line to pre-generate the groth parameters used by the API.

--- a/storage-proofs/src/beacon_post.rs
+++ b/storage-proofs/src/beacon_post.rs
@@ -155,6 +155,7 @@ where
             let pub_inputs_vdf_post = vdf_post::PublicInputs {
                 challenge_seed: r,
                 commitments: pub_inputs.commitments.clone(),
+                faults: Vec::new(),
             };
 
             let priv_inputs_vdf_post = vdf_post::PrivateInputs::new(priv_inputs.trees);
@@ -188,6 +189,7 @@ where
             let pub_inputs_vdf_post = vdf_post::PublicInputs {
                 challenge_seed: r,
                 commitments: pub_inputs.commitments.clone(),
+                faults: Vec::new(),
             };
 
             if !vdf_post::VDFPoSt::verify(

--- a/storage-proofs/src/compound_proof.rs
+++ b/storage-proofs/src/compound_proof.rs
@@ -82,16 +82,16 @@ where
         let vanilla_proofs =
             S::prove_all_partitions(&pub_params.vanilla_params, &pub_in, priv_in, partitions)?;
 
+        let sanity_check =
+            S::verify_all_partitions(&pub_params.vanilla_params, &pub_in, &vanilla_proofs)?;
+        assert!(sanity_check, "sanity check failed");
+
         // This will always run at least once, since there cannot be zero partitions.
         assert!(partition_count > 0);
 
         // If groth_params is None, generate once and share with each thread.
         let actual_groth_params = match groth_params {
             None => {
-                // TODO: eventually, don't generate random params here at all.
-                let rng =
-                    &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
-
                 let circuit = Self::circuit(
                     &pub_in,
                     C::ComponentPrivateInputs::default(),
@@ -100,7 +100,7 @@ where
                     &pub_params.vanilla_params,
                     &pub_params.engine_params,
                 );
-                Self::get_groth_params(circuit, &pub_params.vanilla_params, rng)?
+                Self::get_groth_params(circuit, &pub_params.vanilla_params)?
             }
             Some(gp) => gp,
         };

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -36,7 +36,7 @@ where
     pub challenge_count: usize,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Tau<T: Domain> {
     pub layer_taus: Vec<porep::Tau<T>>,
     pub comm_r_star: T,

--- a/storage-proofs/src/vdf.rs
+++ b/storage-proofs/src/vdf.rs
@@ -3,6 +3,8 @@ use crate::hasher::Domain;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
+use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
+
 /// Generic trait to represent any Verfiable Delay Function (VDF).
 pub trait Vdf<T: Domain>: Clone + ::std::fmt::Debug {
     type SetupParams: Clone + ::std::fmt::Debug;

--- a/storage-proofs/src/vdf_post.rs
+++ b/storage-proofs/src/vdf_post.rs
@@ -66,6 +66,7 @@ pub struct PublicInputs<T: Domain> {
     pub commitments: Vec<T>,
     /// The initial set of challenges. Must be of length `challenge_count`.
     pub challenge_seed: T,
+    pub faults: Vec<u64>, // TODO: Actually use the faults once faults are designed.
 }
 
 #[derive(Clone, Debug)]
@@ -325,7 +326,7 @@ fn derive_partial_challenges<H: Hasher>(count: usize, seed: &[u8]) -> Vec<H::Dom
 /// requires a new random input (`mix`).
 /// A `ChallengeStream` mediates between this usage requirement and the implementation details
 /// of the actual challenge generation mechanism.
-struct ChallengeStream<H: Hasher, V: Vdf<H::Domain>> {
+pub struct ChallengeStream<H: Hasher, V: Vdf<H::Domain>> {
     partial_challenges: Option<Vec<H::Domain>>,
     challenge_count: usize,
     partial_challenge_count: usize,
@@ -337,7 +338,7 @@ struct ChallengeStream<H: Hasher, V: Vdf<H::Domain>> {
 impl<H: Hasher, V: Vdf<H::Domain>> ChallengeStream<H, V> {
     /// A `ChallengeStream` must derive some shared parameters used in challenge derivation.
     /// `new` initializes a new, stateful, `ChallengeStream` with these parameters.
-    fn new(pp: &PublicParams<H::Domain, V>) -> ChallengeStream<H, V> {
+    pub fn new(pp: &PublicParams<H::Domain, V>) -> ChallengeStream<H, V> {
         let challenge_count = pp.challenge_count;
         let sectors_count = pp.sectors_count;
         let challenge_bits = pp.challenge_bits;
@@ -557,6 +558,7 @@ mod tests {
         let pub_inputs = PublicInputs {
             challenge_seed: rng.gen(),
             commitments: vec![tree0.root(), tree1.root()],
+            faults: Vec::new(),
         };
 
         let priv_inputs = PrivateInputs {


### PR DESCRIPTION
This handles the plumbing required to connect `generate_post` to `VDFPost`. For some reason I have not yet been able to determine, generate/verify tests don't pass from `internal.rs` — though the same process is tested as working in the circuit code.

Nevertheless, this bring us strictly closer to PoSt integration, and we should merge now so further work in `internal.rs` doesn't lead to code drift.