### PR TITLE
chore: rename rust-proofs to rust-fil-proofs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ If at any point it were to become clear that the FFI approach is irredeemably pr
 
 ## Install and configure Rust
 
-**NOTE:** If you have installed `rust-proofs` incidentally, as a submodule of `go-filecoin`, then you may already have installed Rust.
+**NOTE:** If you have installed `rust-fil-proofs` incidentally, as a submodule of `go-filecoin`, then you may already have installed Rust.
 
-The instructions below assume you have independently installed `rust-proofs` in order to test, develop, or experiment with it.
+The instructions below assume you have independently installed `rust-fil-proofs` in order to test, develop, or experiment with it.
 
 [Install Rust.](https://www.rust-lang.org/en-US/install.html)
 
@@ -99,7 +99,7 @@ Note: On macOS you need `gtime` (`brew install gnu-time`), as the built in `time
 
 For better logging with backtraces on errors, developers should use `expects` rather than `expect` on `Result<T, E>` and `Option<T>`.
 
-Developers can control `rust-proofs` logging through environment variables:
+Developers can control `rust-fil-proofs` logging through environment variables:
 
 -
   `RUST_PROOFS_LOG_JSON`
@@ -156,25 +156,25 @@ docker build -t foo -f ./Dockerfile-ci . && \
 
 ## Generate Documentation
 
-First, navigate to the `rust-proofs` directory.
-- If you installed `rust-proofs` automatically as a submodule of `go-filecoin`:
+First, navigate to the `rust-fil-proofs` directory.
+- If you installed `rust-fil-proofs` automatically as a submodule of `go-filecoin`:
 ```
-> cd <go-filecoin-install-path>/go-filecoin/proofs/rust-proofs
-```
-
-- If you cloned `rust-proofs` manually, it will be wherever you cloned it:
-```
-> cd <install-path>/rust-proofs
+> cd <go-filecoin-install-path>/go-filecoin/proofs/rust-fil-proofs
 ```
 
-[Note that the version of `rust-proofs` included in `go-filecoin` as a submodule is not always the current head of `rust-proofs/master`. For documentation corresponding to the latest source, you should clone `rust-proofs` yourself.]
+- If you cloned `rust-fil-proofs` manually, it will be wherever you cloned it:
+```
+> cd <install-path>/rust-fil-proofs
+```
+
+[Note that the version of `rust-fil-proofs` included in `go-filecoin` as a submodule is not always the current head of `rust-fil-proofs/master`. For documentation corresponding to the latest source, you should clone `rust-fil-proofs` yourself.]
 
 Now, generate the documentation:
 ```
 > cargo doc --all --no-deps
 ```
 
-View the docs by pointing your browser at: `…/rust-proofs/target/doc/proofs/index.html`.
+View the docs by pointing your browser at: `…/rust-fil-proofs/target/doc/proofs/index.html`.
 
 ---
 
@@ -184,24 +184,24 @@ The **FPS** is accessed from [**go-filecoin**](https://github.com/filecoin-proje
 
  The Rust source code serves as the source of truth defining the **FPS** APIs. View the source directly:
 
-- [**filecoin-proofs**](https://github.com/filecoin-project/rust-proofs/blob/master/filecoin-proofs/src/api/mod.rs)
-- [**sector-base**](https://github.com/filecoin-project/rust-proofs/blob/master/sector-base/README.md#api-reference).
+- [**filecoin-proofs**](https://github.com/filecoin-project/rust-fil-proofs/blob/master/filecoin-proofs/src/api/mod.rs)
+- [**sector-base**](https://github.com/filecoin-project/rust-fil-proofs/blob/master/sector-base/README.md#api-reference).
 
 
 Or better, generate the documentation locally (until repository is public). Follow the instructions to generate documentation above. Then navigate to:
-- **Sector Base API:** `…/rust-proofs/target/doc/sector_base/api/index.html`
-- **Filecoin Proofs API:** `…/rust-proofs/target/doc/filecoin_proofs/api/index.html`
+- **Sector Base API:** `…/rust-fil-proofs/target/doc/sector_base/api/index.html`
+- **Filecoin Proofs API:** `…/rust-fil-proofs/target/doc/filecoin_proofs/api/index.html`
 
 - [Go implementation of filecoin-proofs API](https://github.com/filecoin-project/go-filecoin/blob/master/proofs/rustprover.go) and [associated interface structures](https://github.com/filecoin-project/go-filecoin/blob/master/proofs/interface.go).
 - [Go implementation of sector-base API](https://github.com/filecoin-project/go-filecoin/blob/master/proofs/disk_backed_sector_store.go).
 
 ## Contributing
 
-See [Contributing](./CONTRIBUTING.md)
+See [Contributing](CONTRIBUTING.md)
 
 ## License
 
 The Filecoin Project is dual-licensed under Apache 2.0 and MIT terms:
 
-- Apache license, Version 2.0, ([LICENSE-APACHE](https://github.com/filecoin-project/rust-proofs/blob/master/LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](https://github.com/filecoin-project/rust-proofs/blob/master/LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)

--- a/filecoin-proofs/build.rs
+++ b/filecoin-proofs/build.rs
@@ -75,7 +75,7 @@ fn main() {
         pc_file,
         "Name: libfilecoin_proofs
 Version: {version}
-Description: rust-proofs library
+Description: rust-fil-proofs library
 Libs: {libs}
 ",
         version = git_hash.trim(),

--- a/sector-base/README.md
+++ b/sector-base/README.md
@@ -1,6 +1,6 @@
 # Sector Base
 
-The Sector Base provides a database of sectors, implemented in Rust as a crate and exporting a C API for consumption by (for example) `go-filecoin`. It will eventually manage the configuration and implementation of access to sectors (sealed and unsealed) and the disk cache required to perform the operations of `filecoin-proofs` and `storage-proofs`. 
+The Sector Base provides a database of sectors, implemented in Rust as a crate and exporting a C API for consumption by (for example) `go-filecoin`. It will eventually manage the configuration and implementation of access to sectors (sealed and unsealed) and the disk cache required to perform the operations of `filecoin-proofs` and `storage-proofs`.
 
 These methods will include at least:
 - Incremental writing of pieces to sectors
@@ -17,32 +17,33 @@ The Sector Base's responsibilities may extend to:
 - Construction of aggregate merkle trees (merging multiple sectors to generate a single root)
 
 Or even possibly:
-- Random access to sectors indexed by field element (further reducing padding) 
+- Random access to sectors indexed by field element (further reducing padding)
 
 ## A word on 'padding'
 
 There are two types of padding performed on raw data before it can be replicated. For the sake of simplicity, we will refer to these as byte-padding and bit-padding. Byte-padding refers to (zero or more) bytes of zeroes added to the end of raw data in order to bring its total size up to the expected sector size.
 
 Bit-padding, also called 'preprocessing', refers to the two zero *bits* added after every 254 bits of raw data. Padding is necessary (in the current implementation) so that successive logical field elements (Fr) will be byte-aligned. Because the modulus of the field is a 255-bit prime, there are some 255-bit numbers which are NOT elements of our field. Therefore, in order to ensure we never overflow the field, we can take at most 254 bits of real data for every 256 bits (32 bytes) of byte-aligned storage.
-  
+
 ## Design Notes
 
 ### Motivation for Sector Base as a Rust module. Why not part of `go-filecoin`?
    We need to expose some control over disk/file storage at a level that is difficult to do from `go-filecoin` and across the FFI boundary.
 -   Example: Miners may want to treat disks as raw block devices without a filesystem.
-    
-  For example: Go code may pass a Go pointer to C, provided the Go memory to which it points does not contain any Go pointers. Our earlier attempts to write this disk/storage manager in Go involved passing a pointer to a function defined in Go to Rust, which, when applied to some key, returned a value from a Go map (this simulated the FPS acquiring file paths from the disk/file manager). In addition to this pointer, we passed the key. This panicked at runtime with a message "cgo argument has Go pointer to Go pointer," which makes sense given the [cgo documentation](https://golang.org/cmd/cgo/). This isn't a problem if we let Rust manage the disk/storage manager state.  
-      
+
+  For example: Go code may pass a Go pointer to C, provided the Go memory to which it points does not contain any Go pointers. Our earlier attempts to write this disk/storage manager in Go involved passing a pointer to a function defined in Go to Rust, which, when applied to some key, returned a value from a Go map (this simulated the FPS acquiring file paths from the disk/file manager). In addition to this pointer, we passed the key. This panicked at runtime with a message "cgo argument has Go pointer to Go pointer," which makes sense given the [cgo documentation](https://golang.org/cmd/cgo/). This isn't a problem if we let Rust manage the disk/storage manager state.
+
    Moreover, this specific problem is emblematic of the friction imposed by the FFI boundary. In fact, communication between the Sector Base and the proving components of FPS (`filecoin-proofs` and `storage-proofs`) will need to be carefully coordinated for both efficiency and correctness. The issue is less that Go is problematic than that the FFI boundary will interfere with optimal function. That said, Rust’s type system will be quite helpful for the kind of performant genericity required. Although this naturally lives on the Rust side of that API boundary, the concerns controlling these functions include those which are only peripherally related to the proofs themselves.
 
- Configuration and tuning of storage concerns will depend on considerations derived from interacting with the Filecoin protocol and blockchain in ways which have potentially nothing to do with the storage proofs. This logic should not be contained in the proof modules. These two considerations delimit what the Sector Base is *not* (part of `go-filecoin` itself, or part of `storage-proofs` which must consume it). This also explains why `sector-base` currently exists as an independent crate packaged under the umbrella of the Filecoin Proving Subsystem (FPS) with source in the `rust-proofs` repository.
+ Configuration and tuning of storage concerns will depend on considerations derived from interacting with the Filecoin protocol and blockchain in ways which have potentially nothing to do with the storage proofs. This logic should not be contained in the proof modules. These two considerations delimit what the Sector Base is *not* (part of `go-filecoin` itself, or part of `storage-proofs` which must consume it). This also explains why `sector-base` currently exists as an independent crate packaged under the umbrella of the Filecoin Proving Subsystem (FPS) with source in the `rust-fil-proofs` repository.
 
 ## API Reference
-[**Sector Base API**](https://github.com/filecoin-project/rust-proofs/blob/master/sector-base/src/api/mod.rs). The Rust source code serves as the source of truth defining the **Sector Base** API and will be the eventual source of generated documentation.
+[**Sector Base API**](https://github.com/filecoin-project/rust-fil-proofs/blob/master/sector-base/src/api/mod.rs). The Rust source code serves as the source of truth defining the **Sector Base** API and will be the eventual source of generated documentation.
 
-[**DiskBackedSectorStore API**](https://github.com/filecoin-project/rust-proofs/blob/master/sector-base/src/api/disk_backed_storage.rs)
+[**DiskBackedSectorStore API**](https://github.com/filecoin-project/rust-fil-proofs/blob/master/sector-base/src/api/disk_backed_storage.rs)
 
-[**Response Structs**](https://github.com/filecoin-project/rust-proofs/blob/master/sector-base/src/api/responses.rs)
+[**Response Structs**](https://github.com/filecoin-project/rust-fil-proofs/blob/master/sector-base/src/api/responses.rs)
+
 ## License
 
 MIT or Apache 2.0


### PR DESCRIPTION
Closes #475 

@porcuquine I have not renamed the top level crate, because I realized we already have `filecoin-proofs`, which would make things very confusing. I don't think it matters much, as that is only the placeholder crate and would not get published for now. But let me know if you think otherwise