### PR TITLE
examples: zigzag: add heap profiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ debug = true
 
 [features]
 default = []
-profile = ["filecoin-proofs/profile"]
+cpu-profile = ["filecoin-proofs/cpu-profile"]
+heap-profile = ["filecoin-proofs/heap-profile"]
 simd = ["storage-proofs/simd", "filecoin-proofs/simd"]
 asm = ["storage-proofs/asm", "filecoin-proofs/asm"]

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -38,7 +38,7 @@ slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_tr
 regex = "1"
 
 [dev-dependencies]
-gperftools = { git = "https://github.com/dignifiedquire/rust-gperftools" }
+gperftools = "0.2"
 scopeguard = "0.3.3"
 
 [dependencies.pairing]
@@ -51,6 +51,7 @@ cbindgen = "0.6.8"
 
 [features]
 default = []
-profile = []
+cpu-profile = []
+heap-profile = []
 simd = ["storage-proofs/simd"]
 asm = ["storage-proofs/asm"]

--- a/filecoin-proofs/examples/beacon-post.rs
+++ b/filecoin-proofs/examples/beacon-post.rs
@@ -4,7 +4,7 @@ extern crate rand;
 extern crate sapling_crypto;
 #[macro_use]
 extern crate clap;
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 extern crate gperftools;
 extern crate memmap;
 extern crate tempfile;
@@ -15,7 +15,7 @@ extern crate filecoin_proofs;
 extern crate storage_proofs;
 
 use clap::{App, Arg};
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 use gperftools::profiler::PROFILER;
 use pairing::bls12_381::Bls12;
 use rand::{Rng, SeedableRng, XorShiftRng};
@@ -31,7 +31,7 @@ use storage_proofs::hasher::PedersenHasher;
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::{vdf_post, vdf_sloth};
 
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 #[inline(always)]
 fn start_profile(stage: &str) {
     PROFILER
@@ -41,17 +41,17 @@ fn start_profile(stage: &str) {
         .unwrap();
 }
 
-#[cfg(not(feature = "profile"))]
+#[cfg(not(feature = "cpu-profile"))]
 #[inline(always)]
 fn start_profile(_stage: &str) {}
 
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 #[inline(always)]
 fn stop_profile() {
     PROFILER.lock().unwrap().stop().unwrap();
 }
 
-#[cfg(not(feature = "profile"))]
+#[cfg(not(feature = "cpu-profile"))]
 #[inline(always)]
 fn stop_profile() {}
 

--- a/filecoin-proofs/examples/drgporep-vanilla.rs
+++ b/filecoin-proofs/examples/drgporep-vanilla.rs
@@ -4,7 +4,7 @@ extern crate rand;
 extern crate sapling_crypto;
 #[macro_use]
 extern crate clap;
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 extern crate gperftools;
 #[macro_use]
 extern crate slog;
@@ -17,7 +17,7 @@ use pairing::bls12_381::Bls12;
 use rand::{Rng, SeedableRng, XorShiftRng};
 use std::time::{Duration, Instant};
 
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 use gperftools::profiler::PROFILER;
 
 use storage_proofs::drgporep::*;
@@ -30,7 +30,7 @@ use storage_proofs::proof::ProofScheme;
 
 use filecoin_proofs::FCP_LOG;
 
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 #[inline(always)]
 fn start_profile(stage: &str) {
     PROFILER
@@ -40,17 +40,17 @@ fn start_profile(stage: &str) {
         .unwrap();
 }
 
-#[cfg(not(feature = "profile"))]
+#[cfg(not(feature = "cpu-profile"))]
 #[inline(always)]
 fn start_profile(_stage: &str) {}
 
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 #[inline(always)]
 fn stop_profile() {
     PROFILER.lock().unwrap().stop().unwrap();
 }
 
-#[cfg(not(feature = "profile"))]
+#[cfg(not(feature = "cpu-profile"))]
 #[inline(always)]
 fn stop_profile() {}
 

--- a/filecoin-proofs/examples/encoding.rs
+++ b/filecoin-proofs/examples/encoding.rs
@@ -4,7 +4,7 @@ extern crate rand;
 extern crate sapling_crypto;
 #[macro_use]
 extern crate clap;
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 extern crate gperftools;
 extern crate memmap;
 extern crate tempfile;
@@ -15,7 +15,7 @@ extern crate filecoin_proofs;
 extern crate storage_proofs;
 
 use clap::{App, Arg};
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 use gperftools::profiler::PROFILER;
 use memmap::MmapMut;
 use memmap::MmapOptions;
@@ -37,7 +37,7 @@ use storage_proofs::zigzag_drgporep::*;
 
 use filecoin_proofs::FCP_LOG;
 
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 #[inline(always)]
 fn start_profile(stage: &str) {
     PROFILER
@@ -47,17 +47,17 @@ fn start_profile(stage: &str) {
         .unwrap();
 }
 
-#[cfg(not(feature = "profile"))]
+#[cfg(not(feature = "cpu-profile"))]
 #[inline(always)]
 fn start_profile(_stage: &str) {}
 
-#[cfg(feature = "profile")]
+#[cfg(feature = "cpu-profile")]
 #[inline(always)]
 fn stop_profile() {
     PROFILER.lock().unwrap().stop().unwrap();
 }
 
-#[cfg(not(feature = "profile"))]
+#[cfg(not(feature = "cpu-profile"))]
 #[inline(always)]
 fn stop_profile() {}
 


### PR DESCRIPTION
The CPU and memory profilers don't seem to play nice together (at least in my local tests), I'm getting a

```
Check failed: f->header.magic == Magic(kMagicAllocated, &f->header): bad magic number in Free()
Aborted (core dumped)
```

so I'm deliberately redefining `start_profile` to make sure the two features are not used together (as far as I've seen `cargo` doesn't support mutually exclusive features).