### PR TITLE
memory cache for groth params and verifying key

### DIFF
--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -19,18 +19,37 @@ const GENERATE_POST_PARAMS: bool = false;
 
 fn cache_params(sector_size: u64) {
     let public_params = internal::public_params(sector_size as usize);
-    let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
-    let _ = ZigZagCompound::get_groth_params(circuit, &public_params);
+    {
+        let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
+
+        let _ = ZigZagCompound::get_groth_params(circuit, &public_params);
+    }
+    {
+        let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
+        let _ = ZigZagCompound::get_verifying_key(circuit, &public_params);
+    }
 
     if GENERATE_POST_PARAMS {
         let post_public_params = internal::post_public_params(sector_size as usize);
-        let post_circuit: VDFPoStCircuit<Bls12> =
-            <VDFPostCompound as CompoundProof<
-                Bls12,
-                VDFPoSt<PedersenHasher, Sloth>,
-                VDFPoStCircuit<Bls12>,
-            >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
-        let _ = VDFPostCompound::get_groth_params(post_circuit, &post_public_params);
+        {
+            let post_circuit: VDFPoStCircuit<Bls12> =
+                <VDFPostCompound as CompoundProof<
+                    Bls12,
+                    VDFPoSt<PedersenHasher, Sloth>,
+                    VDFPoStCircuit<Bls12>,
+                >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
+            let _ = VDFPostCompound::get_groth_params(post_circuit, &post_public_params);
+        }
+        {
+            let post_circuit: VDFPoStCircuit<Bls12> =
+                <VDFPostCompound as CompoundProof<
+                    Bls12,
+                    VDFPoSt<PedersenHasher, Sloth>,
+                    VDFPoStCircuit<Bls12>,
+                >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
+
+            let _ = VDFPostCompound::get_verifying_key(post_circuit, &post_public_params);
+        }
     }
 }
 

--- a/filecoin-proofs/src/lib.rs
+++ b/filecoin-proofs/src/lib.rs
@@ -23,6 +23,7 @@ extern crate serde_cbor;
 #[macro_use]
 extern crate serde_derive;
 extern crate blake2;
+#[macro_use]
 extern crate slog;
 
 pub mod api;

--- a/parameters.json
+++ b/parameters.json
@@ -3,6 +3,14 @@
     "cid": "QmY8UR7sPGgfeoVB381mrvcdVK4QF28qV5cdoyZFfPuUfM",
     "digest": "8a8e8c1f71927fd93c3c6f0d0f8c3ece"
   },
