### PR TITLE
verify_post should be passed cfg + add FFI tests for PoSt generation/verification

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run:
           name: Ensure cache is hydrated with PoRep and PoSt Groth parameters (for test)
           command: |
-            cargo +stable run --release --color=always --package filecoin-proofs --bin paramcache -- --include-post --test-only
+            cargo run --release --color=always --package filecoin-proofs --bin paramcache -- --include-post --test-only
       - run:
           name: run regression tests (examples) against FFI-exposed filecoin-proofs API
           command: RUSTFLAGS="-Z sanitizer=leak" cargo run --release --package filecoin-proofs --example ffi --target x86_64-unknown-linux-gnu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,10 @@ jobs:
             - cargo-v7-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
             - parameter-cache-{{ .Revision }}
       - run:
+          name: Ensure cache is hydrated with PoRep and PoSt Groth parameters
+          command: |
+            cargo +stable run --release --color=always --package filecoin-proofs --bin paramcache true
+      - run:
           name: Test (stable) in release profile
           command: |
             cargo +stable test --verbose --release --frozen --all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,10 +75,6 @@ jobs:
             - cargo-v7-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
             - parameter-cache-{{ .Revision }}
       - run:
-          name: Ensure cache is hydrated with PoRep and PoSt Groth parameters
-          command: |
-            cargo +stable run --release --color=always --package filecoin-proofs --bin paramcache true
-      - run:
           name: Test (stable) in release profile
           command: |
             cargo +stable test --verbose --release --frozen --all
@@ -97,12 +93,17 @@ jobs:
           keys:
             - cargo-v7-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
             - parameter-cache-{{ .Revision }}
-      - restore_cache:
-          keys:
-            - parameter-cache-{{ .Revision }}
+      - run:
+          name: Ensure cache is hydrated with PoRep and PoSt Groth parameters (for test)
+          command: |
+            cargo +stable run --release --color=always --package filecoin-proofs --bin paramcache -- --include-post --test-only
       - run:
           name: run regression tests (examples) against FFI-exposed filecoin-proofs API
           command: RUSTFLAGS="-Z sanitizer=leak" cargo run --release --package filecoin-proofs --example ffi --target x86_64-unknown-linux-gnu
