### PR TITLE
bugs/493 dynamic public parameters sectors count

### DIFF
--- a/filecoin-proofs/src/api/sector_builder/helpers/add_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/add_piece.rs
@@ -4,7 +4,7 @@ use crate::api::sector_builder::metadata::StagedSectorMetadata;
 use crate::api::sector_builder::state::StagedState;
 use crate::api::sector_builder::*;
 use crate::error;
-use sector_base::api::sector_store::SectorManager;
+use sector_base::api::sector_store::{SectorManager, UnpaddedBytesAmount};
 use std::sync::Arc;
 
 pub fn add_piece(
@@ -16,7 +16,7 @@ pub fn add_piece(
     let sector_mgr = sector_store.inner.manager();
     let sector_max = sector_store.inner.config().max_unsealed_bytes_per_sector();
 
-    let piece_bytes_len = piece_bytes.len() as u64;
+    let piece_bytes_len = UnpaddedBytesAmount(piece_bytes.len() as u64);
 
     let opt_dest_sector_id = {
         let candidates: Vec<StagedSectorMetadata> = staged_state
@@ -41,7 +41,10 @@ pub fn add_piece(
             .map_err(|err| err.into())
             .and_then(|num_bytes_written| {
                 if num_bytes_written != piece_bytes_len {
-                    Err(err_inc_write(num_bytes_written, piece_bytes_len).into())
+                    Err(
+                        err_inc_write(u64::from(num_bytes_written), u64::from(piece_bytes_len))
+                            .into(),
+                    )
                 } else {
                     Ok(s.sector_id)
                 }
@@ -63,11 +66,11 @@ pub fn add_piece(
 // first staged sector into which the bytes will fit.
 fn compute_destination_sector_id(
     candidate_sectors: &[StagedSectorMetadata],
-    max_bytes_per_sector: u64,
-    num_bytes_in_piece: u64,
+    max_bytes_per_sector: UnpaddedBytesAmount,
+    num_bytes_in_piece: UnpaddedBytesAmount,
 ) -> error::Result<Option<SectorId>> {
     if num_bytes_in_piece > max_bytes_per_sector {
-        Err(err_overflow(num_bytes_in_piece, max_bytes_per_sector).into())
+        Err(err_overflow(num_bytes_in_piece.into(), max_bytes_per_sector.into()).into())
     } else {
         Ok(candidate_sectors
             .iter()
@@ -116,25 +119,29 @@ mod tests {
 
         sealed_sector_a.pieces.push(PieceMetadata {
             piece_key: String::from("x"),
-            num_bytes: 5,
+            num_bytes: UnpaddedBytesAmount(5),
         });
 
         sealed_sector_a.pieces.push(PieceMetadata {
             piece_key: String::from("x"),
-            num_bytes: 10,
+            num_bytes: UnpaddedBytesAmount(10),
         });
 
         let mut sealed_sector_b: StagedSectorMetadata = Default::default();
 
         sealed_sector_b.pieces.push(PieceMetadata {
             piece_key: String::from("x"),
-            num_bytes: 5,
+            num_bytes: UnpaddedBytesAmount(5),
         });
 
         let staged_sectors = vec![sealed_sector_a.clone(), sealed_sector_b.clone()];
 
         // piece takes up all remaining space in first sector
-        match compute_destination_sector_id(&staged_sectors, 100, 85) {
+        match compute_destination_sector_id(
+            &staged_sectors,
+            UnpaddedBytesAmount(100),
+            UnpaddedBytesAmount(85),
+        ) {
             Ok(Some(destination_sector_id)) => {
                 assert_eq!(destination_sector_id, sealed_sector_a.sector_id)
             }
@@ -142,7 +149,11 @@ mod tests {
         }
 
         // piece doesn't fit into the first, but does the second
-        match compute_destination_sector_id(&staged_sectors, 100, 90) {
+        match compute_destination_sector_id(
+            &staged_sectors,
+            UnpaddedBytesAmount(100),
+            UnpaddedBytesAmount(90),
+        ) {
             Ok(Some(destination_sector_id)) => {
                 assert_eq!(destination_sector_id, sealed_sector_b.sector_id)
             }
@@ -150,13 +161,21 @@ mod tests {
         }
 
         // piece doesn't fit into any in the list
-        match compute_destination_sector_id(&staged_sectors, 100, 100) {
+        match compute_destination_sector_id(
+            &staged_sectors,
+            UnpaddedBytesAmount(100),
+            UnpaddedBytesAmount(100),
+        ) {
             Ok(None) => (),
             _ => panic!(),
         }
 
         // piece is over max
-        match compute_destination_sector_id(&staged_sectors, 100, 101) {
+        match compute_destination_sector_id(
+            &staged_sectors,
+            UnpaddedBytesAmount(100),
+            UnpaddedBytesAmount(101),
+        ) {
             Err(_) => (),
             _ => panic!(),
         }

--- a/filecoin-proofs/src/api/sector_builder/helpers/get_sectors_ready_for_sealing.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/get_sectors_ready_for_sealing.rs
@@ -4,11 +4,12 @@ use crate::api::sector_builder::metadata::StagedSectorMetadata;
 use crate::api::sector_builder::state::StagedState;
 use crate::api::sector_builder::SectorId;
 use itertools::chain;
+use sector_base::api::sector_store::UnpaddedBytesAmount;
 use std::cmp::Reverse;
 
 pub fn get_sectors_ready_for_sealing(
     staged_state: &StagedState,
-    max_user_bytes_per_staged_sector: u64,
+    max_user_bytes_per_staged_sector: UnpaddedBytesAmount,
     max_num_staged_sectors: u8,
     seal_all_staged_sectors: bool,
 ) -> Vec<SectorId> {
@@ -59,7 +60,7 @@ mod tests {
                 sector_id,
                 pieces: vec![PieceMetadata {
                     piece_key: format!("{}", sector_id),
-                    num_bytes,
+                    num_bytes: UnpaddedBytesAmount(num_bytes),
                 }],
                 seal_status,
                 ..Default::default()
@@ -79,9 +80,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 10, true)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 10, true)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![201 as SectorId, 200 as SectorId], to_seal);
     }
@@ -98,9 +100,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 10, false)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 10, false)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![200 as SectorId], to_seal);
     }
@@ -119,9 +122,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 2, false)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 2, false)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![201 as SectorId, 200 as SectorId], to_seal);
     }
@@ -140,9 +144,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 4, false)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 4, false)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![0; 0], to_seal);
     }
@@ -161,9 +166,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 4, false)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 4, false)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![0; 0], to_seal);
     }

