### PR TITLE
distinguish padded/unpadded bytes at the type level

### DIFF
--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -10,6 +10,7 @@ use pairing::bls12_381::{Bls12, Fr};
 use pairing::{Engine, PrimeField};
 use sapling_crypto::jubjub::JubjubBls12;
 
+use sector_base::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount};
 use sector_base::api::sector_store::SectorConfig;
 use sector_base::io::fr32::write_unpadded;
 use std::path::Path;
@@ -110,20 +111,20 @@ fn lookup_verifying_key<F: FnOnce() -> error::Result<Bls12VerifyingKey>>(
 
 ////////////////////////////////////////////////////////////////////////////////
 
-fn get_zigzag_params(sector_bytes: usize) -> error::Result<groth16::Parameters<Bls12>> {
-    let public_params = public_params(sector_bytes as usize);
+fn get_zigzag_params(sector_bytes: PaddedBytesAmount) -> error::Result<groth16::Parameters<Bls12>> {
+    let public_params = public_params(sector_bytes);
 
     let get_params =
         || ZigZagCompound::groth_params(&public_params, &ENGINE_PARAMS).map_err(|e| e.into());
 
     Ok(lookup_groth_params(
-        format!("ZIGZAG[{}]", sector_bytes),
+        format!("ZIGZAG[{}]", usize::from(sector_bytes)),
         get_params,
     )?)
 }
 
-fn get_post_params(sector_bytes: usize) -> error::Result<groth16::Parameters<Bls12>> {
-    let post_public_params = post_public_params(sector_bytes as usize);
+fn get_post_params(sector_bytes: PaddedBytesAmount) -> error::Result<groth16::Parameters<Bls12>> {
+    let post_public_params = post_public_params(sector_bytes);
 
     let get_params = || {
         <VDFPostCompound as CompoundProof<
@@ -135,25 +136,25 @@ fn get_post_params(sector_bytes: usize) -> error::Result<groth16::Parameters<Bls
     };
 
     Ok(lookup_groth_params(
-        format!("POST[{}]", sector_bytes),
+        format!("POST[{}]", usize::from(sector_bytes)),
         get_params,
     )?)
 }
 
-fn get_zigzag_verifying_key(sector_bytes: usize) -> error::Result<Bls12VerifyingKey> {
-    let public_params = public_params(sector_bytes as usize);
+fn get_zigzag_verifying_key(sector_bytes: PaddedBytesAmount) -> error::Result<Bls12VerifyingKey> {
+    let public_params = public_params(sector_bytes);
 
     let get_verifying_key =
         || ZigZagCompound::verifying_key(&public_params, &ENGINE_PARAMS).map_err(|e| e.into());
 
     Ok(lookup_verifying_key(
-        format!("ZIGZAG[{}]", sector_bytes),
+        format!("ZIGZAG[{}]", usize::from(sector_bytes)),
         get_verifying_key,
     )?)
 }
 
-fn get_post_verifying_key(sector_bytes: usize) -> error::Result<Bls12VerifyingKey> {
-    let post_public_params = post_public_params(sector_bytes as usize);
+fn get_post_verifying_key(sector_bytes: PaddedBytesAmount) -> error::Result<Bls12VerifyingKey> {
+    let post_public_params = post_public_params(sector_bytes);
 
     let get_verifying_key = || {
         <VDFPostCompound as CompoundProof<
@@ -165,7 +166,7 @@ fn get_post_verifying_key(sector_bytes: usize) -> error::Result<Bls12VerifyingKe
     };
 
     Ok(lookup_verifying_key(
-        format!("POST[{}]", sector_bytes),
+        format!("POST[{}]", usize::from(sector_bytes)),
         get_verifying_key,
     )?)
 }
@@ -184,7 +185,9 @@ lazy_static! {
         LayerChallenges::new_tapered(LAYERS, CHALLENGE_COUNT, TAPER_LAYERS, TAPER);
 }
 
-fn setup_params(sector_bytes: usize) -> layered_drgporep::SetupParams {
+fn setup_params(sector_bytes: PaddedBytesAmount) -> layered_drgporep::SetupParams {
+    let sector_bytes = usize::from(sector_bytes);
+
     assert!(
         sector_bytes % 32 == 0,
         "sector_bytes ({}) must be a multiple of 32",
@@ -206,7 +209,7 @@ fn setup_params(sector_bytes: usize) -> layered_drgporep::SetupParams {
 }
 
 pub fn public_params(
-    sector_bytes: usize,
+    sector_bytes: PaddedBytesAmount,
 ) -> layered_drgporep::PublicParams<DefaultTreeHasher, ZigZagBucketGraph<DefaultTreeHasher>> {
     ZigZagDrgPoRep::<DefaultTreeHasher>::setup(&setup_params(sector_bytes)).unwrap()
 }
@@ -224,10 +227,10 @@ lazy_static! {
         PedersenDomain(Fr::from_str("12345").unwrap().into_repr());
 }
 
-fn post_setup_params(sector_bytes: usize) -> PostSetupParams {
+fn post_setup_params(sector_bytes: PaddedBytesAmount) -> PostSetupParams {
     vdf_post::SetupParams::<PedersenDomain, vdf_sloth::Sloth> {
         challenge_count: POST_CHALLENGE_COUNT,
-        sector_size: sector_bytes,
+        sector_size: sector_bytes.into(),
         post_epochs: POST_EPOCHS,
         setup_params_vdf: vdf_sloth::SetupParams {
             key: *POST_VDF_KEY,
@@ -237,7 +240,7 @@ fn post_setup_params(sector_bytes: usize) -> PostSetupParams {
     }
 }
 
-pub fn post_public_params(sector_bytes: usize) -> PostPublicParams {
+pub fn post_public_params(sector_bytes: PaddedBytesAmount) -> PostPublicParams {
     VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&post_setup_params(sector_bytes)).unwrap()
 }
 
@@ -270,7 +273,10 @@ pub struct PoStInput {
     pub input_parts: Vec<PoStInputPart>,
 }
 
-pub fn fake_generate_post(_sector_bytes: u64, input: PoStInput) -> error::Result<PoStOutput> {
+pub fn fake_generate_post(
+    _sector_bytes: UnpaddedBytesAmount,
+    input: PoStInput,
+) -> error::Result<PoStOutput> {
     let faults: Vec<u64> = if !input.input_parts.is_empty() {
         vec![0]
     } else {
@@ -283,11 +289,14 @@ pub fn fake_generate_post(_sector_bytes: u64, input: PoStInput) -> error::Result
     })
 }
 
-pub fn generate_post(sector_bytes: u64, input: PoStInput) -> error::Result<PoStOutput> {
+pub fn generate_post(
+    sector_bytes: PaddedBytesAmount,
+    input: PoStInput,
+) -> error::Result<PoStOutput> {
     let faults: Vec<u64> = Vec::new();
 
     let setup_params = compound_proof::SetupParams {
-        vanilla_params: &post_setup_params(sector_bytes as usize),
+        vanilla_params: &post_setup_params(sector_bytes),
         engine_params: &(*ENGINE_PARAMS),
         partitions: None,
     };
@@ -321,7 +330,11 @@ pub fn generate_post(sector_bytes: u64, input: PoStInput) -> error::Result<PoStO
         .iter()
         .map(|p| {
             if let Some(s) = &p.sealed_sector_access {
-                make_merkle_tree(s, pub_params.vanilla_params.sector_size).unwrap()
+                make_merkle_tree(
+                    s,
+                    PaddedBytesAmount(pub_params.vanilla_params.sector_size as u64),
+                )
+                .unwrap()
             } else {
                 panic!("faults are not yet supported")
             }
@@ -332,7 +345,7 @@ pub fn generate_post(sector_bytes: u64, input: PoStInput) -> error::Result<PoStO
 
     let priv_inputs = vdf_post::PrivateInputs::<PedersenHasher>::new(&borrowed_trees[..]);
 
-    let groth_params = get_post_params(sector_bytes as usize)?;
+    let groth_params = get_post_params(sector_bytes)?;
 
     let proof = VDFPostCompound::prove(&pub_params, &pub_inputs, &priv_inputs, Some(groth_params))
         .expect("failed while proving");
@@ -351,7 +364,7 @@ pub fn generate_post(sector_bytes: u64, input: PoStInput) -> error::Result<PoStO
 }
 
 pub fn verify_post(
-    sector_bytes: u64,
+    sector_bytes: PaddedBytesAmount,
     comm_rs: &[Commitment],
     challenge_seed: &ChallengeSeed,
     proof_vec: &[u8],
@@ -365,7 +378,7 @@ pub fn verify_post(
     };
 
     let compound_setup_params = compound_proof::SetupParams {
-        vanilla_params: &post_setup_params(sector_bytes as usize),
+        vanilla_params: &post_setup_params(sector_bytes),
         engine_params: &(*ENGINE_PARAMS),
         partitions: None,
     };
@@ -386,7 +399,7 @@ pub fn verify_post(
         faults,
     };
 
-    let verifying_key = get_post_verifying_key(sector_bytes as usize)?;
+    let verifying_key = get_post_verifying_key(sector_bytes)?;
 
     let proof = MultiProof::new_from_reader(Some(POST_PARTITIONS), proof_vec, verifying_key)?;
 
@@ -404,7 +417,7 @@ pub fn verify_post(
 type Tree = MerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function>;
 fn make_merkle_tree<T: Into<PathBuf> + AsRef<Path>>(
     sealed_path: T,
-    bytes: usize,
+    bytes: PaddedBytesAmount,
 ) -> storage_proofs::error::Result<Tree> {
     let mut f_in = File::open(sealed_path.into())?;
     let mut data = Vec::new();
@@ -429,7 +442,7 @@ pub fn seal<T: Into<PathBuf> + AsRef<Path>>(
     prover_id_in: &FrSafe,
     sector_id_in: &FrSafe,
 ) -> error::Result<SealOutput> {
-    let sector_bytes = sector_config.sector_bytes() as usize;
+    let sector_bytes = usize::from(sector_config.sector_bytes());
     let f_in = File::open(in_path)?;
 
     // Read all the provided data, even if we will prove less of it because we are faking.
@@ -449,7 +462,7 @@ pub fn seal<T: Into<PathBuf> + AsRef<Path>>(
 
     let compound_setup_params = compound_proof::SetupParams {
         // The proof might use a different number of bytes than we read and copied, if we are faking.
-        vanilla_params: &setup_params(sector_bytes),
+        vanilla_params: &setup_params(sector_config.sector_bytes()),
         engine_params: &(*ENGINE_PARAMS),
         partitions: Some(POREP_PARTITIONS),
     };
@@ -479,8 +492,10 @@ pub fn seal<T: Into<PathBuf> + AsRef<Path>>(
         tau: tau.layer_taus,
     };
 
-    let groth_params = get_zigzag_params(sector_bytes)?;
-    info!(FCP_LOG, "got groth params ({}) while sealing", sector_bytes; "target" => "params");
+    let groth_params = get_zigzag_params(sector_config.sector_bytes())?;
+
+    info!(FCP_LOG, "got groth params ({}) while sealing", u64::from(sector_config.sector_bytes()); "target" => "params");
+
     let proof = ZigZagCompound::prove(
         &compound_public_params,
         &public_inputs,
@@ -535,9 +550,9 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>>(
     prover_id_in: &FrSafe,
     sector_id_in: &FrSafe,
     offset: u64,
-    num_bytes: u64,
-) -> error::Result<(u64)> {
-    let sector_bytes = sector_config.sector_bytes() as usize;
+    num_bytes: UnpaddedBytesAmount,
+) -> error::Result<(UnpaddedBytesAmount)> {
+    let sector_bytes: usize = sector_config.sector_bytes().into();
 
     let prover_id = pad_safe_fr(prover_id_in);
     let sector_id = pad_safe_fr(sector_id_in);
@@ -550,16 +565,20 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>>(
     let f_out = File::create(output_path)?;
     let mut buf_writer = BufWriter::new(f_out);
 
-    let unsealed = ZigZagDrgPoRep::extract_all(&public_params(sector_bytes), &replica_id, &data)?;
+    let unsealed = ZigZagDrgPoRep::extract_all(
+        &public_params(sector_config.sector_bytes()),
+        &replica_id,
+        &data,
+    )?;
 
     let written = write_unpadded(
         &unsealed,
         &mut buf_writer,
         offset as usize,
-        num_bytes as usize,
+        num_bytes.into(),
     )?;
 
-    Ok(written as u64)
+    Ok(UnpaddedBytesAmount(written as u64))
 }
 
 pub fn verify_seal(
@@ -571,8 +590,7 @@ pub fn verify_seal(
     sector_id_in: &FrSafe,
     proof_vec: &[u8],
 ) -> error::Result<bool> {
-    let sector_bytes = sector_config.sector_bytes() as usize;
-
+    let sector_bytes = sector_config.sector_bytes();
     let prover_id = pad_safe_fr(prover_id_in);
     let sector_id = pad_safe_fr(sector_id_in);
     let replica_id = replica_id::<DefaultTreeHasher>(prover_id, sector_id);
@@ -583,7 +601,7 @@ pub fn verify_seal(
 
     let compound_setup_params = compound_proof::SetupParams {
         // The proof might use a different number of bytes than we read and copied, if we are faking.
-        vanilla_params: &setup_params(sector_bytes),
+        vanilla_params: &setup_params(sector_config.sector_bytes()),
         engine_params: &(*ENGINE_PARAMS),
         partitions: Some(POREP_PARTITIONS),
     };
@@ -605,7 +623,8 @@ pub fn verify_seal(
     };
 
     let verifying_key = get_zigzag_verifying_key(sector_bytes)?;
-    info!(FCP_LOG, "got verifying key ({}) while verifying seal", sector_bytes; "target" => "params");
+
+    info!(FCP_LOG, "got verifying key ({}) while verifying seal", u64::from(sector_bytes); "target" => "params");
 
     let proof = MultiProof::new_from_reader(Some(POREP_PARTITIONS), proof_vec, verifying_key)?;
 
@@ -646,6 +665,7 @@ mod tests {
         let store = create_sector_store(cs);
         let mgr = store.manager();
         let cfg = store.config();
+        let max: u64 = store.config().max_unsealed_bytes_per_sector().into();
 
         let staged_access = mgr
             .new_staging_sector_access()
@@ -666,18 +686,16 @@ mod tests {
         for bytes_amt in bytes_amts {
             let contents = match bytes_amt {
                 BytesAmount::Exact(bs) => bs.to_vec(),
-                BytesAmount::Max => {
-                    make_random_bytes(store.config().max_unsealed_bytes_per_sector())
-                }
-                BytesAmount::Offset(m) => {
-                    make_random_bytes(store.config().max_unsealed_bytes_per_sector() - m)
-                }
+                BytesAmount::Max => make_random_bytes(max),
+                BytesAmount::Offset(m) => make_random_bytes(max - m),
             };
 
             assert_eq!(
-                contents.len() as u64,
-                mgr.write_and_preprocess(&staged_access, &contents)
-                    .expect("failed to write and preprocess")
+                contents.len(),
+                usize::from(
+                    mgr.write_and_preprocess(&staged_access, &contents)
+                        .expect("failed to write and preprocess")
+                )
             );
 
             written_contents.push(contents);
@@ -715,17 +733,19 @@ mod tests {
 
         // unseal the whole thing
         assert_eq!(
-            cfg.max_unsealed_bytes_per_sector(),
-            get_unsealed_range(
-                cfg,
-                &sealed_access,
-                &unseal_access,
-                &prover_id,
-                &sector_id,
-                0,
-                cfg.max_unsealed_bytes_per_sector(),
+            u64::from(cfg.max_unsealed_bytes_per_sector()),
+            u64::from(
+                get_unsealed_range(
+                    cfg,
+                    &sealed_access,
+                    &unseal_access,
+                    &prover_id,
+                    &sector_id,
+                    0,
+                    cfg.max_unsealed_bytes_per_sector(),
+                )
+                .expect("failed to unseal")
             )
-            .expect("failed to unseal")
         );
 
         Harness {
@@ -786,13 +806,12 @@ mod tests {
         let h = create_harness(&cs, &vec![bytes_amt]);
         let seal_output = h.seal_output;
 
-        let sector_bytes = h.store.config().sector_bytes();
         let comm_r = seal_output.comm_r;
         let comm_rs = vec![comm_r, comm_r];
         let challenge_seed = rng.gen();
 
         let post_output = generate_post(
-            sector_bytes,
+            h.store.config().sector_bytes(),
             PoStInput {
                 challenge_seed,
                 input_parts: vec![
@@ -810,7 +829,7 @@ mod tests {
         .expect("PoSt generation failed");
 
         let is_valid = verify_post(
-            sector_bytes,
+            h.store.config().sector_bytes(),
             &comm_rs,
             &challenge_seed,
             &post_output.snark_proof,
@@ -833,7 +852,7 @@ mod tests {
             let read_unsealed_buf = h
                 .store
                 .manager()
-                .read_raw(&h.unseal_access, 0, buf.len() as u64)
+                .read_raw(&h.unseal_access, 0, UnpaddedBytesAmount(buf.len() as u64))
                 .expect("failed to read_raw a");
 
             assert_eq!(
@@ -848,7 +867,11 @@ mod tests {
             let read_unsealed_buf = h
                 .store
                 .manager()
-                .read_raw(&h.unseal_access, 1, buf.len() as u64 - 2)
+                .read_raw(
+                    &h.unseal_access,
+                    1,
+                    UnpaddedBytesAmount(buf.len() as u64 - 2),
+                )
                 .expect("failed to read_raw a");
 
             assert_eq!(
@@ -862,7 +885,8 @@ mod tests {
 
         let byte_padding_amount = match bytes_amt {
             BytesAmount::Exact(bs) => {
-                h.store.config().max_unsealed_bytes_per_sector() - (bs.len() as u64)
+                let max: u64 = h.store.config().max_unsealed_bytes_per_sector().into();
+                max - (bs.len() as u64)
             }
             BytesAmount::Max => 0,
             BytesAmount::Offset(m) => m,
@@ -893,16 +917,18 @@ mod tests {
 
         assert_eq!(
             range_length,
-            get_unsealed_range(
-                h.store.config(),
-                &PathBuf::from(&h.sealed_access),
-                &PathBuf::from(&h.unseal_access),
-                &h.prover_id,
-                &h.sector_id,
-                offset,
-                range_length,
+            u64::from(
+                get_unsealed_range(
+                    h.store.config(),
+                    &PathBuf::from(&h.sealed_access),
+                    &PathBuf::from(&h.unseal_access),
+                    &h.prover_id,
+                    &h.sector_id,
+                    offset,
+                    UnpaddedBytesAmount(range_length),
+                )
+                .expect("failed to unseal")
             )
-            .expect("failed to unseal")
         );
 
         let mut file = File::open(&h.unseal_access).unwrap();
@@ -950,7 +976,7 @@ mod tests {
             &h.prover_id,
             &h.sector_id,
             0,
-            (contents_a.len() + contents_b.len()) as u64,
+            UnpaddedBytesAmount((contents_a.len() + contents_b.len()) as u64),
         )
         .expect("failed to unseal");
 

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -341,7 +341,7 @@ pub unsafe extern "C" fn get_max_user_bytes_per_staged_sector(
     let mut response: responses::GetMaxStagedBytesPerSector = Default::default();
 
     response.status_code = FCPResponseStatus::FCPNoError;
-    response.max_staged_bytes_per_sector = (*ptr).get_max_user_bytes_per_staged_sector();;
+    response.max_staged_bytes_per_sector = (*ptr).get_max_user_bytes_per_staged_sector().into();
 
     raw_ptr(response)
 }
@@ -377,7 +377,7 @@ pub unsafe extern "C" fn get_seal_status(
                         .iter()
                         .map(|p| FFIPieceMetadata {
                             piece_key: rust_str_to_c_str(p.piece_key.to_string()),
-                            num_bytes: p.num_bytes,
+                            num_bytes: p.num_bytes.into(),
                         })
                         .collect::<Vec<FFIPieceMetadata>>();
 
@@ -426,7 +426,7 @@ pub unsafe extern "C" fn get_sealed_sectors(
                         .iter()
                         .map(|p| FFIPieceMetadata {
                             piece_key: rust_str_to_c_str(p.piece_key.to_string()),
-                            num_bytes: p.num_bytes,
+                            num_bytes: p.num_bytes.into(),
                         })
                         .collect::<Vec<FFIPieceMetadata>>();
 
@@ -480,7 +480,7 @@ pub unsafe extern "C" fn get_staged_sectors(
                         .iter()
                         .map(|p| FFIPieceMetadata {
                             piece_key: rust_str_to_c_str(p.piece_key.to_string()),
-                            num_bytes: p.num_bytes,
+                            num_bytes: p.num_bytes.into(),
                         })
                         .collect::<Vec<FFIPieceMetadata>>();
 

--- a/filecoin-proofs/src/api/sector_builder/helpers/get_sectors_ready_for_sealing.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/get_sectors_ready_for_sealing.rs
@@ -4,11 +4,12 @@ use crate::api::sector_builder::metadata::StagedSectorMetadata;
 use crate::api::sector_builder::state::StagedState;
 use crate::api::sector_builder::SectorId;
 use itertools::chain;
+use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use std::cmp::Reverse;
 
 pub fn get_sectors_ready_for_sealing(
     staged_state: &StagedState,
-    max_user_bytes_per_staged_sector: u64,
+    max_user_bytes_per_staged_sector: UnpaddedBytesAmount,
     max_num_staged_sectors: u8,
     seal_all_staged_sectors: bool,
 ) -> Vec<SectorId> {
@@ -59,7 +60,7 @@ mod tests {
                 sector_id,
                 pieces: vec![PieceMetadata {
                     piece_key: format!("{}", sector_id),
-                    num_bytes,
+                    num_bytes: UnpaddedBytesAmount(num_bytes),
                 }],
                 seal_status,
                 ..Default::default()
@@ -79,9 +80,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 10, true)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 10, true)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![201 as SectorId, 200 as SectorId], to_seal);
     }
@@ -98,9 +100,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 10, false)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 10, false)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![200 as SectorId], to_seal);
     }
@@ -119,9 +122,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 2, false)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 2, false)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![201 as SectorId, 200 as SectorId], to_seal);
     }
@@ -140,9 +144,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 4, false)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 4, false)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![0; 0], to_seal);
     }
@@ -161,9 +166,10 @@ mod tests {
             sectors: m,
         };
 
-        let to_seal: Vec<SectorId> = get_sectors_ready_for_sealing(&state, 127, 4, false)
-            .into_iter()
-            .collect();
+        let to_seal: Vec<SectorId> =
+            get_sectors_ready_for_sealing(&state, UnpaddedBytesAmount(127), 4, false)
+                .into_iter()
+                .collect();
 
         assert_eq!(vec![0; 0], to_seal);
     }

--- a/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
@@ -4,6 +4,7 @@ use crate::api::sector_builder::metadata::sector_id_as_bytes;
 use crate::api::sector_builder::metadata::SealedSectorMetadata;
 use crate::api::sector_builder::WrappedSectorStore;
 use crate::error;
+use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -47,7 +48,7 @@ fn retrieve_piece_aux<'a>(
     prover_id: &[u8; 31],
     piece_key: &'a str,
     staging_sector_access: &'a str,
-) -> error::Result<(u64, Vec<u8>)> {
+) -> error::Result<(UnpaddedBytesAmount, Vec<u8>)> {
     let (start_offset, num_bytes) = piece_pos(&sealed_sector, piece_key).ok_or_else(|| {
         let msg = format!(
             "piece {} not found in sector {}",
@@ -69,7 +70,8 @@ fn retrieve_piece_aux<'a>(
     if num_bytes_unsealed != num_bytes {
         let s = format!(
             "expected to unseal {} bytes, but unsealed {} bytes",
-            num_bytes, num_bytes_unsealed
+            u64::from(num_bytes),
+            u64::from(num_bytes_unsealed)
         );
 
         return Err(err_unrecov(s).into());
@@ -86,16 +88,23 @@ fn retrieve_piece_aux<'a>(
 
 // Returns a tuple of piece bytes-offset and number-of-bytes in piece if the
 // provided sealed sector contains a matching piece.
-fn piece_pos(sealed_sector: &SealedSectorMetadata, piece_key: &str) -> Option<(u64, u64)> {
+fn piece_pos(
+    sealed_sector: &SealedSectorMetadata,
+    piece_key: &str,
+) -> Option<(u64, UnpaddedBytesAmount)> {
     let (found_piece, start_offset, num_bytes) = sealed_sector.pieces.iter().fold(
-        (false, 0, 0),
+        (false, 0, UnpaddedBytesAmount(0)),
         |(eject, start_offset, num_bytes), item| {
             if eject {
                 (eject, start_offset, num_bytes)
             } else if item.piece_key == piece_key {
                 (true, start_offset, item.num_bytes)
             } else {
-                (false, start_offset + item.num_bytes, item.num_bytes)
+                (
+                    false,
+                    start_offset + u64::from(item.num_bytes),
+                    item.num_bytes,
+                )
             }
         },
     );
@@ -118,31 +127,31 @@ mod tests {
 
         sealed_sector.pieces.push(PieceMetadata {
             piece_key: String::from("x"),
-            num_bytes: 5,
+            num_bytes: UnpaddedBytesAmount(5),
         });
 
         sealed_sector.pieces.push(PieceMetadata {
             piece_key: String::from("y"),
-            num_bytes: 30,
+            num_bytes: UnpaddedBytesAmount(30),
         });
 
         sealed_sector.pieces.push(PieceMetadata {
             piece_key: String::from("z"),
-            num_bytes: 100,
+            num_bytes: UnpaddedBytesAmount(100),
         });
 
         match piece_pos(&sealed_sector, "x") {
-            Some(pair) => assert_eq!(pair, (0, 5)),
+            Some(pair) => assert_eq!(pair, (0, UnpaddedBytesAmount(5))),
             None => panic!(),
         }
 
         match piece_pos(&sealed_sector, "y") {
-            Some(pair) => assert_eq!(pair, (5, 30)),
+            Some(pair) => assert_eq!(pair, (5, UnpaddedBytesAmount(30))),
             None => panic!(),
         }
 
         match piece_pos(&sealed_sector, "z") {
-            Some(pair) => assert_eq!(pair, (35, 100)),
+            Some(pair) => assert_eq!(pair, (35, UnpaddedBytesAmount(100))),
             None => panic!(),
         }
     }

--- a/filecoin-proofs/src/api/sector_builder/metadata.rs
+++ b/filecoin-proofs/src/api/sector_builder/metadata.rs
@@ -3,6 +3,7 @@ use crate::error;
 use crate::serde_big_array::BigArray;
 use byteorder::LittleEndian;
 use byteorder::WriteBytesExt;
+use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -30,7 +31,7 @@ pub struct SealedSectorMetadata {
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
 pub struct PieceMetadata {
     pub piece_key: String,
-    pub num_bytes: u64,
+    pub num_bytes: UnpaddedBytesAmount,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -84,8 +85,10 @@ impl Default for SealedSectorMetadata {
     }
 }
 
-pub fn sum_piece_bytes(s: &StagedSectorMetadata) -> u64 {
-    s.pieces.iter().map(|x| x.num_bytes).sum()
+pub fn sum_piece_bytes(s: &StagedSectorMetadata) -> UnpaddedBytesAmount {
+    s.pieces
+        .iter()
+        .fold(UnpaddedBytesAmount(0), |acc, x| acc + x.num_bytes)
 }
 
 pub fn sector_id_as_bytes(sector_id: SectorId) -> error::Result<[u8; 31]> {

--- a/filecoin-proofs/src/api/sector_builder/mod.rs
+++ b/filecoin-proofs/src/api/sector_builder/mod.rs
@@ -1,3 +1,6 @@
+use slog::*;
+use std::sync::{mpsc, Arc, Mutex};
+
 use crate::api::internal::PoStOutput;
 use crate::api::sector_builder::errors::SectorBuilderErr;
 use crate::api::sector_builder::kv_store::fs::FileSystemKvs;
@@ -9,11 +12,10 @@ use crate::api::sector_builder::sealer::*;
 use crate::error::ExpectWithBacktrace;
 use crate::error::Result;
 use crate::FCP_LOG;
+use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use sector_base::api::disk_backed_storage::new_sector_store;
 use sector_base::api::disk_backed_storage::ConfiguredStore;
 use sector_base::api::sector_store::SectorStore;
-use slog::*;
-use std::sync::{mpsc, Arc, Mutex};
 
 pub mod errors;
 mod helpers;
@@ -109,7 +111,7 @@ impl SectorBuilder {
 
     // Returns the number of user-provided bytes that will fit into a staged
     // sector.
-    pub fn get_max_user_bytes_per_staged_sector(&self) -> u64 {
+    pub fn get_max_user_bytes_per_staged_sector(&self) -> UnpaddedBytesAmount {
         self.run_blocking(Request::GetMaxUserBytesPerStagedSector)
     }
 

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -6,6 +6,7 @@ extern crate storage_proofs;
 use filecoin_proofs::api::internal;
 use pairing::bls12_381::Bls12;
 
+use sector_base::api::bytes_amount::PaddedBytesAmount;
 use sector_base::api::disk_backed_storage::{LIVE_SECTOR_SIZE, TEST_SECTOR_SIZE};
 use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
 use storage_proofs::circuit::zigzag::ZigZagCompound;
@@ -18,7 +19,9 @@ use storage_proofs::vdf_sloth::Sloth;
 const GENERATE_POST_PARAMS: bool = false;
 
 fn cache_params(sector_size: u64) {
-    let public_params = internal::public_params(sector_size as usize);
+    let bytes_amount = PaddedBytesAmount(sector_size);
+
+    let public_params = internal::public_params(bytes_amount);
     {
         let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
 
@@ -30,7 +33,7 @@ fn cache_params(sector_size: u64) {
     }
 
     if GENERATE_POST_PARAMS {
-        let post_public_params = internal::post_public_params(sector_size as usize);
+        let post_public_params = internal::post_public_params(bytes_amount);
         {
             let post_circuit: VDFPoStCircuit<Bls12> =
                 <VDFPostCompound as CompoundProof<

--- a/filecoin-proofs/src/bin/paramgen.rs
+++ b/filecoin-proofs/src/bin/paramgen.rs
@@ -9,6 +9,7 @@ use std::env;
 use std::fs::File;
 
 use filecoin_proofs::api::internal;
+use sector_base::api::bytes_amount::PaddedBytesAmount;
 use sector_base::api::disk_backed_storage::LIVE_SECTOR_SIZE;
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::CompoundProof;
@@ -18,7 +19,7 @@ pub fn main() {
     let args: Vec<String> = env::args().collect();
     let out_file = &args[1];
 
-    let public_params = internal::public_params(LIVE_SECTOR_SIZE as usize);
+    let public_params = internal::public_params(PaddedBytesAmount(LIVE_SECTOR_SIZE));
 
     let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
     let mut params = phase2::MPCParameters::new(circuit).unwrap();

--- a/sector-base/Cargo.toml
+++ b/sector-base/Cargo.toml
@@ -14,6 +14,10 @@ libc = "0.2"
 rand = "0.4"
 storage-proofs = { path = "../storage-proofs" }
 ffi-toolkit = { path = "../ffi-toolkit" }
+serde_cbor = "0.9.0"
+serde = { version = "1", features = ["rc"] }
+serde_derive = "1.0"
+serde_json = "1.0"
 
 [dependencies.pairing]
 version = "0.14.2"

--- a/sector-base/src/api/bytes_amount.rs
+++ b/sector-base/src/api/bytes_amount.rs
@@ -1,0 +1,64 @@
+use serde::{Deserialize, Serialize};
+use std::ops::{Add, Sub};
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct UnpaddedBytesAmount(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct PaddedBytesAmount(pub u64);
+
+impl From<UnpaddedBytesAmount> for u64 {
+    fn from(n: UnpaddedBytesAmount) -> Self {
+        n.0
+    }
+}
+
+impl From<UnpaddedBytesAmount> for usize {
+    fn from(n: UnpaddedBytesAmount) -> Self {
+        n.0 as usize
+    }
+}
+
+impl From<PaddedBytesAmount> for u64 {
+    fn from(n: PaddedBytesAmount) -> Self {
+        n.0
+    }
+}
+
+impl From<PaddedBytesAmount> for usize {
+    fn from(n: PaddedBytesAmount) -> Self {
+        n.0 as usize
+    }
+}
+
+impl Add for UnpaddedBytesAmount {
+    type Output = UnpaddedBytesAmount;
+
+    fn add(self, other: UnpaddedBytesAmount) -> UnpaddedBytesAmount {
+        UnpaddedBytesAmount(self.0 + other.0)
+    }
+}
+
+impl Add for PaddedBytesAmount {
+    type Output = PaddedBytesAmount;
+
+    fn add(self, other: PaddedBytesAmount) -> PaddedBytesAmount {
+        PaddedBytesAmount(self.0 + other.0)
+    }
+}
+
+impl Sub for UnpaddedBytesAmount {
+    type Output = UnpaddedBytesAmount;
+
+    fn sub(self, other: UnpaddedBytesAmount) -> UnpaddedBytesAmount {
+        UnpaddedBytesAmount(self.0 - other.0)
+    }
+}
+
+impl Sub for PaddedBytesAmount {
+    type Output = PaddedBytesAmount;
+
+    fn sub(self, other: PaddedBytesAmount) -> PaddedBytesAmount {
+        PaddedBytesAmount(self.0 - other.0)
+    }
+}

--- a/sector-base/src/api/bytes_amount.rs
+++ b/sector-base/src/api/bytes_amount.rs
@@ -62,3 +62,46 @@ impl Sub for PaddedBytesAmount {
         PaddedBytesAmount(self.0 - other.0)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowed_operations() {
+        let a = UnpaddedBytesAmount(1);
+        let b = UnpaddedBytesAmount(2);
+        let c = UnpaddedBytesAmount(3);
+
+        let d = PaddedBytesAmount(1);
+        let e = PaddedBytesAmount(2);
+        let f = PaddedBytesAmount(3);
+
+        // Operations between UnpaddedBytesAmounts are allowed
+        assert_eq!(a + b, c);
+        assert_eq!(c - b, a);
+
+        // Operations between PaddedBytesAmounts are allowed
+        assert_eq!(d + e, f);
+        assert_eq!(f - e, d);
+
+        // Mixed operations fail at compile time.
+        // assert_eq!(a + b, f);
+
+        // Coercion to primitives work
+        assert_eq!(1u64 + u64::from(b), 3u64);
+        assert_eq!(1usize + usize::from(b), 3usize);
+        assert_eq!(1u64 + u64::from(e), 3u64);
+        assert_eq!(1usize + usize::from(e), 3usize);
+
+        // But not between BytesAmount types
+        // assert_eq!(a + UnpaddedBytesAmount::from(e), c);
+        // assert_eq!(d + UnpaddedBytesAmount::from(b), f);
+
+        // But must be explicit or won't compile.
+        // assert_eq!(1u64 + b, 3u64);
+        // assert_eq!(1usize + b, 3usize);
+        // assert_eq!(1u64 + u64::from(e), 3u64);
+        // assert_eq!(1usize + usize::from(e), 3usize);
+    }
+}

--- a/sector-base/src/api/disk_backed_storage.rs
+++ b/sector-base/src/api/disk_backed_storage.rs
@@ -1,14 +1,19 @@
-use crate::api::errors::SectorManagerErr;
-use crate::api::sector_store::{SectorConfig, SectorManager, SectorStore};
-use crate::api::util;
-use crate::io::fr32::{
-    almost_truncate_to_unpadded_bytes, target_unpadded_bytes, unpadded_bytes, write_padded,
-};
-use ffi_toolkit::{c_str_to_rust_str, raw_ptr};
 use libc;
 use std::fs::{create_dir_all, remove_file, File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom};
 use std::path::Path;
+
+use crate::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount};
+use crate::api::errors::SectorManagerErr;
+use crate::api::sector_store::SectorConfig;
+use crate::api::sector_store::SectorManager;
+use crate::api::sector_store::SectorStore;
+use crate::api::util;
+use crate::io::fr32::almost_truncate_to_unpadded_bytes;
+use crate::io::fr32::target_unpadded_bytes;
+use crate::io::fr32::unpadded_bytes;
+use crate::io::fr32::write_padded;
+use ffi_toolkit::{c_str_to_rust_str, raw_ptr};
 
 // These sizes are for SEALED sectors. They are used to calculate the values of setup parameters.
 // They can be overridden by setting the corresponding environment variable (with FILECOIN_PROOFS_ prefix),
@@ -113,7 +118,11 @@ impl SectorManager for DiskManager {
     }
 
     // TODO: write_and_preprocess should refuse to write more data than will fit. In that case, return 0.
-    fn write_and_preprocess(&self, access: &str, data: &[u8]) -> Result<u64, SectorManagerErr> {
+    fn write_and_preprocess(
+        &self,
+        access: &str,
+        data: &[u8],
+    ) -> Result<UnpaddedBytesAmount, SectorManagerErr> {
         OpenOptions::new()
             .read(true)
             .write(true)
@@ -122,7 +131,7 @@ impl SectorManager for DiskManager {
             .and_then(|mut file| {
                 write_padded(data, &mut file)
                     .map_err(|err| SectorManagerErr::ReceiverError(format!("{:?}", err)))
-                    .map(|n| n as u64)
+                    .map(|n| UnpaddedBytesAmount(n as u64))
             })
     }
 
@@ -134,7 +143,7 @@ impl SectorManager for DiskManager {
         &self,
         access: &str,
         start_offset: u64,
-        num_bytes: u64,
+        num_bytes: UnpaddedBytesAmount,
     ) -> Result<Vec<u8>, SectorManagerErr> {
         OpenOptions::new()
             .read(true)
@@ -144,7 +153,7 @@ impl SectorManager for DiskManager {
                 file.seek(SeekFrom::Start(start_offset))
                     .map_err(|err| SectorManagerErr::CallerError(format!("{:?}", err)))?;
 
-                let mut buf = vec![0; num_bytes as usize];
+                let mut buf = vec![0; usize::from(num_bytes)];
 
                 file.read_exact(buf.as_mut_slice())
                     .map_err(|err| SectorManagerErr::CallerError(format!("{:?}", err)))?;
@@ -179,7 +188,7 @@ impl DiskManager {
 }
 
 pub struct Config {
-    sector_bytes: u64,
+    pub sector_bytes: u64,
 }
 
 #[derive(Debug)]
@@ -231,12 +240,12 @@ pub fn new_sector_config(cs: &ConfiguredStore) -> Box<SectorConfig> {
 }
 
 impl SectorConfig for Config {
-    fn max_unsealed_bytes_per_sector(&self) -> u64 {
-        unpadded_bytes(self.sector_bytes)
+    fn max_unsealed_bytes_per_sector(&self) -> UnpaddedBytesAmount {
+        UnpaddedBytesAmount(unpadded_bytes(self.sector_bytes))
     }
 
-    fn sector_bytes(&self) -> u64 {
-        self.sector_bytes
+    fn sector_bytes(&self) -> PaddedBytesAmount {
+        PaddedBytesAmount(self.sector_bytes)
     }
 }
 
@@ -282,7 +291,7 @@ pub mod tests {
         for (configured_store, num_bytes) in xs {
             let storage: Box<SectorStore> = create_sector_store(&configured_store);
             let cfg = storage.config();
-            assert_eq!(cfg.max_unsealed_bytes_per_sector(), num_bytes);
+            assert_eq!(u64::from(cfg.max_unsealed_bytes_per_sector()), num_bytes);
         }
     }
 
@@ -310,7 +319,7 @@ pub mod tests {
             let output_bytes_written = buf.len();
 
             // ensure that we reported the correct number of written bytes
-            assert_eq!(contents.len(), n as usize);
+            assert_eq!(contents.len(), usize::from(n));
 
             // ensure the file we wrote to contains the expected bytes
             assert_eq!(contents[0..32], buf[0..32]);
@@ -375,13 +384,19 @@ pub mod tests {
         let store = create_sector_store(&configured_store);
         let access = store.manager().new_staging_sector_access().unwrap();
 
-        assert!(store.manager().read_raw(&access, 0, 0).is_ok());
+        assert!(store
+            .manager()
+            .read_raw(&access, 0, UnpaddedBytesAmount(0))
+            .is_ok());
 
         assert!(store
             .manager()
             .delete_staging_sector_access(&access)
             .is_ok());
 
-        assert!(store.manager().read_raw(&access, 0, 0).is_err());
+        assert!(store
+            .manager()
+            .read_raw(&access, 0, UnpaddedBytesAmount(0))
+            .is_err());
     }
 }

--- a/sector-base/src/api/mod.rs
+++ b/sector-base/src/api/mod.rs
@@ -1,3 +1,4 @@
+pub mod bytes_amount;
 pub mod disk_backed_storage;
 pub mod errors;
 pub mod sector_store;

--- a/sector-base/src/api/sector_store.rs
+++ b/sector-base/src/api/sector_store.rs
@@ -1,11 +1,12 @@
+use crate::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount};
 use crate::api::errors::SectorManagerErr;
 
 pub trait SectorConfig {
-    /// returns the number of bytes that will fit into a sector managed by this store
-    fn max_unsealed_bytes_per_sector(&self) -> u64;
+    /// returns the number of user-provided bytes that will fit into a sector managed by this store
+    fn max_unsealed_bytes_per_sector(&self) -> UnpaddedBytesAmount;
 
     /// returns the number of bytes in a sealed sector managed by this store
-    fn sector_bytes(&self) -> u64;
+    fn sector_bytes(&self) -> PaddedBytesAmount;
 }
 
 pub trait SectorManager {
@@ -22,7 +23,11 @@ pub trait SectorManager {
     fn truncate_unsealed(&self, access: &str, size: u64) -> Result<(), SectorManagerErr>;
 
     /// writes `data` to the staging sector identified by `access`, incrementally preprocessing `access`
-    fn write_and_preprocess(&self, access: &str, data: &[u8]) -> Result<u64, SectorManagerErr>;
+    fn write_and_preprocess(
+        &self,
+        access: &str,
+        data: &[u8],
+    ) -> Result<UnpaddedBytesAmount, SectorManagerErr>;
 
     fn delete_staging_sector_access(&self, access: &str) -> Result<(), SectorManagerErr>;
 
@@ -30,7 +35,7 @@ pub trait SectorManager {
         &self,
         access: &str,
         start_offset: u64,
-        num_bytes: u64,
+        num_bytes: UnpaddedBytesAmount,
     ) -> Result<Vec<u8>, SectorManagerErr>;
 }
 


### PR DESCRIPTION
Fixes #502 

## Why does this PR exist?

I found it pretty easy to become units-confused when dealing with sector bytes (padded) vs. sector bytes (not padded).

## What's in this PR?

This PR introduces two [newtype](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html) wrappers for u64: `UnpaddedBytesAmount` and `PaddedBytesAmount` and modifies the codebase to give/receive values of these types instead of u64.

## Usage

```rust
let n = UnpaddedBytesAmount(42);
let m = UnpaddedBytesAmount(18);
let a = n + m;
println!("{:?}", u64::from(a)); // 60

let r = PaddedBytesAmount(2);
let b = n + r; // type error
```