+  "v9-zigzag-proof-of-replication-f8b6b5b4f1015da3984944b4aef229b63ce950f65c7f41055a995718a452204d.vk": {
+    "cid": "QmUtdjzNLxVDRJV1zYZaZTcuVDZUuvtcfou5Fcdgqph7Ws",
+    "digest": "de91e6df768b455e14748e78693d272b"
+  },
+  "v9-zigzag-proof-of-replication-52431242c129794fe51d373ae29953f2ff52abd94c78756e318ce45f3e4946d8.vk": {
+    "cid": "QmVLfMXHHthzpZo2raxZkF34KLNJQTuNJzkhTTMzxhWfVi",
+    "digest": "76684f54c4b473693a53dfe52e21bb54"
+  },
   "v9-zigzag-proof-of-replication-52431242c129794fe51d373ae29953f2ff52abd94c78756e318ce45f3e4946d8": {
     "cid": "QmP7yBN63YRmnQt7p7ZTQWgahwniNgSoJL5KD1b8eKmGWr",
     "digest": "ad932f2b7b635ee0219cc8d349d06f80"

--- a/storage-proofs/src/circuit/multi_proof.rs
+++ b/storage-proofs/src/circuit/multi_proof.rs
@@ -6,24 +6,24 @@ use std::io::{self, Read, Write};
 
 pub struct MultiProof<E: Engine> {
     pub circuit_proofs: Vec<groth16::Proof<E>>,
-    pub groth_params: groth16::Parameters<E>,
+    pub verifying_key: groth16::VerifyingKey<E>,
 }
 
 impl<E: Engine> MultiProof<E> {
     pub fn new(
         groth_proofs: Vec<groth16::Proof<E>>,
-        groth_params: groth16::Parameters<E>,
+        verifying_key: groth16::VerifyingKey<E>,
     ) -> MultiProof<E> {
         MultiProof {
             circuit_proofs: groth_proofs,
-            groth_params,
+            verifying_key,
         }
     }
 
     pub fn new_from_reader<R: Read>(
         partitions: Option<usize>,
         mut reader: R,
-        groth_params: groth16::Parameters<E>,
+        verifying_key: groth16::VerifyingKey<E>,
     ) -> Result<MultiProof<E>> {
         let num_proofs = match partitions {
             Some(n) => n,
@@ -33,7 +33,7 @@ impl<E: Engine> MultiProof<E> {
             .map(|_| groth16::Proof::read(&mut reader))
             .collect::<io::Result<Vec<_>>>()?;
 
-        Ok(Self::new(proofs, groth_params))
+        Ok(Self::new(proofs, verifying_key))
     }
 
     pub fn write<W: Write>(&self, mut writer: W) -> Result<()> {

--- a/storage-proofs/src/compound_proof.rs
+++ b/storage-proofs/src/compound_proof.rs
@@ -118,7 +118,7 @@ where
             })
             .collect();
 
-        Ok(MultiProof::new(groth_proofs?, actual_groth_params.clone()))
+        Ok(MultiProof::new(groth_proofs?, actual_groth_params.vk))
     }
 
     // verify is equivalent to ProofScheme::verify.
@@ -128,7 +128,7 @@ where
         multi_proof: &MultiProof<E>,
     ) -> Result<bool> {
         let vanilla_public_params = &public_params.vanilla_params;
-        let pvk = groth16::prepare_verifying_key(&multi_proof.groth_params.vk);
+        let pvk = groth16::prepare_verifying_key(&multi_proof.verifying_key);
         if multi_proof.circuit_proofs.len() != Self::partition_count(public_params) {
             return Ok(false);
         }
@@ -154,7 +154,6 @@ where
         params: &'a E::Params,
         groth_params: &groth16::Parameters<E>,
     ) -> Result<groth16::Proof<E>> {
-        // TODO: eventually, don't generate 'random proof' here at all.
         let rng = &mut OsRng::new().unwrap();
 
         // We need to make the circuit repeatedly because we can't clone it.
@@ -208,6 +207,16 @@ where
         engine_params: &'a E::Params,
     ) -> Result<groth16::Parameters<E>> {
         Self::get_groth_params(
+            Self::blank_circuit(public_params, engine_params),
+            public_params,
+        )
+    }
+
+    fn verifying_key(
+        public_params: &S::PublicParams,
+        engine_params: &'a E::Params,
+    ) -> Result<groth16::VerifyingKey<E>> {
+        Self::get_verifying_key(
             Self::blank_circuit(public_params, engine_params),
             public_params,
         )


### PR DESCRIPTION
Closes #477.
Closes #468.

---
**UPDATE**

I added support for verifying key as well. This parallels groth parameter generation throughout.

This means that clients who want only to verify (but not generate) proofs will be able to fetch only the verifying keys they require. This is not necessarily an issue now, but may become one in the future as number and size of circuits grows. Creation of verifying keys still necessarily requires groth params (whether generated or fetched).

**NOTE**

This means that there are now new cache files — just like the groth param files, but with a `.vk` suffix added to the corresponding parameter filename.

I published the initial verifying keys corresponding to the already-published groth params, and updated `parameters.json` here.

---

Unlike the approach described in #477, I ended up putting this in the API internal implementation.

It's not clear that we always want this behavior (especially during tests — where many parameters might be generated).

As importantly, when I tried to implement this in `parameter_cache.rs`, I ran up against a problem:
 - The implementation has to be generic over `JubjubEngine` — but the static `HashMap` has to have a concrete type. Since callers of `get_groth_params()` are also generic, code implementing the cache doesn't know for what type to specialize. That problem is avoided by making the cache a more local construct isolated to a specific usage in which the concrete type (`Bls12`) is known.

Because we don't have the full `parameter_set_identifier()` mechanism, parameters are only distinguished by size (bytes) and type ("ZIGZAG" or "POST"). This is fine as long as we don't have multiple sectors of the same size with different security parameters — which we probably never will.


The following log output shows this is working as designed.
```
➜  rust-proofs git:(feat/in-memory-param-cache-alt) time ./target/release/examples/ffi
Feb 13 18:32:15.070 INFO encoding, layer {}: 0, place: storage-proofs/src/layered_drgporep.rs:398 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.071 INFO encoding, layer {}: 1, place: storage-proofs/src/layered_drgporep.rs:398 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.071 INFO encoding, layer {}: 2, place: storage-proofs/src/layered_drgporep.rs:398 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.071 INFO encoding, layer {}: 3, place: storage-proofs/src/layered_drgporep.rs:398 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.072 INFO returning tree, layer: 0, place: storage-proofs/src/layered_drgporep.rs:391 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.072 INFO returning tree, layer: 1, place: storage-proofs/src/layered_drgporep.rs:391 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.072 INFO returning tree, layer: 2, place: storage-proofs/src/layered_drgporep.rs:391 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.072 INFO returning tree, layer: 3, place: storage-proofs/src/layered_drgporep.rs:391 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.073 INFO returning tree, layer: 4, place: storage-proofs/src/layered_drgporep.rs:391 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.073 INFO setting tau/aux, layer: 0, place: storage-proofs/src/layered_drgporep.rs:437 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.073 INFO setting tau/aux, layer: 1, place: storage-proofs/src/layered_drgporep.rs:437 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.073 INFO setting tau/aux, layer: 2, place: storage-proofs/src/layered_drgporep.rs:437 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.073 INFO setting tau/aux, layer: 3, place: storage-proofs/src/layered_drgporep.rs:437 storage_proofs::layered_drgporep, root: storage-proofs
Feb 13 18:32:15.073 INFO trying memory cache for: ZIGZAG[1024], target: params, place: filecoin-proofs/src/api/internal.rs:95 filecoin_proofs::api::internalFeb 13 18:32:15.074 INFO parameter set identifier for cache: layered_drgporep::PublicParams{ drg_porep_identifier: drgporep::PublicParams{graph: zigzag_graph::ZigZagGraph{expansion_degree: 8 base_graph: drgraph::BucketGraph{size: 32; degree: 5} }; sloth_iter: 0}, challenges: Tapered { layers: 4, count: 2, taper: 0.3333333333333333, taper_layers: 2 } }, target: params, , place: storage-proofs/src/parameter_cache.rs:54 storage_proofs::parameter_cache, root: root: filecoin-proofs
storage-proofs
Feb 13 18:32:15.074 INFO checking cache_path: "/tmp/filecoin-proof-parameters/v9-zigzag-proof-of-replication-f8b6b5b4f1015da3984944b4aef229b63ce950f65c7f41055a995718a452204d", target: params, place: storage-proofs/src/parameter_cache.rs:83 storage_proofs::parameter_cache, root: storage-proofs
Feb 13 18:32:15.074 INFO reading groth params from cache: "/tmp/filecoin-proof-parameters/v9-zigzag-proof-of-replication-f8b6b5b4f1015da3984944b4aef229b63ce950f65c7f41055a995718a452204d", target: params, place: storage-proofs/src/parameter_cache.rs:126 storage_proofs::parameter_cache, root: storage-proofs
Feb 13 18:32:24.978 Feb 13 18:32:24.978 INFOINFO got groth params (1024) while sealing groth_parameter_bytes: 770902584, target: stats, target, place: : storage-proofs/src/parameter_cache.rs:131 storage_proofs::parameter_cache, root: storage-proofs
params, place: filecoin-proofs/src/api/internal.rs:467 filecoin_proofs::api::internal, root: filecoin-proofs
Feb 13 18:32:45.374 INFO trying memory cache for: ZIGZAG[1024], target: params, place: filecoin-proofs/src/api/internal.rs:95 filecoin_proofs::api::internal, root: filecoin-proofs
Feb 13 18:32:45.375 INFO got groth params (1024) while verifying seal, target: params, place: filecoin-proofs/src/api/internal.rs:592 filecoin_proofs::api::internal, root: filecoin-proofs
./target/release/examples/ffi  279.49s user 7.31s system 920% cpu 31.153 total
```
Note in the final lines that parameters were acquired in 1ms with no reading.

Compare with the first report of 'trying memory cache' — which takes 9 seconds and reads from disk.

Unfortunately, the log output is slightly mangled because of interleaved entries.