### PR TITLE
drgporep: add parents to `decode_domain_block`

### DIFF
--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -281,12 +281,12 @@ where
             let parents = pub_params.graph.parents(challenge);
             let mut replica_parentsi = Vec::with_capacity(parents.len());
 
-            for p in parents {
-                replica_parentsi.push((p, {
-                    let proof = tree_r.gen_proof(p);
+            for p in &parents {
+                replica_parentsi.push((*p, {
+                    let proof = tree_r.gen_proof(*p);
                     DataProof {
                         proof: MerkleProof::new_from_proof(&proof),
-                        data: domain_replica[p],
+                        data: domain_replica[*p],
                     }
                 }));
             }
@@ -310,6 +310,7 @@ where
                     &pub_inputs.replica_id,
                     domain_replica,
                     challenge,
+                    parents,
                 )?
                 .into_bytes();
                 data_nodes.push(DataProof {

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -304,8 +304,8 @@ where
                 //     challenge,
                 // )?;
 
-                let extracted = decode_domain_block(
-                    &pub_params.graph,
+                let extracted = decode_domain_block::<H>(
+                    pub_params.graph.degree(),
                     pub_params.sloth_iter,
                     &pub_inputs.replica_id,
                     domain_replica,

--- a/storage-proofs/src/vde.rs
+++ b/storage-proofs/src/vde.rs
@@ -92,13 +92,12 @@ pub fn decode_domain_block<'a, H, G>(
     replica_id: &'a H::Domain,
     data: &'a [H::Domain],
     v: usize,
+    parents: Vec<usize>,
 ) -> Result<H::Domain>
 where
     H: Hasher,
     G: Graph<H>,
 {
-    let parents = graph.parents(v);
-
     let byte_data = data
         .iter()
         .flat_map(H::Domain::into_bytes)

--- a/storage-proofs/src/vde.rs
+++ b/storage-proofs/src/vde.rs
@@ -86,8 +86,8 @@ where
     Ok(H::sloth_decode(&key, &node_data, sloth_iter))
 }
 
-pub fn decode_domain_block<'a, H, G>(
-    graph: &'a G,
+pub fn decode_domain_block<'a, H>(
+    degree: usize,
     sloth_iter: usize,
     replica_id: &'a H::Domain,
     data: &'a [H::Domain],
@@ -96,14 +96,13 @@ pub fn decode_domain_block<'a, H, G>(
 ) -> Result<H::Domain>
 where
     H: Hasher,
-    G: Graph<H>,
 {
     let byte_data = data
         .iter()
         .flat_map(H::Domain::into_bytes)
         .collect::<Vec<u8>>();
 
-    let key = create_key::<H>(replica_id, v, &parents, &byte_data, graph.degree())?;
+    let key = create_key::<H>(replica_id, v, &parents, &byte_data, degree)?;
     let node_data = data[v];
 
     // TODO: round constant


### PR DESCRIPTION
```
Add the `parents` of node `v` as an argument to `decode_domain_block` to avoid
requesting (and maybe recalculating) them twice for the same node.
`decode_domain_block` is only called in `prove` where the `parents` of node `v`
(`challenge`, in the caller) are already available.
```