+      - save_cache:
+          key: parameter-cache-{{ .Revision }}
+          paths:
+          - /root/.filecoin-parameter-cache
 
   test_ignored_release:
     docker:

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -136,13 +136,13 @@ pub unsafe extern "C" fn generate_post(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn verify_post(
+    _cfg_ptr: *const ConfiguredStore,
     _flattened_comm_rs_ptr: *const u8,
     _flattened_comm_rs_len: libc::size_t,
     _challenge_seed: &[u8; 32],
     proof: &[u8; API_POST_PROOF_BYTES],
     _faults_ptr: *const u64,
     _faults_len: libc::size_t,
-    _sector_bytes: u64,
 ) -> *mut responses::VerifyPoSTResponse {
     let mut response: responses::VerifyPoSTResponse = Default::default();
 

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -16,7 +16,7 @@ use storage_proofs::parameter_cache::CacheableParameters;
 use storage_proofs::vdf_post::VDFPoSt;
 use storage_proofs::vdf_sloth::Sloth;
 
-use clap::{Arg, App};
+use clap::{App, Arg};
 use slog::*;
 
 fn cache_porep_params(sector_size: u64) {
@@ -68,14 +68,18 @@ pub fn main() {
     let matches = App::new("paramcache")
         .version("0.1")
         .about("Generate and persist Groth parameters")
-        .arg(Arg::with_name("test-only")
-            .long("test-only")
-            .help("generate only parameters useful for testing")
-            .takes_value(false))
-        .arg(Arg::with_name("include-post")
-            .long("include-post")
-            .help("generate PoSt parameters in addition to PoRep")
-            .takes_value(false))
+        .arg(
+            Arg::with_name("test-only")
+                .long("test-only")
+                .help("generate only parameters useful for testing")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("include-post")
+                .long("include-post")
+                .help("generate PoSt parameters in addition to PoRep")
+                .takes_value(false),
+        )
         .get_matches();
 
     let include_post: bool = matches.is_present("include-post");

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -5,7 +5,6 @@ extern crate storage_proofs;
 
 use filecoin_proofs::api::internal;
 use pairing::bls12_381::Bls12;
-
 use sector_base::api::bytes_amount::PaddedBytesAmount;
 use sector_base::api::disk_backed_storage::{LIVE_SECTOR_SIZE, TEST_SECTOR_SIZE};
 use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
@@ -16,9 +15,9 @@ use storage_proofs::parameter_cache::CacheableParameters;
 use storage_proofs::vdf_post::VDFPoSt;
 use storage_proofs::vdf_sloth::Sloth;
 
-const GENERATE_POST_PARAMS: bool = false;
+use std::env;
 
-fn cache_params(sector_size: u64) {
+fn cache_porep_params(sector_size: u64) {
     let bytes_amount = PaddedBytesAmount(sector_size);
 
     let public_params = internal::public_params(bytes_amount);
@@ -31,33 +30,42 @@ fn cache_params(sector_size: u64) {
         let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
         let _ = ZigZagCompound::get_verifying_key(circuit, &public_params);
     }
+}
 
-    if GENERATE_POST_PARAMS {
-        let post_public_params = internal::post_public_params(bytes_amount);
-        {
-            let post_circuit: VDFPoStCircuit<Bls12> =
-                <VDFPostCompound as CompoundProof<
-                    Bls12,
-                    VDFPoSt<PedersenHasher, Sloth>,
-                    VDFPoStCircuit<Bls12>,
-                >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
-            let _ = VDFPostCompound::get_groth_params(post_circuit, &post_public_params);
-        }
-        {
-            let post_circuit: VDFPoStCircuit<Bls12> =
-                <VDFPostCompound as CompoundProof<
-                    Bls12,
-                    VDFPoSt<PedersenHasher, Sloth>,
-                    VDFPoStCircuit<Bls12>,
-                >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
+fn cache_post_params(sector_size: u64) {
+    let bytes_amount = PaddedBytesAmount(sector_size);
 
-            let _ = VDFPostCompound::get_verifying_key(post_circuit, &post_public_params);
-        }
+    let post_public_params = internal::post_public_params(bytes_amount);
+    {
+        let post_circuit: VDFPoStCircuit<Bls12> =
+            <VDFPostCompound as CompoundProof<
+                Bls12,
+                VDFPoSt<PedersenHasher, Sloth>,
+                VDFPoStCircuit<Bls12>,
+            >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
+        let _ = VDFPostCompound::get_groth_params(post_circuit, &post_public_params);
+    }
+    {
+        let post_circuit: VDFPoStCircuit<Bls12> =
+            <VDFPostCompound as CompoundProof<
+                Bls12,
+                VDFPoSt<PedersenHasher, Sloth>,
+                VDFPoStCircuit<Bls12>,
+            >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
+
+        let _ = VDFPostCompound::get_verifying_key(post_circuit, &post_public_params);
     }
 }
 
 // Run this from the command-line to pre-generate the groth parameters used by the API.
 pub fn main() {
-    cache_params(TEST_SECTOR_SIZE);
-    cache_params(LIVE_SECTOR_SIZE);
+
+    // We can delete this guard once rust-fil-proofs issue #510 lands.
+    if let Some("true") = env::args().collect().get(1).map(|x| x.as_ref()) {
+        cache_post_params(TEST_SECTOR_SIZE);
+        cache_post_params(LIVE_SECTOR_SIZE);
+    }
+
+    cache_porep_params(TEST_SECTOR_SIZE);
+    cache_porep_params(LIVE_SECTOR_SIZE);
 }


### PR DESCRIPTION
Fixes go-filecoin `#2095`, which you can [read all about here](https://app.zenhub.com/workspaces/filecoin-5ab0036a12f8e82ae4ed60f0/issues/filecoin-project/go-filecoin/2095).

## Why does this PR exist?

The FFI-exposed `verify_post` function used to accept a u64 which represented sealed sector bytes. go-filecoin had no way of getting sealed sector-bytes from its sector builder, so this API wouldn't have worked without modifying the sector builder interface.

## What's in this PR?

- `verify_post` to accept config value (like `verify_seal`)
- add FFI tests which exercise PoSt verification and generation
- modify `paramcache` to accept two optional flags: `--test-only` and `--include-post` (omits Live parameters and includes PoSt parameters, respectively)

## `paramcache` mods

`paramcache` now accepts two optional flags which are used to control Groth parameter cache-populating behavior.

By default, `paramcache` will generate PoRep parameters for both Live and Test configs.

If the `--include-post` flag is passed, `paramcache` will (in addition to PoRep) generate PoSt parameters. *Once PoSt goes live in go-filecoin, we will remove this flag; we will always generate PoSt and PoRep parameters from that point onwards.*

If the `--test-only` flag is passed, `paramcache` will only generate parameters for Test config.