--- a/filecoin-proofs/src/api/sector_builder/metadata.rs
+++ b/filecoin-proofs/src/api/sector_builder/metadata.rs
@@ -3,6 +3,7 @@ use crate::error;
 use crate::serde_big_array::BigArray;
 use byteorder::LittleEndian;
 use byteorder::WriteBytesExt;
+use sector_base::api::sector_store::UnpaddedBytesAmount;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -30,7 +31,7 @@ pub struct SealedSectorMetadata {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct PieceMetadata {
     pub piece_key: String,
-    pub num_bytes: u64,
+    pub num_bytes: UnpaddedBytesAmount,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -84,8 +85,10 @@ impl Default for SealedSectorMetadata {
     }
 }
 
-pub fn sum_piece_bytes(s: &StagedSectorMetadata) -> u64 {
-    s.pieces.iter().map(|x| x.num_bytes).sum()
+pub fn sum_piece_bytes(s: &StagedSectorMetadata) -> UnpaddedBytesAmount {
+    s.pieces
+        .iter()
+        .fold(UnpaddedBytesAmount(0), |acc, x| acc + x.num_bytes)
 }
 
 pub fn sector_id_as_bytes(sector_id: SectorId) -> error::Result<[u8; 31]> {

--- a/filecoin-proofs/src/api/sector_builder/mod.rs
+++ b/filecoin-proofs/src/api/sector_builder/mod.rs
@@ -12,6 +12,7 @@ use crate::FCP_LOG;
 use sector_base::api::disk_backed_storage::new_sector_store;
 use sector_base::api::disk_backed_storage::ConfiguredStore;
 use sector_base::api::sector_store::SectorStore;
+use sector_base::api::sector_store::UnpaddedBytesAmount;
 use slog::*;
 use std::sync::{mpsc, Arc, Mutex};
 
@@ -109,7 +110,7 @@ impl SectorBuilder {
 
     // Returns the number of user-provided bytes that will fit into a staged
     // sector.
-    pub fn get_max_user_bytes_per_staged_sector(&self) -> u64 {
+    pub fn get_max_user_bytes_per_staged_sector(&self) -> UnpaddedBytesAmount {
         self.run_blocking(Request::GetMaxUserBytesPerStagedSector)
     }
 

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -21,6 +21,7 @@ use crate::api::sector_builder::WrappedKeyValueStore;
 use crate::api::sector_builder::WrappedSectorStore;
 use crate::error::ExpectWithBacktrace;
 use crate::error::Result;
+use sector_base::api::sector_store::UnpaddedBytesAmount;
 use std::collections::HashMap;
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -52,7 +53,7 @@ pub enum Request {
     ),
     RetrievePiece(String, mpsc::SyncSender<Result<Vec<u8>>>),
     SealAllStagedSectors(mpsc::SyncSender<Result<()>>),
-    GetMaxUserBytesPerStagedSector(mpsc::SyncSender<u64>),
+    GetMaxUserBytesPerStagedSector(mpsc::SyncSender<UnpaddedBytesAmount>),
     HandleSealResult(SectorId, Box<Result<SealedSectorMetadata>>),
     Shutdown,
 }
@@ -153,7 +154,7 @@ pub struct SectorMetadataManager {
     sealer_input_tx: mpsc::Sender<SealerInput>,
     scheduler_input_tx: mpsc::SyncSender<Request>,
     max_num_staged_sectors: u8,
-    max_user_bytes_per_staged_sector: u64,
+    max_user_bytes_per_staged_sector: UnpaddedBytesAmount,
 }
 
 impl SectorMetadataManager {
@@ -188,10 +189,13 @@ impl SectorMetadataManager {
             });
         }
 
-        let output = internal::fake_generate_post(
-            self.sector_store.inner.config().sector_bytes(),
+        let mut seed = [0; 32];
+        seed.copy_from_slice(challenge_seed);
+
+        let output = internal::generate_post(
+            self.sector_store.inner.config(),
             PoStInput {
-                challenge_seed: *challenge_seed,
+                challenge_seed: seed,
                 input_parts,
             },
         );
@@ -272,7 +276,7 @@ impl SectorMetadataManager {
 
     // Returns the number of user-provided bytes that will fit into a staged
     // sector.
-    pub fn max_user_bytes(&self) -> u64 {
+    pub fn max_user_bytes(&self) -> UnpaddedBytesAmount {
         self.max_user_bytes_per_staged_sector
     }
 

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -7,6 +7,7 @@ use filecoin_proofs::api::internal;
 use pairing::bls12_381::Bls12;
 
 use sector_base::api::disk_backed_storage::{LIVE_SECTOR_SIZE, TEST_SECTOR_SIZE};
+use sector_base::api::sector_store::PaddedBytesAmount;
 use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::CompoundProof;
@@ -18,12 +19,16 @@ use storage_proofs::vdf_sloth::Sloth;
 const GENERATE_POST_PARAMS: bool = false;
 
 fn cache_params(sector_size: u64) {
-    let public_params = internal::public_params(sector_size as usize);
+    let bytes_amount = PaddedBytesAmount(sector_size);
+    let public_params = internal::public_params(bytes_amount);
     let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
     let _ = ZigZagCompound::get_groth_params(circuit, &public_params);
 
     if GENERATE_POST_PARAMS {
-        let post_public_params = internal::post_public_params(sector_size as usize);
+        // TODO: How do we select a "sectors count" in this context?
+        //
+        // See: https://github.com/filecoin-project/rust-fil-proofs/issues/492
+        let post_public_params = internal::post_public_params(1, bytes_amount);
         let post_circuit: VDFPoStCircuit<Bls12> =
             <VDFPostCompound as CompoundProof<
                 Bls12,

--- a/filecoin-proofs/src/bin/paramgen.rs
+++ b/filecoin-proofs/src/bin/paramgen.rs
@@ -10,6 +10,7 @@ use std::fs::File;
 
 use filecoin_proofs::api::internal;
 use sector_base::api::disk_backed_storage::LIVE_SECTOR_SIZE;
+use sector_base::api::sector_store::PaddedBytesAmount;
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::CompoundProof;
 
@@ -18,7 +19,7 @@ pub fn main() {
     let args: Vec<String> = env::args().collect();
     let out_file = &args[1];
 
-    let public_params = internal::public_params(LIVE_SECTOR_SIZE as usize);
+    let public_params = internal::public_params(PaddedBytesAmount(LIVE_SECTOR_SIZE));
 
     let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
     let mut params = phase2::MPCParameters::new(circuit).unwrap();

--- a/sector-base/Cargo.toml
+++ b/sector-base/Cargo.toml
@@ -14,6 +14,10 @@ libc = "0.2"
 rand = "0.4"
 storage-proofs = { path = "../storage-proofs" }
 ffi-toolkit = { path = "../ffi-toolkit" }
+serde_cbor = "0.9.0"
+serde = { version = "1", features = ["rc"] }
+serde_derive = "1.0"
+serde_json = "1.0"
 
 [dependencies.pairing]
 version = "0.14.2"

--- a/sector-base/src/api/disk_backed_storage.rs
+++ b/sector-base/src/api/disk_backed_storage.rs
@@ -179,7 +179,7 @@ impl DiskManager {
 }
 
 pub struct Config {
-    sector_bytes: u64,
+    pub sector_bytes: u64,
 }
 
 #[derive(Debug)]
@@ -233,6 +233,10 @@ pub fn new_sector_config(cs: &ConfiguredStore) -> Box<SectorConfig> {
 impl SectorConfig for Config {
     fn max_unsealed_bytes_per_sector(&self) -> u64 {
         unpadded_bytes(self.sector_bytes)
+    }
+
+    fn max_sealed_bytes_per_sector(&self) -> u64 {
+        self.sector_bytes
     }
 
     fn sector_bytes(&self) -> u64 {

--- a/sector-base/src/api/sector_store.rs
+++ b/sector-base/src/api/sector_store.rs
@@ -1,8 +1,11 @@
 use crate::api::errors::SectorManagerErr;
 
 pub trait SectorConfig {
-    /// returns the number of bytes that will fit into a sector managed by this store
+    /// returns the number of user-provided bytes that will fit into a sector managed by this store
     fn max_unsealed_bytes_per_sector(&self) -> u64;
+
+    /// returns the number of bytes that will fit into a sector managed by this store
+    fn max_sealed_bytes_per_sector(&self) -> u64;
 
     /// returns the number of bytes in a sealed sector managed by this store
     fn sector_bytes(&self) -> u64;


### PR DESCRIPTION
Fixes #493 and unblocks go-filecoin issue [`#1996`](https://github.com/filecoin-project/go-filecoin/issues/1996) (_PoSt Randomness outside the State Machine_).

## What's in this PR?

- BUGFIX: make VDF PoSt public parameter-generation accept a value to use as "sectors count" instead of hard-coding to 2
- Modify FFI-exposed `generate_post` to call `internal::generate_post`
- Add PoSt generate and verify to FFI-level tests

## Controversial Stuff: newtypes

I've introduced two [newtypes](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html), `PaddedBytesAmount` and `UnpaddedBytesAmount` and modified the `SectorManager` and `SectorConfig` traits to return/accept values of these types instead of `u64`. This will improve safety (from a programmer bug-producing standpoint) by preventing a programmer from passing a padded bytes amount to a place where an unpadded bytes amount is expected (and vice-versa).

## Controversial Stuff: Groth parameter-generation in `paramcache`

The problem described in #492 means that I had to hard-code a "sectors count" value in the `paramcache` program.