### PR TITLE
paramfetch: validate all parameters

### DIFF
--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -1,4 +1,5 @@
 use clap::{App, Arg, ArgMatches};
+use failure::err_msg;
 use filecoin_proofs::param::*;
 use std::path::PathBuf;
 use std::process::exit;
@@ -43,6 +44,14 @@ Defaults to '{}'
 
 fn fetch(matches: &ArgMatches) -> Result<()> {
     let json = PathBuf::from(matches.value_of("json").unwrap_or("./parameters.json"));
+
+    if !json.exists() {
+        return Err(err_msg(format!(
+            "json file '{}' does not exist",
+            &json.to_str().unwrap_or("")
+        )));
+    }
+
     let parameter_map = get_parameter_map(&json)?;
 
     let parameter_ids = if matches.is_present("all") {

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -1,6 +1,8 @@
 use clap::{App, Arg, ArgMatches};
 use failure::err_msg;
 use filecoin_proofs::param::*;
+use std::io;
+use std::io::prelude::*;
 use std::path::PathBuf;
 use std::process::exit;
 use storage_proofs::parameter_cache::PARAMETER_CACHE_DIR;
@@ -34,7 +36,7 @@ Defaults to '{}'
         .get_matches();
 
     match fetch(&matches) {
-        Ok(_) => println!("success"),
+        Ok(_) => println!("done"),
         Err(err) => {
             println!("fatal error: {}", err);
             exit(1);
@@ -43,72 +45,99 @@ Defaults to '{}'
 }
 
 fn fetch(matches: &ArgMatches) -> Result<()> {
-    let json = PathBuf::from(matches.value_of("json").unwrap_or("./parameters.json"));
+    let json_path = PathBuf::from(matches.value_of("json").unwrap_or("./parameters.json"));
 
-    if !json.exists() {
+    if !json_path.exists() {
         return Err(err_msg(format!(
             "json file '{}' does not exist",
-            &json.to_str().unwrap_or("")
+            &json_path.to_str().unwrap_or("")
         )));
     }
 
-    let parameter_map = get_parameter_map(&json)?;
+    let parameter_map = get_parameter_map(&json_path)?;
+    let all_parameter_ids = get_mapped_parameter_ids(&parameter_map)?;
 
-    let parameter_ids = if matches.is_present("all") {
-        get_mapped_parameter_ids(&parameter_map)?
-    } else {
-        choose_from(get_mapped_parameter_ids(&parameter_map)?)?
-    };
+    println!("checking {} parameters...", all_parameter_ids.len());
+    println!("");
 
-    if !parameter_ids.is_empty() {
-        println!("fetching parameters");
+    let mut parameter_ids = get_pending_parameter_ids(&parameter_map, all_parameter_ids.clone())?;
 
-        for parameter_id in parameter_ids {
-            println!("fetching {}", parameter_id);
-
-            if get_parameter_file_path(&parameter_id).exists() {
-                println!("ok (already exists)");
-            } else {
-                match fetch_parameter_file(&parameter_map, &parameter_id) {
-                    Ok(_) => println!("ok"),
-                    Err(err) => println!("error: {}", err),
-                }
-            }
-        }
-    } else {
-        println!("no parameters to fetch");
+    if !matches.is_present("all") && parameter_ids.len() > 0 {
+        parameter_ids = choose_from(parameter_ids)?;
+        println!("");
     }
 
-    let parameter_ids = get_mapped_parameter_ids(&parameter_map)?;
+    loop {
+        println!("{} parameters to fetch...", parameter_ids.len());
+        println!("");
 
-    if !parameter_ids.is_empty() {
-        println!("validating parameters");
+        for parameter_id in &parameter_ids {
+            println!("fetching: {}", parameter_id);
+            print!("downloading parameter... ");
+            io::stdout().flush().unwrap();
 
-        let mut all_valid = true;
-
-        for parameter_id in get_mapped_parameter_ids(&parameter_map)? {
-            println!("validating {}", parameter_id);
-
-            match validate_parameter_file(&parameter_map, &parameter_id) {
-                Ok(true) => println!("ok"),
-                Ok(false) => {
-                    println!("error: invalid parameter file");
-                    invalidate_parameter_file(&parameter_id)?;
-                    all_valid = false;
-                }
-                Err(err) => {
-                    println!("error: {}", err);
-                    all_valid = false;
-                }
+            match fetch_parameter_file(&parameter_map, &parameter_id) {
+                Ok(_) => println!("ok\n"),
+                Err(err) => println!("error: {}\n", err),
             }
         }
 
-        if !all_valid {
-            println!("some parameter files were invalid, you may need to run paramfetch again");
+        parameter_ids = get_pending_parameter_ids(&parameter_map, parameter_ids)?;
+
+        if parameter_ids.is_empty() {
+            break;
+        } else {
+            println!("{} parameters failed to be fetched:", parameter_ids.len());
+
+            for parameter_id in &parameter_ids {
+                println!("{}", parameter_id);
+            }
+
+            println!("");
+
+            if !choose("try again?") {
+                return Err(err_msg("some parameters failed to be fetched"));
+            }
         }
-    } else {
-        println!("no parameters to validate");
     }
 
     Ok(())
+}
+
+fn get_pending_parameter_ids(
+    parameter_map: &ParameterMap,
+    parameter_ids: Vec<String>,
+) -> Result<Vec<String>> {
+    Ok(parameter_ids
+        .into_iter()
+        .filter(|parameter_id| {
+            println!("checking: {}", parameter_id);
+            print!("does parameter exist... ");
+
+            if get_parameter_file_path(parameter_id).exists() {
+                println!("yes");
+                print!("is parameter valid... ");
+                io::stdout().flush().unwrap();
+
+                match validate_parameter_file(&parameter_map, &parameter_id) {
+                    Ok(true) => {
+                        println!("yes\n");
+                        false
+                    }
+                    Ok(false) => {
+                        println!("no\n");
+                        invalidate_parameter_file(&parameter_id).unwrap();
+                        true
+                    }
+                    Err(err) => {
+                        println!("error: {}\n", err);
+                        true
+                    }
+                }
+            } else {
+                println!("no\n");
+                true
+            }
+        })
+        .collect())
 }

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -1,83 +1,105 @@
-use clap::{App, AppSettings, Arg, SubCommand};
-
+use clap::{App, Arg, ArgMatches};
 use filecoin_proofs::param::*;
 use std::path::PathBuf;
+use std::process::exit;
 use storage_proofs::parameter_cache::PARAMETER_CACHE_DIR;
 
 pub fn main() {
     let matches = App::new("paramfetch")
-        .setting(AppSettings::ArgRequiredElseHelp)
         .version("1.0")
-        .about("")
         .about(
             &format!(
                 "
-Set $FILECOIN_PARAMETER_CACHE to specify parameter directory. Defaults to '{}'
+Set $FILECOIN_PARAMETER_CACHE to specify parameter directory.
+Defaults to '{}'
 ",
                 PARAMETER_CACHE_DIR
             )[..],
         )
         .arg(
             Arg::with_name("json")
-                .global(true)
                 .value_name("JSON")
                 .takes_value(true)
                 .short("j")
                 .long("json")
                 .help("Use specific json file"),
         )
-        .subcommand(
-            SubCommand::with_name("fetch")
-                .arg(
-                    Arg::with_name("all")
-                        .short("a")
-                        .long("all")
-                        .help("Download all available parameters"),
-                )
-                .about("Download parameters through IPFS"),
-        )
-        .subcommand(
-            SubCommand::with_name("check").about("Check which mapped parameters have been fetched"),
+        .arg(
+            Arg::with_name("all")
+                .short("a")
+                .long("all")
+                .help("Download all available parameters"),
         )
         .get_matches();
 
-    let json = PathBuf::from(matches.value_of("json").unwrap_or("./parameters.json"));
-    let parameter_map = get_parameter_map(&json).expect(ERROR_PARAMETERS_MAPPED);
-
-    if let Some(matches) = matches.subcommand_matches("fetch") {
-        let parameter_ids = if matches.is_present("all") {
-            get_mapped_parameter_ids(&parameter_map)
-        } else {
-            choose_mapped_parameter_ids(&parameter_map)
+    match fetch(&matches) {
+        Ok(_) => println!("success"),
+        Err(err) => {
+            println!("fatal error: {}", err);
+            exit(1);
         }
-        .expect(ERROR_PARAMETERS_MAPPED);
+    }
+}
 
-        if !parameter_ids.is_empty() {
-            println!("fetching parameters");
+fn fetch(matches: &ArgMatches) -> Result<()> {
+    let json = PathBuf::from(matches.value_of("json").unwrap_or("./parameters.json"));
+    let parameter_map = get_parameter_map(&json)?;
 
-            for parameter_id in parameter_ids.iter() {
-                println!("fetching '{}'...", parameter_id);
+    let parameter_ids = if matches.is_present("all") {
+        get_mapped_parameter_ids(&parameter_map)?
+    } else {
+        choose_from(get_mapped_parameter_ids(&parameter_map)?)?
+    };
 
+    if !parameter_ids.is_empty() {
+        println!("fetching parameters");
+
+        for parameter_id in parameter_ids {
+            println!("fetching {}", parameter_id);
+
+            if get_parameter_file_path(&parameter_id).exists() {
+                println!("ok (already exists)");
+            } else {
                 match fetch_parameter_file(&parameter_map, &parameter_id) {
                     Ok(_) => println!("ok"),
                     Err(err) => println!("error: {}", err),
                 }
             }
-        } else {
-            println!("nothing to fetch");
         }
+    } else {
+        println!("no parameters to fetch");
     }
 
-    if matches.subcommand_matches("check").is_some() {
-        let mapped_parameters =
-            get_mapped_parameter_ids(&parameter_map).expect(ERROR_PARAMETERS_MAPPED);
-        let local_parameters = get_local_parameter_ids().expect(ERROR_PARAMETERS_LOCAL);
+    let parameter_ids = get_mapped_parameter_ids(&parameter_map)?;
 
-        mapped_parameters.iter().for_each(|p| {
-            let local = local_parameters.contains(p);
-            let check = if local { "☑" } else { "☐" };
+    if !parameter_ids.is_empty() {
+        println!("validating parameters");
 
-            println!("{} {}", check, p);
-        });
+        let mut all_valid = true;
+
+        for parameter_id in get_mapped_parameter_ids(&parameter_map)? {
+            println!("validating {}", parameter_id);
+
+            match validate_parameter_file(&parameter_map, &parameter_id) {
+                Ok(true) => println!("ok"),
+                Ok(false) => {
+                    println!("error: invalid parameter file");
+                    invalidate_parameter_file(&parameter_id)?;
+                    all_valid = false;
+                }
+                Err(err) => {
+                    println!("error: {}", err);
+                    all_valid = false;
+                }
+            }
+        }
+
+        if !all_valid {
+            println!("some parameter files were invalid, you may need to run paramfetch again");
+        }
+    } else {
+        println!("no parameters to validate");
     }
+
+    Ok(())
 }

--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -1,94 +1,82 @@
-use clap::{App, AppSettings, Arg, SubCommand};
+use clap::{App, Arg, ArgMatches};
+use filecoin_proofs::param::*;
 use std::collections::HashMap;
 use std::path::PathBuf;
-
-use filecoin_proofs::param::*;
+use std::process::exit;
 use storage_proofs::parameter_cache::PARAMETER_CACHE_DIR;
 
 pub fn main() {
     let matches = App::new("parampublish")
-        .setting(AppSettings::ArgRequiredElseHelp)
         .version("1.0")
         .about(
             &format!(
                 "
-Set $FILECOIN_PARAMETER_CACHE to specify parameter directory. Defaults to '{}'
+Set $FILECOIN_PARAMETER_CACHE to specify parameter directory.
+Defaults to '{}'
 ",
                 PARAMETER_CACHE_DIR
             )[..],
         )
         .arg(
             Arg::with_name("json")
-                .global(true)
                 .value_name("JSON")
                 .takes_value(true)
                 .short("j")
                 .long("json")
                 .help("Use specific json file"),
         )
-        .subcommand(
-            SubCommand::with_name("publish")
-                .arg(
-                    Arg::with_name("all")
-                        .short("a")
-                        .long("all")
-                        .help("Publish all local parameters"),
-                )
-                .about("Publish local parameters through IPFS"),
-        )
-        .subcommand(
-            SubCommand::with_name("check")
-                .about("Check which local parameters have been published"),
+        .arg(
+            Arg::with_name("all")
+                .short("a")
+                .long("all")
+                .help("Publish all local parameters"),
         )
         .get_matches();
 
+    match publish(&matches) {
+        Ok(_) => println!("success"),
+        Err(err) => {
+            println!("fatal error: {}", err);
+            exit(1);
+        }
+    }
+}
+
+fn publish(matches: &ArgMatches) -> Result<()> {
+    let parameter_ids = if matches.is_present("all") {
+        get_local_parameter_ids()?
+    } else {
+        choose_from(get_local_parameter_ids()?)?
+    };
+
     let json = PathBuf::from(matches.value_of("json").unwrap_or("./parameters.json"));
-    let parameter_map = get_parameter_map(&json).expect(ERROR_PARAMETERS_MAPPED);
+    let mut parameter_map: ParameterMap = HashMap::new();
 
-    if let Some(matches) = matches.subcommand_matches("publish") {
-        let mut new_parameter_map: ParameterMap = HashMap::new();
-        let parameter_ids = if matches.is_present("all") {
-            get_local_parameter_ids()
-        } else {
-            choose_local_parameter_ids()
-        }
-        .expect(ERROR_PARAMETERS_LOCAL);
+    if !parameter_ids.is_empty() {
+        println!("publishing parameters");
 
-        if !parameter_ids.is_empty() {
-            println!("publishing parameters");
+        for parameter_id in parameter_ids {
+            println!("publishing {}", parameter_id);
 
-            for parameter_id in parameter_ids.into_iter() {
-                println!("publishing '{}'...", parameter_id);
+            match publish_parameter_file(&parameter_id) {
+                Ok(cid) => {
+                    println!("generating digest");
 
-                match publish_parameter_file(&parameter_id) {
-                    Ok(cid) => {
-                        println!("generating digest...");
-                        let digest = get_parameter_digest(&parameter_id).expect(ERROR_DIGEST);
-                        let data = ParameterData { cid, digest };
+                    let digest = get_parameter_digest(&parameter_id)?;
+                    let data = ParameterData { cid, digest };
 
-                        println!("ok.");
-                        new_parameter_map.insert(parameter_id, data);
-                    }
-                    Err(err) => println!("err: {}", err),
+                    parameter_map.insert(parameter_id, data);
+
+                    println!("ok");
                 }
+                Err(err) => println!("error: {}", err),
             }
-
-            save_parameter_map(&new_parameter_map, &json).expect(ERROR_PARAMETER_MAP_SAVE);
-        } else {
-            println!("nothing to publish");
         }
+
+        save_parameter_map(&parameter_map, &json)?;
+    } else {
+        println!("no parameters to publish");
     }
 
-    if matches.subcommand_matches("check").is_some() {
-        let mapped_parameters =
-            get_mapped_parameter_ids(&parameter_map).expect(ERROR_PARAMETERS_MAPPED);
-        let local_parameters = get_local_parameter_ids().expect(ERROR_PARAMETERS_LOCAL);
-
-        local_parameters.iter().for_each(|p| {
-            let mapped = mapped_parameters.contains(p);
-            let check = if mapped { "☑" } else { "☐" };
-
-            println!("{} {}", check, p);
-        });
-    }
+    Ok(())
 }

--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -1,6 +1,8 @@
 use clap::{App, Arg, ArgMatches};
 use filecoin_proofs::param::*;
 use std::collections::HashMap;
+use std::io;
+use std::io::prelude::*;
 use std::path::PathBuf;
 use std::process::exit;
 use storage_proofs::parameter_cache::PARAMETER_CACHE_DIR;
@@ -34,7 +36,7 @@ Defaults to '{}'
         .get_matches();
 
     match publish(&matches) {
-        Ok(_) => println!("success"),
+        Ok(_) => println!("done"),
         Err(err) => {
             println!("fatal error: {}", err);
             exit(1);
@@ -43,24 +45,30 @@ Defaults to '{}'
 }
 
 fn publish(matches: &ArgMatches) -> Result<()> {
-    let parameter_ids = if matches.is_present("all") {
-        get_local_parameter_ids()?
-    } else {
-        choose_from(get_local_parameter_ids()?)?
+    let mut parameter_ids = get_local_parameter_ids()?;
+
+    if !matches.is_present("all") {
+        parameter_ids = choose_from(parameter_ids)?;
+        println!("");
     };
 
     let json = PathBuf::from(matches.value_of("json").unwrap_or("./parameters.json"));
     let mut parameter_map: ParameterMap = HashMap::new();
 
     if !parameter_ids.is_empty() {
-        println!("publishing parameters");
+        println!("publishing {} parameters...", parameter_ids.len());
+        println!("");
 
         for parameter_id in parameter_ids {
-            println!("publishing {}", parameter_id);
+            println!("publishing: {}", parameter_id);
+            print!("publishing to ipfs... ");
+            io::stdout().flush().unwrap();
 
             match publish_parameter_file(&parameter_id) {
                 Ok(cid) => {
-                    println!("generating digest");
+                    println!("ok");
+                    print!("generating digest... ");
+                    io::stdout().flush().unwrap();
 
                     let digest = get_parameter_digest(&parameter_id)?;
                     let data = ParameterData { cid, digest };
@@ -71,6 +79,8 @@ fn publish(matches: &ArgMatches) -> Result<()> {
                 }
                 Err(err) => println!("error: {}", err),
             }
+
+            println!("");
         }
 
         save_parameter_map(&parameter_map, &json)?;

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -57,20 +57,11 @@ pub fn get_mapped_parameter_ids(parameter_map: &ParameterMap) -> Result<Vec<Stri
 }
 
 pub fn get_parameter_map(path: &PathBuf) -> Result<ParameterMap> {
-    if path.exists() {
-        let file = File::open(path)?;
-        let reader = BufReader::new(file);
-        let parameter_map = serde_json::from_reader(reader)?;
+    let file = File::open(path)?;
+    let reader = BufReader::new(file);
+    let parameter_map = serde_json::from_reader(reader)?;
 
-        Ok(parameter_map)
-    } else {
-        println!(
-            "parameter manifest '{}' does not exist",
-            path.as_path().to_str().unwrap()
-        );
-
-        Ok(HashMap::new())
-    }
+    Ok(parameter_map)
 }
 
 pub fn get_parameter_data<'a>(

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -165,7 +165,7 @@ pub fn invalidate_parameter_file(parameter_id: &str) -> Result<()> {
 
 pub fn choose(message: &str) -> bool {
     loop {
-        print!("{} [y/n]: ", message);
+        print!("[y/n] {}: ", message);
 
         let _ = stdout().flush();
         let mut s = String::new();


### PR DESCRIPTION
fixes: https://github.com/filecoin-project/rust-fil-proofs/issues/511

removed check subcommands and simplified tool use (run `paramfetch`, not `paramfetch fetch`)

moved the commands themselves to their own functions with `Result` return type so i can use `?`

made output verbiage a bit more consistent