### PR TITLE
revert to using fake_generate_post instead of real generate_post

### DIFF
--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -274,7 +274,7 @@ pub struct PoStInput {
 }
 
 pub fn fake_generate_post(
-    _sector_bytes: UnpaddedBytesAmount,
+    _sector_bytes: PaddedBytesAmount,
     input: PoStInput,
 ) -> error::Result<PoStOutput> {
     let faults: Vec<u64> = if !input.input_parts.is_empty() {

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -192,10 +192,10 @@ impl SectorMetadataManager {
         let mut seed = [0; 32];
         seed.copy_from_slice(challenge_seed);
 
-        let output = internal::generate_post(
+        let output = internal::fake_generate_post(
             self.sector_store.inner.config().sector_bytes(),
             PoStInput {
-                challenge_seed: *challenge_seed,
+                challenge_seed: seed,
                 input_parts,
             },
         );


### PR DESCRIPTION
I introduced a bug recently which would cause the FFI-exposed `generate_post` call to call in to the real `internal.rs` `generate_post` function. go-filecoin is not ready for that change yet.

This changeset reverts that change back to the `fake_generate_post` call.