### PR TITLE
adapter layer to accommodate fixed "sectors count" in VDF PoSt

### DIFF
--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -344,7 +344,8 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
             &sealed_sector_replica_commitment[0],
             32,
             &challenge_seed,
-            &((*resp).proof),
+            (*resp).proofs_ptr,
+            (*resp).proofs_len,
             (*resp).faults_ptr,
             (*resp).faults_len,
         );

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -261,12 +261,14 @@ fn pad_safe_fr(unpadded: &FrSafe) -> Fr32Ary {
 pub fn generate_post(
     dynamic: GeneratePoStDynamicSectorsCountInput,
 ) -> error::Result<GeneratePoStDynamicSectorsCountOutput> {
+    let n = { dynamic.input_parts.len() };
+
     let fixed_output = generate_post_spread_input(dynamic)
         .iter()
         .map(generate_post_fixed_sectors_count)
         .collect();
 
-    generate_post_collect_output(fixed_output)
+    generate_post_collect_output(n, fixed_output)
 }
 
 pub fn fake_generate_post(

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -261,12 +261,12 @@ fn pad_safe_fr(unpadded: &FrSafe) -> Fr32Ary {
 pub fn generate_post(
     dynamic: GeneratePoStDynamicSectorsCountInput,
 ) -> error::Result<GeneratePoStDynamicSectorsCountOutput> {
-    let fixed_output = fan_out_generate_post_input(dynamic)
+    let fixed_output = generate_post_spread_input(dynamic)
         .iter()
         .map(generate_post_fixed_sectors_count)
         .collect();
 
-    fan_in_generate_post_output(fixed_output)
+    generate_post_collect_output(fixed_output)
 }
 
 pub fn fake_generate_post(
@@ -287,12 +287,12 @@ pub fn fake_generate_post(
 pub fn verify_post(
     dynamic: VerifyPoStDynamicSectorsCountInput,
 ) -> error::Result<VerifyPoStDynamicSectorsCountOutput> {
-    let fixed = fan_out_verify_post_input(dynamic)?
+    let fixed = verify_post_spread_input(dynamic)?
         .iter()
         .map(verify_post_fixed_sectors_count)
         .collect();
 
-    fan_in_verify_post_output(fixed)
+    verify_post_collect_output(fixed)
 }
 
 pub fn generate_post_fixed_sectors_count(

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -136,15 +136,30 @@ pub unsafe extern "C" fn generate_post(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn verify_post(
-    cfg_ptr: *const ConfiguredStore,
-    flattened_comm_rs_ptr: *const u8,
-    flattened_comm_rs_len: libc::size_t,
-    challenge_seed: &[u8; 32],
+    _cfg_ptr: *const ConfiguredStore,
+    _flattened_comm_rs_ptr: *const u8,
+    _flattened_comm_rs_len: libc::size_t,
+    _challenge_seed: &[u8; 32],
     proofs_ptr: *const [u8; 192],
     proofs_len: libc::size_t,
-    faults_ptr: *const u64,
-    faults_len: libc::size_t,
+    _faults_ptr: *const u64,
+    _faults_len: libc::size_t,
 ) -> *mut responses::VerifyPoSTResponse {
+    let mut response: responses::VerifyPoSTResponse = Default::default();
+
+    let proofs: &[[u8; 192]] = from_raw_parts(proofs_ptr, proofs_len);
+
+    if proofs[0][0] == 42 {
+        response.is_valid = true;
+    } else {
+        response.is_valid = false;
+    };
+
+    // Stay mocked for now — remove early return when ready to use.
+    Box::into_raw(Box::new(response))
+
+    /*
+
     let mut response: responses::VerifyPoSTResponse = Default::default();
 
     if let Some(cfg) = cfg_ptr.as_ref() {
@@ -196,6 +211,8 @@ pub unsafe extern "C" fn verify_post(
     }
 
     Box::into_raw(Box::new(response))
+
+    */
 }
 
 /// Initializes and returns a SectorBuilder.

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -1,4 +1,4 @@
-use crate::api::internal::PoStOutput;
+use crate::api::post_adapter::*;
 use crate::api::responses::err_code_and_msg;
 use crate::api::responses::FCPResponseStatus;
 use crate::api::responses::FFIPieceMetadata;
@@ -7,15 +7,17 @@ use crate::api::sector_builder::metadata::SealStatus;
 use crate::api::sector_builder::SectorBuilder;
 use ffi_toolkit::rust_str_to_c_str;
 use ffi_toolkit::{c_str_to_rust_str, raw_ptr};
-use libc;
 use sector_base::api::disk_backed_storage::new_sector_config;
 use sector_base::api::disk_backed_storage::ConfiguredStore;
+
+use libc;
 use std::ffi::CString;
 use std::mem;
 use std::ptr;
 use std::slice::from_raw_parts;
 
 pub mod internal;
+pub mod post_adapter;
 pub mod responses;
 mod sector_builder;
 
@@ -94,7 +96,7 @@ pub unsafe extern "C" fn generate_post(
     flattened_comm_rs_ptr: *const u8,
     flattened_comm_rs_len: libc::size_t,
     challenge_seed: &[u8; 32],
-) -> *mut responses::GeneratePoSTResponse {
+) -> *mut responses::GeneratePoStResponse {
     let comm_rs = from_raw_parts(flattened_comm_rs_ptr, flattened_comm_rs_len)
         .iter()
         .step_by(32)
@@ -106,15 +108,13 @@ pub unsafe extern "C" fn generate_post(
             acc
         });
 
-    let mut response: responses::GeneratePoSTResponse = Default::default();
+    let mut response: responses::GeneratePoStResponse = Default::default();
 
     match (*ptr).generate_post(&comm_rs, challenge_seed) {
-        Ok(PoStOutput {
-            snark_proof,
-            faults,
-        }) => {
+        Ok(GeneratePoStDynamicSectorsCountOutput { proofs, faults }) => {
             response.status_code = FCPResponseStatus::FCPNoError;
-            response.proof = snark_proof;
+            response.proofs_len = proofs.len();
+            response.proofs_ptr = proofs.as_ptr();
 
             response.faults_len = faults.len();
             response.faults_ptr = faults.as_ptr();
@@ -136,68 +136,66 @@ pub unsafe extern "C" fn generate_post(
 ///
 #[no_mangle]
 pub unsafe extern "C" fn verify_post(
-    _cfg_ptr: *const ConfiguredStore,
-    _flattened_comm_rs_ptr: *const u8,
-    _flattened_comm_rs_len: libc::size_t,
-    _challenge_seed: &[u8; 32],
-    proof: &[u8; API_POST_PROOF_BYTES],
-    _faults_ptr: *const u64,
-    _faults_len: libc::size_t,
+    cfg_ptr: *const ConfiguredStore,
+    flattened_comm_rs_ptr: *const u8,
+    flattened_comm_rs_len: libc::size_t,
+    challenge_seed: &[u8; 32],
+    proofs_ptr: *const [u8; 192],
+    proofs_len: libc::size_t,
+    faults_ptr: *const u64,
+    faults_len: libc::size_t,
 ) -> *mut responses::VerifyPoSTResponse {
     let mut response: responses::VerifyPoSTResponse = Default::default();
 
-    if proof[0] == 42 {
-        response.is_valid = true;
+    if let Some(cfg) = cfg_ptr.as_ref() {
+        let cfg = new_sector_config(cfg);
+
+        let comm_rs = from_raw_parts(flattened_comm_rs_ptr, flattened_comm_rs_len)
+            .iter()
+            .step_by(32)
+            .fold(Default::default(), |mut acc: Vec<[u8; 32]>, item| {
+                let sliced = from_raw_parts(item, 32);
+                let mut x: [u8; 32] = Default::default();
+                x.copy_from_slice(&sliced[..32]);
+                acc.push(x);
+                acc
+            });
+
+        let faults = from_raw_parts(faults_ptr, faults_len);
+
+        let safe_challenge_seed = {
+            let mut cs = [0; 32];
+            cs.copy_from_slice(challenge_seed);
+            cs[31] &= 0b00111111;
+            cs
+        };
+
+        match internal::verify_post(VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: cfg.sector_bytes(),
+            comm_rs,
+            challenge_seed: safe_challenge_seed,
+            proofs: from_raw_parts(proofs_ptr, proofs_len).to_vec(),
+            faults: faults.to_vec(),
+        }) {
+            Ok(dynamic) => {
+                response.status_code = FCPResponseStatus::FCPNoError;
+                response.is_valid = dynamic.is_valid;
+            }
+            Err(err) => {
+                let (code, ptr) = err_code_and_msg(&err);
+                response.status_code = code;
+                response.error_msg = ptr;
+            }
+        }
     } else {
-        response.is_valid = false;
-    };
+        response.status_code = FCPResponseStatus::FCPCallerError;
 
-    // Stay mocked for now — remove early return when ready to use.
+        let msg = CString::new("caller did not provide ConfiguredStore").unwrap();
+        response.error_msg = msg.as_ptr();
+        mem::forget(msg);
+    }
+
     Box::into_raw(Box::new(response))
-
-    // let comm_rs = from_raw_parts(flattened_comm_rs_ptr, flattened_comm_rs_len)
-    //     .iter()
-    //     .step_by(32)
-    //     .fold(Default::default(), |mut acc: Vec<[u8; 32]>, item| {
-    //         let sliced = from_raw_parts(item, 32);
-    //         let mut x: [u8; 32] = Default::default();
-    //         x.copy_from_slice(&sliced[..32]);
-    //         acc.push(x);
-    //         acc
-    //     });
-
-    // let faults = from_raw_parts(faults_ptr, faults_len);
-
-    // let safe_challenge_seed = {
-    //     let mut cs = [0; 32];
-    //     cs.copy_from_slice(challenge_seed);
-    //     cs[31] &= 0b00111111;
-    //     cs
-    // };
-
-    // match internal::verify_post(
-    //     sector_bytes,
-    //     &comm_rs,
-    //     &safe_challenge_seed,
-    //     proof,
-    //     faults.to_vec(),
-    // ) {
-    //     Ok(true) => {
-    //         response.status_code = FCPResponseStatus::FCPNoError;
-    //         response.is_valid = true;
-    //     }
-    //     Ok(false) => {
-    //         response.status_code = FCPResponseStatus::FCPNoError;
-    //         response.is_valid = false;
-    //     }
-    //     Err(err) => {
-    //         let (code, ptr) = err_code_and_msg(&err);
-    //         response.status_code = code;
-    //         response.error_msg = ptr;
-    //     }
-    // }
-
-    // Box::into_raw(Box::new(response))
 }
 
 /// Initializes and returns a SectorBuilder.

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -52,7 +52,6 @@ pub struct VerifyPoStFixedSectorsCountOutput {
     pub is_valid: bool,
 }
 
-
 /// Maps inputs for a single dynamic sectors-count PoSt generation operation to
 /// a vector of PoSt generation inputs for fixed sectors-count.
 ///
@@ -160,13 +159,13 @@ pub fn verify_post_spread_input(
     if faults_max
         .map(|m| *m > commrs_len as u64 - 1)
         .unwrap_or(false)
-        {
-            return Err(format_err!(
+    {
+        return Err(format_err!(
             "MAX(faults) must <= LEN(comm_rs)-1: {:?}, {:?}",
             faults_max,
             commrs_len - 1
         ));
-        }
+    }
 
     let mut fixed: Vec<VerifyPoStFixedSectorsCountInput> = vec![];
 

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -167,7 +167,7 @@ pub fn verify_post_spread_input(
 
     if proofs_len != replicas_c {
         return Err(format_err!(
-            "LEN(proofs) must == CEIL(LEN(comm_rs)/2): {:?}, {:?}",
+            "LEN(proofs) must == CEIL(LEN(comm_rs)/POST_SECTORS_COUNT): {:?}, {:?}",
             proofs_len,
             replicas_c
         ));

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -277,15 +277,15 @@ pub fn verify_post_spread_input(
     //   {comm_rs=[c, c] faults=[0, 1]}
     // ]
     if !remainder.is_empty() {
-        let fixed_len = { fixed.len() - 1 };
+        let fixed_len = { fixed.len() };
         let remdr_len = { remainder.len() };
 
         let last_remainder_fault: Option<u64> =
-            { fixed[fixed_len].faults.get(remdr_len - 1).cloned() };
+            { fixed[fixed_len - 1].faults.get(remdr_len - 1).cloned() };
 
         if let Some(fault) = last_remainder_fault {
             for n in 0..(POST_SECTORS_COUNT - remdr_len) {
-                fixed[fixed_len].faults.push(1 + fault + n as u64);
+                fixed[fixed_len - 1].faults.push(1 + fault + n as u64);
             }
         }
     }

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -83,11 +83,14 @@ pub fn generate_post_spread_input(
         let mut input_parts: [(Option<String>, Commitment); POST_SECTORS_COUNT] =
             Default::default();
 
-        let vs = repeat_with(|| remainder[remainder.len() - 1].clone());
-        let rs = remainder.iter().cloned();
-        let it = rs.chain(vs).take(POST_SECTORS_COUNT).enumerate();
+        let iter_with_idx = remainder
+            .iter()
+            .cloned()
+            .chain(repeat_with(|| remainder[remainder.len() - 1].clone()))
+            .take(POST_SECTORS_COUNT)
+            .enumerate();
 
-        for (i, input_part) in it {
+        for (i, input_part) in iter_with_idx {
             input_parts[i] = input_part;
         }
 
@@ -210,11 +213,14 @@ pub fn verify_post_spread_input(
     if !remainder.is_empty() {
         let mut comm_rs: [Commitment; POST_SECTORS_COUNT] = Default::default();
 
-        let vs = repeat(remainder[remainder.len() - 1]);
-        let rs = remainder.iter().cloned();
-        let it = rs.chain(vs).take(POST_SECTORS_COUNT).enumerate();
+        let iter_with_idx = remainder
+            .iter()
+            .cloned()
+            .chain(repeat(remainder[remainder.len() - 1]))
+            .take(POST_SECTORS_COUNT)
+            .enumerate();
 
-        for (i, comm_r) in it {
+        for (i, comm_r) in iter_with_idx {
             comm_rs[i] = comm_r;
         }
 

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -154,8 +154,7 @@ pub fn verify_post_spread_input(
     let commrs_len = dynamic.comm_rs.len();
     let proofs_len = dynamic.proofs.len();
     let replicas_c = (commrs_len as f64 / POST_SECTORS_COUNT as f64)
-        .ceil()
-        .round() as usize;
+        .ceil() as usize;
     let faults_max = dynamic.faults.iter().max();
 
     if faults_len > commrs_len {

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -65,10 +65,17 @@ pub fn generate_post_spread_input(
     let remainder = chunks.remainder();
 
     for chunk in chunks {
+        let mut input_parts: [(Option<String>, Commitment); POST_SECTORS_COUNT] =
+            Default::default();
+
+        for (i, input_part) in chunk.iter().cloned().enumerate() {
+            input_parts[i] = input_part
+        }
+
         fixed.push(GeneratePoStFixedSectorsCountInput {
             sector_bytes: dynamic.sector_bytes,
             challenge_seed: dynamic.challenge_seed,
-            input_parts: [chunk[0].clone(), chunk[1].clone()],
+            input_parts,
         });
     }
 

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -269,13 +269,13 @@ pub fn verify_post_spread_input(
 pub fn verify_post_collect_output(
     xs: Vec<error::Result<VerifyPoStFixedSectorsCountOutput>>,
 ) -> error::Result<VerifyPoStDynamicSectorsCountOutput> {
-    let x = if xs.is_empty() {
+    let seed = if xs.is_empty() {
         Err(format_err!("input vector must not be empty"))
     } else {
         Ok(VerifyPoStDynamicSectorsCountOutput { is_valid: true })
     };
 
-    xs.into_iter().fold(x, |acc, item| {
+    xs.into_iter().fold(seed, |acc, item| {
         acc.and_then(|d1| {
             item.map(|d2| VerifyPoStDynamicSectorsCountOutput {
                 is_valid: d1.is_valid && d2.is_valid,

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -1,0 +1,598 @@
+use crate::api::internal::ChallengeSeed;
+use crate::api::internal::Commitment;
+use crate::api::internal::POST_SECTORS_COUNT;
+use crate::error;
+use sector_base::api::bytes_amount::PaddedBytesAmount;
+use std::iter::repeat;
+use std::iter::repeat_with;
+
+pub struct GeneratePoStDynamicSectorsCountInput {
+    pub sector_bytes: PaddedBytesAmount,
+    pub challenge_seed: ChallengeSeed,
+    pub input_parts: Vec<(Option<String>, Commitment)>,
+}
+
+pub struct GeneratePoStFixedSectorsCountInput {
+    pub sector_bytes: PaddedBytesAmount,
+    pub challenge_seed: ChallengeSeed,
+    pub input_parts: [(Option<String>, Commitment); POST_SECTORS_COUNT],
+}
+
+pub struct VerifyPoStDynamicSectorsCountInput {
+    pub sector_bytes: PaddedBytesAmount,
+    pub comm_rs: Vec<Commitment>,
+    pub challenge_seed: ChallengeSeed,
+    pub proofs: Vec<[u8; 192]>,
+    pub faults: Vec<u64>,
+}
+
+pub struct VerifyPoStFixedSectorsCountInput {
+    pub sector_bytes: PaddedBytesAmount,
+    pub comm_rs: [Commitment; POST_SECTORS_COUNT],
+    pub challenge_seed: ChallengeSeed,
+    pub proof: [u8; 192],
+    pub faults: Vec<u64>,
+}
+
+pub struct GeneratePoStDynamicSectorsCountOutput {
+    pub proofs: Vec<[u8; 192]>,
+    pub faults: Vec<u64>,
+}
+
+pub struct GeneratePoStFixedSectorsCountOutput {
+    pub proof: [u8; 192],
+    pub faults: Vec<u64>,
+}
+
+pub struct VerifyPoStDynamicSectorsCountOutput {
+    pub is_valid: bool,
+}
+
+pub struct VerifyPoStFixedSectorsCountOutput {
+    pub is_valid: bool,
+}
+
+pub fn fan_in_generate_post_output(
+    xs: Vec<error::Result<GeneratePoStFixedSectorsCountOutput>>,
+) -> error::Result<GeneratePoStDynamicSectorsCountOutput> {
+    if xs.is_empty() {
+        return Err(format_err!("input vector must not be empty"));
+    }
+
+    let mut dynamic = GeneratePoStDynamicSectorsCountOutput {
+        proofs: Vec::new(),
+        faults: Vec::new(),
+    };
+
+    for (i, x) in xs.into_iter().enumerate() {
+        match x {
+            Err(e) => {
+                return Err(e);
+            }
+            Ok(fixed) => {
+                dynamic.proofs.push(fixed.proof);
+                for fault in fixed.faults.iter() {
+                    dynamic.faults.push(((i as u64) * 2) + fault)
+                }
+            }
+        }
+    }
+
+    Ok(dynamic)
+}
+
+pub fn fan_out_generate_post_input(
+    dynamic: GeneratePoStDynamicSectorsCountInput,
+) -> Vec<GeneratePoStFixedSectorsCountInput> {
+    let mut fixed: Vec<GeneratePoStFixedSectorsCountInput> = vec![];
+
+    let chunks = dynamic.input_parts.chunks_exact(POST_SECTORS_COUNT);
+
+    let remainder = chunks.remainder();
+
+    for chunk in chunks {
+        fixed.push(GeneratePoStFixedSectorsCountInput {
+            sector_bytes: dynamic.sector_bytes,
+            challenge_seed: dynamic.challenge_seed,
+            input_parts: [chunk[0].clone(), chunk[1].clone()],
+        });
+    }
+
+    if !remainder.is_empty() {
+        let mut input_parts: [(Option<String>, Commitment); POST_SECTORS_COUNT] =
+            Default::default();
+
+        let vs = repeat_with(|| remainder[remainder.len() - 1].clone());
+        let rs = remainder.iter().cloned();
+        let it = rs.chain(vs).take(POST_SECTORS_COUNT).enumerate();
+
+        for (i, input_part) in it {
+            input_parts[i] = input_part;
+        }
+
+        fixed.push(GeneratePoStFixedSectorsCountInput {
+            sector_bytes: dynamic.sector_bytes,
+            challenge_seed: dynamic.challenge_seed,
+            input_parts,
+        });
+    }
+
+    fixed
+}
+
+pub fn fan_in_verify_post_output(
+    xs: Vec<error::Result<VerifyPoStFixedSectorsCountOutput>>,
+) -> error::Result<VerifyPoStDynamicSectorsCountOutput> {
+    if xs.is_empty() {
+        return Err(format_err!("input vector must not be empty"));
+    }
+
+    let mut dynamic = VerifyPoStDynamicSectorsCountOutput { is_valid: true };
+
+    for x in xs.into_iter() {
+        match x {
+            Err(e) => {
+                return Err(e);
+            }
+            Ok(VerifyPoStFixedSectorsCountOutput { is_valid }) => {
+                dynamic.is_valid = dynamic.is_valid && is_valid;
+            }
+        }
+    }
+
+    Ok(dynamic)
+}
+
+pub fn fan_out_verify_post_input(
+    dynamic: VerifyPoStDynamicSectorsCountInput,
+) -> error::Result<Vec<VerifyPoStFixedSectorsCountInput>> {
+    let faults_len = dynamic.faults.len();
+    let commrs_len = dynamic.comm_rs.len();
+    let proofs_len = dynamic.proofs.len();
+    let replicas_c = (commrs_len as f64 / POST_SECTORS_COUNT as f64)
+        .ceil()
+        .round() as usize;
+    let faults_max = dynamic.faults.iter().max();
+
+    if faults_len > commrs_len {
+        return Err(format_err!(
+            "LEN(faults) must <= LEN(comm_rs): {:?}, {:?}",
+            faults_len,
+            commrs_len
+        ));
+    }
+
+    if proofs_len != replicas_c {
+        return Err(format_err!(
+            "LEN(proofs) must == CEIL(LEN(comm_rs)/2): {:?}, {:?}",
+            proofs_len,
+            replicas_c
+        ));
+    }
+
+    if faults_max
+        .map(|m| *m > commrs_len as u64 - 1)
+        .unwrap_or(false)
+    {
+        return Err(format_err!(
+            "MAX(faults) must <= LEN(comm_rs)-1: {:?}, {:?}",
+            faults_max,
+            commrs_len - 1
+        ));
+    }
+
+    let mut fixed: Vec<VerifyPoStFixedSectorsCountInput> = vec![];
+
+    let chunks = dynamic.comm_rs.chunks_exact(POST_SECTORS_COUNT);
+
+    let remainder = chunks.remainder();
+
+    // each POST_SECTORS_COUNT grouping of commitments maps to a single fixed
+    // sectors-count PoSt verification call
+    for (i, chunk) in chunks.enumerate() {
+        let mut comm_rs: [Commitment; POST_SECTORS_COUNT] = [[0; 32]; POST_SECTORS_COUNT];
+        for (i, comm_r) in chunk.iter().enumerate() {
+            comm_rs[i] = *comm_r;
+        }
+
+        fixed.push(VerifyPoStFixedSectorsCountInput {
+            sector_bytes: dynamic.sector_bytes,
+            comm_rs,
+            challenge_seed: dynamic.challenge_seed,
+            proof: dynamic.proofs[i],
+            faults: Vec::new(),
+        })
+    }
+
+    // If we receive a number of comm_rs which does not divide evenly by
+    // POST_SECTORS_COUNT, form a grouping of comm_rs which does divide
+    // evenly by POST_SECTORS_COUNT by duplicating the last comm_r in the
+    // group until LEN(comm_rs) == POST_SECTORS_COUNT.
+    if !remainder.is_empty() {
+        let mut comm_rs: [Commitment; POST_SECTORS_COUNT] = Default::default();
+
+        let vs = repeat(remainder[remainder.len() - 1]);
+        let rs = remainder.iter().cloned();
+        let it = rs.chain(vs).take(POST_SECTORS_COUNT).enumerate();
+
+        for (i, comm_r) in it {
+            comm_rs[i] = comm_r;
+        }
+
+        fixed.push(VerifyPoStFixedSectorsCountInput {
+            sector_bytes: dynamic.sector_bytes,
+            comm_rs,
+            challenge_seed: dynamic.challenge_seed,
+            proof: dynamic.proofs[proofs_len - 1],
+            faults: Vec::new(),
+        })
+    }
+
+    // Map the dynamic sectors count indices to the fixed sectors count indices.
+    for fault in dynamic.faults {
+        let i = (fault as f64 / POST_SECTORS_COUNT as f64).floor();
+        fixed[i as usize]
+            .faults
+            .push(fault % POST_SECTORS_COUNT as u64);
+    }
+
+    // If we had to duplicate commitments to make LEN(COMMITMENTS) ==
+    // POST_SECTORS_COUNT and the thing we duplicated was faulty, ensure that
+    // the duplicates are marked as faulty, too.
+    if !remainder.is_empty() {
+        let fixed_len = { fixed.len() - 1 };
+        let remdr_len = { remainder.len() };
+
+        let last_remainder_fault: Option<u64> =
+            { fixed[fixed_len].faults.get(remdr_len - 1).cloned() };
+
+        if let Some(fault) = last_remainder_fault {
+            for n in 0..(POST_SECTORS_COUNT - remdr_len) {
+                fixed[fixed_len].faults.push(1 + fault + n as u64);
+            }
+        }
+    }
+
+    Ok(fixed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sector_access_flattened(fixed: &[GeneratePoStFixedSectorsCountInput]) -> Vec<&String> {
+        fixed
+            .iter()
+            .flat_map(|x| x.input_parts.iter().flat_map(|(x, _)| x.iter()))
+            .collect()
+    }
+
+    fn comm_rs_flattened(fixed: &[VerifyPoStFixedSectorsCountInput]) -> Vec<&[u8; 32]> {
+        fixed.iter().flat_map(|x| x.comm_rs.iter()).collect()
+    }
+
+    fn fault_vecs(fixed: &[VerifyPoStFixedSectorsCountInput]) -> Vec<Option<Vec<u64>>> {
+        let mut out: Vec<Option<Vec<u64>>> = Default::default();
+
+        for input in fixed.iter() {
+            if input.faults.is_empty() {
+                out.push(None);
+            } else {
+                out.push(Some(input.faults.clone()));
+            }
+        }
+
+        out
+    }
+
+    #[test]
+    fn test_generate_post_dynamic_to_fixed_input() {
+        let dynamic_a = GeneratePoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            challenge_seed: [0; 32],
+            input_parts: vec![],
+        };
+
+        let dynamic_b = GeneratePoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            challenge_seed: [0; 32],
+            input_parts: vec![(Some("a".to_string()), [0; 32])],
+        };
+
+        let dynamic_c = GeneratePoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            challenge_seed: [0; 32],
+            input_parts: vec![
+                (Some("a".to_string()), [0; 32]),
+                (Some("b".to_string()), [0; 32]),
+            ],
+        };
+
+        let dynamic_d = GeneratePoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            challenge_seed: [0; 32],
+            input_parts: vec![
+                (Some("a".to_string()), [0; 32]),
+                (Some("b".to_string()), [0; 32]),
+                (Some("c".to_string()), [0; 32]),
+            ],
+        };
+
+        let fixed_a = fan_out_generate_post_input(dynamic_a);
+        let fixed_b = fan_out_generate_post_input(dynamic_b);
+        let fixed_c = fan_out_generate_post_input(dynamic_c);
+        let fixed_d = fan_out_generate_post_input(dynamic_d);
+
+        // sanity check
+        assert_eq!(POST_SECTORS_COUNT, 2);
+
+        // produces a number of fixed-count inputs equal to:
+        //
+        // CEIL(LEN(input_parts)/POST_SECTORS_COUNT)
+        //
+        assert_eq!(fixed_a.len(), 0);
+        assert_eq!(fixed_b.len(), 1);
+        assert_eq!(fixed_c.len(), 1);
+        assert_eq!(fixed_d.len(), 2);
+
+        // duplicates the final input if odd number of input_parts provided
+        assert_eq!(0, sector_access_flattened(&fixed_a).len());
+        assert_eq!(vec!["a", "a"], sector_access_flattened(&fixed_b));
+        assert_eq!(vec!["a", "b"], sector_access_flattened(&fixed_c));
+        assert_eq!(vec!["a", "b", "c", "c"], sector_access_flattened(&fixed_d));
+    }
+
+    #[test]
+    fn test_verify_post_dynamic_to_fixed_input() {
+        let proof_a = [0; 192];
+        let proof_b = [1; 192];
+
+        let comm_r_a = [0; 32];
+        let comm_r_b = [1; 32];
+        let comm_r_c = [2; 32];
+        let comm_r_d = [3; 32];
+
+        let dynamic_a = VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            comm_rs: Vec::new(),
+            challenge_seed: [0; 32],
+            proofs: Vec::new(),
+            faults: Vec::new(),
+        };
+
+        let dynamic_b = VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            comm_rs: vec![comm_r_a.clone()],
+            challenge_seed: [0; 32],
+            proofs: vec![proof_a.clone()],
+            faults: Vec::new(),
+        };
+
+        let dynamic_c = VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            comm_rs: vec![comm_r_a.clone(), comm_r_b.clone()],
+            challenge_seed: [0; 32],
+            proofs: vec![proof_a.clone()],
+            faults: Vec::new(),
+        };
+
+        let dynamic_d = VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            comm_rs: vec![comm_r_a.clone(), comm_r_b.clone(), comm_r_c.clone()],
+            challenge_seed: [0; 32],
+            proofs: vec![proof_a.clone(), proof_b.clone()],
+            faults: Vec::new(),
+        };
+
+        let fixed_a = fan_out_verify_post_input(dynamic_a).unwrap();
+        let fixed_b = fan_out_verify_post_input(dynamic_b).unwrap();
+        let fixed_c = fan_out_verify_post_input(dynamic_c).unwrap();
+        let fixed_d = fan_out_verify_post_input(dynamic_d).unwrap();
+
+        // sanity check
+        assert_eq!(POST_SECTORS_COUNT, 2);
+
+        // produces a number of fixed-count inputs equal to:
+        //
+        // CEIL(LEN(comm_rs)/POST_SECTORS_COUNT)
+        //
+        assert_eq!(fixed_a.len(), 0);
+        assert_eq!(fixed_b.len(), 1);
+        assert_eq!(fixed_c.len(), 1);
+        assert_eq!(fixed_d.len(), 2);
+
+        // duplicates the final input if odd number of comm_rs provided
+        assert_eq!(0, comm_rs_flattened(&fixed_a).len());
+        assert_eq!(vec![&comm_r_a, &comm_r_a], comm_rs_flattened(&fixed_b));
+        assert_eq!(vec![&comm_r_a, &comm_r_b], comm_rs_flattened(&fixed_c));
+        assert_eq!(
+            vec![&comm_r_a, &comm_r_b, &comm_r_c, &comm_r_c],
+            comm_rs_flattened(&fixed_d)
+        );
+
+        // LEN(proofs) must equal CEIL(LEN(comm_rs)/2))
+        assert_eq!(
+            true,
+            fan_out_verify_post_input(VerifyPoStDynamicSectorsCountInput {
+                sector_bytes: PaddedBytesAmount(1),
+                comm_rs: vec![comm_r_a.clone()],
+                challenge_seed: [0; 32],
+                proofs: vec![proof_a.clone(), proof_b.clone()],
+                faults: Vec::new()
+            })
+            .is_err()
+        );
+
+        // LEN(proofs) must equal CEIL(LEN(comm_rs)/2))
+        assert_eq!(
+            true,
+            fan_out_verify_post_input(VerifyPoStDynamicSectorsCountInput {
+                sector_bytes: PaddedBytesAmount(1),
+                comm_rs: vec![comm_r_a.clone()],
+                challenge_seed: [0; 32],
+                proofs: vec![],
+                faults: Vec::new()
+            })
+            .is_err()
+        );
+
+        // 0 <= MAX(faults) <= (LEN(comm_rs)-1)
+        assert_eq!(
+            true,
+            fan_out_verify_post_input(VerifyPoStDynamicSectorsCountInput {
+                sector_bytes: PaddedBytesAmount(1),
+                comm_rs: vec![comm_r_a.clone()],
+                challenge_seed: [0; 32],
+                proofs: vec![proof_a.clone()],
+                faults: vec![1]
+            })
+            .is_err()
+        );
+
+        // LEN(FAULTS) <= LEN(COMM_RS)
+        assert_eq!(
+            true,
+            fan_out_verify_post_input(VerifyPoStDynamicSectorsCountInput {
+                sector_bytes: PaddedBytesAmount(1),
+                comm_rs: vec![comm_r_a.clone()],
+                challenge_seed: [0; 32],
+                proofs: vec![proof_a.clone()],
+                faults: vec![0, 1]
+            })
+            .is_err()
+        );
+
+        // map dynamic sectors count indices to fixed count fault indices
+        let fixed_e = fan_out_verify_post_input(VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            comm_rs: vec![
+                comm_r_a.clone(),
+                comm_r_b.clone(),
+                comm_r_c.clone(),
+                comm_r_d.clone(),
+            ],
+            challenge_seed: [0; 32],
+            proofs: vec![proof_a.clone(), proof_b.clone()],
+            faults: vec![3],
+        })
+        .unwrap();
+
+        assert_eq!(vec![None, Some(vec![1 as u64])], fault_vecs(&fixed_e));
+
+        // ensure fault-values map to appropriate, duplicated comm_r
+        let fixed_f = fan_out_verify_post_input(VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            comm_rs: vec![comm_r_a.clone()],
+            challenge_seed: [0; 32],
+            proofs: vec![proof_a.clone()],
+            faults: vec![0],
+        })
+        .unwrap();
+
+        assert_eq!(vec![Some(vec![0 as u64, 1 as u64])], fault_vecs(&fixed_f));
+
+        // ensure fault-values map to appropriate, duplicated comm_r
+        //
+        // explanation: faults=[3] corresponds to faults=[1] in the second fixed
+        // count pair and faults=[] in the first
+        let fixed_g = fan_out_verify_post_input(VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            comm_rs: vec![
+                comm_r_a.clone(),
+                comm_r_b.clone(),
+                comm_r_c.clone(),
+                comm_r_d.clone(),
+            ],
+            challenge_seed: [0; 32],
+            proofs: vec![proof_a.clone(), proof_b.clone()],
+            faults: vec![3],
+        })
+        .unwrap();
+
+        assert_eq!(vec![None, Some(vec![1 as u64])], fault_vecs(&fixed_g));
+
+        // ensure fault-values map to appropriate, duplicated comm_r
+        //
+        // explanation: faults=[0,2] corresponds to faults[0] in the first pair
+        // and faults[0, 1] in the second (because the third commitment was
+        // duplicated
+        let fixed_h = fan_out_verify_post_input(VerifyPoStDynamicSectorsCountInput {
+            sector_bytes: PaddedBytesAmount(1),
+            comm_rs: vec![comm_r_a.clone(), comm_r_b.clone(), comm_r_c.clone()],
+            challenge_seed: [0; 32],
+            proofs: vec![proof_a.clone(), proof_b.clone()],
+            faults: vec![0, 2],
+        })
+        .unwrap();
+
+        assert_eq!(
+            vec![Some(vec![0 as u64]), Some(vec![0 as u64, 1 as u64])],
+            fault_vecs(&fixed_h)
+        );
+    }
+
+    #[test]
+    fn test_generate_post_fixed_to_dynamic_output() {
+        let fixed_a = GeneratePoStFixedSectorsCountOutput {
+            proof: [0; 192],
+            faults: vec![0, 1],
+        };
+        let fixed_b = GeneratePoStFixedSectorsCountOutput {
+            proof: [0; 192],
+            faults: vec![0, 1],
+        };
+        let fixed_c = GeneratePoStFixedSectorsCountOutput {
+            proof: [1; 192],
+            faults: vec![],
+        };
+        let fixed_d = GeneratePoStFixedSectorsCountOutput {
+            proof: [2; 192],
+            faults: vec![1],
+        };
+
+        // returns first error encountered (from head of vector)
+        let result_a = fan_in_generate_post_output(vec![
+            Ok(fixed_a),
+            Err(format_err!("alpha")),
+            Err(format_err!("beta")),
+        ]);
+        let error_a = result_a.err().unwrap();
+        assert_eq!(true, format!("{:?}", error_a).contains("alpha"));
+        assert_eq!(false, format!("{:?}", error_a).contains("beta"));
+
+        // combines proofs into single vector
+        let result_b =
+            fan_in_generate_post_output(vec![Ok(fixed_b), Ok(fixed_c), Ok(fixed_d)]).unwrap();
+        assert_eq!(0, result_b.proofs[0][0]);
+        assert_eq!(1, result_b.proofs[1][0]);
+        assert_eq!(2, result_b.proofs[2][0]);
+
+        // transforms static sectors count faults-offsets to dynamic sectors
+        // count equivalents
+        assert_eq!(vec![0, 1, 5], result_b.faults);
+    }
+
+    #[test]
+    fn test_verify_post_fixed_to_dynamic_output() {
+        let ok = |x| Ok(VerifyPoStFixedSectorsCountOutput { is_valid: x });
+
+        // returns first error encountered (from head of vector)
+        let result_a = fan_in_verify_post_output(vec![
+            ok(false),
+            Err(format_err!("alpha")),
+            Err(format_err!("beta")),
+        ]);
+
+        let error_a = result_a.err().unwrap();
+        assert_eq!(true, format!("{:?}", error_a).contains("alpha"));
+        assert_eq!(false, format!("{:?}", error_a).contains("beta"));
+
+        // verify all proofs as one (invalid)
+        let result_b = fan_in_verify_post_output(vec![ok(false), ok(true)]).unwrap();
+        assert_eq!(false, result_b.is_valid);
+
+        // verify all proofs as one (valid)
+        let result_c = fan_in_verify_post_output(vec![ok(true), ok(true)]).unwrap();
+        assert_eq!(true, result_c.is_valid);
+    }
+}

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -126,7 +126,9 @@ pub fn generate_post_collect_output(
             Ok(fixed) => {
                 dynamic.proofs.push(fixed.proof);
                 for fault in fixed.faults.iter() {
-                    dynamic.faults.push(((i as u64) * 2) + fault)
+                    dynamic
+                        .faults
+                        .push(((i as u64) * POST_SECTORS_COUNT as u64) + fault)
                 }
             }
         }

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -115,7 +115,7 @@ pub fn generate_post_collect_output(
     orig_comm_rs_len: usize,
     xs: Vec<error::Result<GeneratePoStFixedSectorsCountOutput>>,
 ) -> error::Result<GeneratePoStDynamicSectorsCountOutput> {
-    let seed = if xs.is_empty() {
+    let z = if xs.is_empty() {
         Err(format_err!("input vector must not be empty"))
     } else {
         Ok(GeneratePoStDynamicSectorsCountOutput {
@@ -126,7 +126,7 @@ pub fn generate_post_collect_output(
 
     xs.into_iter()
         .enumerate()
-        .fold(seed, |acc, (i, item)| {
+        .fold(z, |acc, (i, item)| {
             acc.and_then(|d1| {
                 item.map(|d2| GeneratePoStDynamicSectorsCountOutput {
                     proofs: [d1.proofs, vec![d2.proof]].concat(),
@@ -300,13 +300,13 @@ pub fn verify_post_spread_input(
 pub fn verify_post_collect_output(
     xs: Vec<error::Result<VerifyPoStFixedSectorsCountOutput>>,
 ) -> error::Result<VerifyPoStDynamicSectorsCountOutput> {
-    let seed = if xs.is_empty() {
+    let z = if xs.is_empty() {
         Err(format_err!("input vector must not be empty"))
     } else {
         Ok(VerifyPoStDynamicSectorsCountOutput { is_valid: true })
     };
 
-    xs.into_iter().fold(seed, |acc, item| {
+    xs.into_iter().fold(z, |acc, item| {
         acc.and_then(|d1| {
             item.map(|d2| VerifyPoStDynamicSectorsCountOutput {
                 is_valid: d1.is_valid && d2.is_valid,

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -83,6 +83,9 @@ pub fn generate_post_spread_input(
         let mut input_parts: [(Option<String>, Commitment); POST_SECTORS_COUNT] =
             Default::default();
 
+        // This commitment duplicating logic might need to be revisited. For
+        // now, we duplicate the last commitment until LEN(COMM_R) divides
+        // evenly by POST_SECTORS_COUNT.
         let iter_with_idx = remainder
             .iter()
             .cloned()

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -153,8 +153,7 @@ pub fn verify_post_spread_input(
     let faults_len = dynamic.faults.len();
     let commrs_len = dynamic.comm_rs.len();
     let proofs_len = dynamic.proofs.len();
-    let replicas_c = (commrs_len as f64 / POST_SECTORS_COUNT as f64)
-        .ceil() as usize;
+    let replicas_c = (commrs_len as f64 / POST_SECTORS_COUNT as f64).ceil() as usize;
     let faults_max = dynamic.faults.iter().max();
 
     if faults_len > commrs_len {

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -236,6 +236,22 @@ pub fn verify_post_spread_input(
     }
 
     // Map the dynamic sectors count indices to the fixed sectors count indices.
+    //
+    // For example:
+    //
+    // POST_SECTORS_COUNT = 2
+    //
+    // dynamic = {
+    //   comm_rs=[a, b, c, d, e, f, g, h]
+    //   faults=[0, 1, 5, 6]
+    // }
+    //
+    // fixed = [
+    //   {comm_rs=[a, b] faults=[0, 1]}
+    //   {comm_rs=[c, d] faults=[]}
+    //   {comm_rs=[e, f] faults=[1]}
+    //   {comm_rs=[g, h] faults=[0]}
+    // ]
     for fault in dynamic.faults {
         let i = (fault as f64 / POST_SECTORS_COUNT as f64).floor();
         fixed[i as usize]
@@ -246,6 +262,20 @@ pub fn verify_post_spread_input(
     // If we had to duplicate commitments to make LEN(COMMITMENTS) ==
     // POST_SECTORS_COUNT and the thing we duplicated was faulty, ensure that
     // the duplicates are marked as faulty, too.
+    //
+    // For example:
+    //
+    // POST_SECTORS_COUNT = 2
+    //
+    // dynamic = {
+    //   comm_rs=[a, b, c]
+    //   faults=[2]
+    // }
+    //
+    // fixed = [
+    //   {comm_rs=[a, b] faults=[]}
+    //   {comm_rs=[c, c] faults=[0, 1]}
+    // ]
     if !remainder.is_empty() {
         let fixed_len = { fixed.len() - 1 };
         let remdr_len = { remainder.len() };

--- a/filecoin-proofs/src/api/responses.rs
+++ b/filecoin-proofs/src/api/responses.rs
@@ -1,6 +1,7 @@
 use crate::api::sector_builder::errors::SectorBuilderErr;
 use crate::api::sector_builder::SectorBuilder;
-use crate::api::{API_POREP_PROOF_BYTES, API_POST_PROOF_BYTES};
+use crate::api::API_POREP_PROOF_BYTES;
+use crate::api::API_POST_PROOF_BYTES;
 use failure::Error;
 use ffi_toolkit::free_c_str;
 use libc;
@@ -67,27 +68,29 @@ pub unsafe extern "C" fn destroy_verify_seal_response(ptr: *mut VerifySealRespon
 //////////////////////
 
 #[repr(C)]
-pub struct GeneratePoSTResponse {
+pub struct GeneratePoStResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
     pub faults_len: libc::size_t,
     pub faults_ptr: *const u64,
-    pub proof: [u8; API_POST_PROOF_BYTES],
+    pub proofs_len: libc::size_t,
+    pub proofs_ptr: *const [u8; API_POST_PROOF_BYTES],
 }
 
-impl Default for GeneratePoSTResponse {
-    fn default() -> GeneratePoSTResponse {
-        GeneratePoSTResponse {
+impl Default for GeneratePoStResponse {
+    fn default() -> GeneratePoStResponse {
+        GeneratePoStResponse {
             status_code: FCPResponseStatus::FCPNoError,
             error_msg: ptr::null(),
             faults_len: 0,
             faults_ptr: ptr::null(),
-            proof: [0; API_POST_PROOF_BYTES],
+            proofs_len: 0,
+            proofs_ptr: ptr::null(),
         }
     }
 }
 
-impl Drop for GeneratePoSTResponse {
+impl Drop for GeneratePoStResponse {
     fn drop(&mut self) {
         unsafe {
             drop(Vec::from_raw_parts(
@@ -102,7 +105,7 @@ impl Drop for GeneratePoSTResponse {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn destroy_generate_post_response(ptr: *mut GeneratePoSTResponse) {
+pub unsafe extern "C" fn destroy_generate_post_response(ptr: *mut GeneratePoStResponse) {
     let _ = Box::from_raw(ptr);
 }
 

--- a/filecoin-proofs/src/api/sector_builder/mod.rs
+++ b/filecoin-proofs/src/api/sector_builder/mod.rs
@@ -1,7 +1,7 @@
 use slog::*;
 use std::sync::{mpsc, Arc, Mutex};
 
-use crate::api::internal::PoStOutput;
+use crate::api::post_adapter::*;
 use crate::api::sector_builder::errors::SectorBuilderErr;
 use crate::api::sector_builder::kv_store::fs::FileSystemKvs;
 use crate::api::sector_builder::kv_store::KeyValueStore;
@@ -154,7 +154,7 @@ impl SectorBuilder {
         &self,
         comm_rs: &[[u8; 32]],
         challenge_seed: &[u8; 32],
-    ) -> Result<PoStOutput> {
+    ) -> Result<GeneratePoStDynamicSectorsCountOutput> {
         log_unrecov(
             self.run_blocking(|tx| Request::GeneratePoSt(Vec::from(comm_rs), *challenge_seed, tx)),
         )

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -188,7 +188,7 @@ impl SectorMetadataManager {
         let mut seed = [0; 32];
         seed.copy_from_slice(challenge_seed);
 
-        let output = internal::generate_post(GeneratePoStDynamicSectorsCountInput {
+        let output = internal::fake_generate_post(GeneratePoStDynamicSectorsCountInput {
             sector_bytes: self.sector_store.inner.config().sector_bytes(),
             challenge_seed: seed,
             input_parts,

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -1,7 +1,5 @@
 use crate::api::internal;
-use crate::api::internal::PoStInput;
-use crate::api::internal::PoStInputPart;
-use crate::api::internal::PoStOutput;
+use crate::api::post_adapter::*;
 use crate::api::sector_builder::errors::err_piecenotfound;
 use crate::api::sector_builder::errors::err_unrecov;
 use crate::api::sector_builder::helpers::add_piece::add_piece;
@@ -22,6 +20,7 @@ use crate::api::sector_builder::WrappedSectorStore;
 use crate::error::ExpectWithBacktrace;
 use crate::error::Result;
 use sector_base::api::bytes_amount::UnpaddedBytesAmount;
+
 use std::collections::HashMap;
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -49,7 +48,7 @@ pub enum Request {
     GeneratePoSt(
         Vec<[u8; 32]>,
         [u8; 32],
-        mpsc::SyncSender<Result<PoStOutput>>,
+        mpsc::SyncSender<Result<GeneratePoStDynamicSectorsCountOutput>>,
     ),
     RetrievePiece(String, mpsc::SyncSender<Result<Vec<u8>>>),
     SealAllStagedSectors(mpsc::SyncSender<Result<()>>),
@@ -162,7 +161,7 @@ impl SectorMetadataManager {
         &self,
         comm_rs: &[[u8; 32]],
         challenge_seed: &[u8; 32],
-        return_channel: mpsc::SyncSender<Result<PoStOutput>>,
+        return_channel: mpsc::SyncSender<Result<GeneratePoStDynamicSectorsCountOutput>>,
     ) {
         // reduce our sealed sector state-map to a mapping of comm_r to sealed
         // sector access (AKA path to sealed sector file)
@@ -178,27 +177,22 @@ impl SectorMetadataManager {
                 acc
             });
 
-        let mut input_parts: Vec<PoStInputPart> = Default::default();
+        let mut input_parts: Vec<(Option<String>, [u8; 32])> = Default::default();
 
         // eject from this loop with an error if we've been provided a comm_r
         // which does not correspond to any sealed sector metadata
         for comm_r in comm_rs {
-            input_parts.push(PoStInputPart {
-                sealed_sector_access: comm_r_to_sector_access.get(comm_r).cloned(),
-                comm_r: *comm_r,
-            });
+            input_parts.push((comm_r_to_sector_access.get(comm_r).cloned(), *comm_r))
         }
 
         let mut seed = [0; 32];
         seed.copy_from_slice(challenge_seed);
 
-        let output = internal::fake_generate_post(
-            self.sector_store.inner.config().sector_bytes(),
-            PoStInput {
-                challenge_seed: seed,
-                input_parts,
-            },
-        );
+        let output = internal::generate_post(GeneratePoStDynamicSectorsCountInput {
+            sector_bytes: self.sector_store.inner.config().sector_bytes(),
+            challenge_seed: seed,
+            input_parts,
+        });
 
         // TODO: Where should this work be scheduled? New worker type?
         return_channel.send(output).expects(FATAL_HUNGUP);


### PR DESCRIPTION
Fixes the rust-fil-proofs side of #505. Note that the go-filecoin CGO code will need to integrate with this new API and the `submitPoSt` message will need to be modified to accommodate the variable number of SNARK proof outputs. That's next on my list of things to do.

## Why does this PR exist?

Our current VDF PoSt construction allows us to prove a fixed number of sectors (that number is 2, or `POST_SECTORS_COUNT`). API consumers don't know about this; they want to provide a variable number of replica commitments when proving and receive a proof in return.

To provide the API that our consumers want, we need to adapt PoSt generation and verification FFI function calls (which accept a variable number of replica commitments) to our internal PoSt generation and verification operations (which accept exactly 2 replica commitments).

## What's in this PR?

This changeset provides adapters to map a single PoSt generation or verification call (for a variable number of sectors) into multiple PoSt generation calls or verification calls (for a fixed number of sectors). 

This changeset also includes functions which collect the result of multiple PoSt generation and verificatoin calls (for a fixed number of sectors) into a single PoSt generation or verification call (for a variable number of sectors).

The design of the adapter layer is such that:

1) We can change `POST_SECTORS_COUNT` and everything will work normally.
2) Moving from a world in which we have a fixed sectors count to one in which it is not fixed is as simple as deleting the adapter.

## API Changes

The FFI-exposed `generate_post` call used to produce a single SNARK proof. Now it produces `CEIL(COMM_RS / POST_SECTORS_COUNT)` proofs.

## Tricky bits

We need to ensure that `LEN(COMM_RS) % POST_SECTORS_COUNT == 0` due to our VDF PoSt construction ("sectors count" is part of public parameters). To achieve this when `LEN(COMM_RS) % POST_SECTORS_COUNT != 0`, we duplicate the last COMM_R. We do this n-number of times until `LEN(COMM_RS) % POST_SECTORS_COUNT == 0`.

Mapping fault indices *from* the API to faults in the fixed sectors-count world is a little tricky due because of the way that we duplicate CommRs to ensure that `LEN(COMM_RS) % POST_SECTORS_COUNT == 0`. We also need to ensure that we don't return through the FFI fault indices for replicas which we duplicated.