### PR TITLE
Larger sectors

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -36,6 +36,7 @@ slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_tr
 serde = "1.0"
 serde_derive = "1.0"
 base64 = "0.10.0"
+blake2b_simd = "0.4.1"
 
 [dependencies.pairing]
 version = "0.14.2"

--- a/storage-proofs/src/crypto/feistel.rs
+++ b/storage-proofs/src/crypto/feistel.rs
@@ -1,19 +1,21 @@
-use blake2::{Blake2s, Digest};
+use blake2b_simd::blake2b;
+use std::mem;
 
 pub const FEISTEL_ROUNDS: usize = 3;
 // 3 rounds is an acceptable value for a pseudo-random permutation,
 // see https://github.com/filecoin-project/rust-proofs/issues/425
 // (and also https://en.wikipedia.org/wiki/Feistel_cipher#Theoretical_work).
 
-pub type FeistelPrecomputed = (u32, u32, u32);
+pub type Index = u64;
+
+pub type FeistelPrecomputed = (Index, Index, Index);
 
 // Find the minimum number of even bits to represent `num_elements`
 // within a `u32` maximum. Returns the left and right masks evenly
 // distributed that together add up to that minimum number of bits.
-pub fn precompute(num_elements: u32) -> FeistelPrecomputed {
-    let mut next_pow4 = 4;
+pub fn precompute(num_elements: Index) -> FeistelPrecomputed {
+    let mut next_pow4: Index = 4;
     let mut log4 = 1;
-
     while next_pow4 < num_elements {
         next_pow4 *= 4;
         log4 += 1;
@@ -30,11 +32,11 @@ pub fn precompute(num_elements: u32) -> FeistelPrecomputed {
 // one within the `[0, num_elements)` range using a `key` that will allow
 // the reverse operation to take place.
 pub fn permute(
-    num_elements: u32,
-    index: u32,
-    keys: &[u32],
+    num_elements: Index,
+    index: Index,
+    keys: &[Index],
     precomputed: FeistelPrecomputed,
-) -> u32 {
+) -> Index {
     let mut u = encode(index, keys, precomputed);
 
     while u >= num_elements {
@@ -49,11 +51,11 @@ pub fn permute(
 
 // Inverts the `permute` result to its starting value for the same `key`.
 pub fn invert_permute(
-    num_elements: u32,
-    index: u32,
-    keys: &[u32],
+    num_elements: Index,
+    index: Index,
+    keys: &[Index],
     precomputed: FeistelPrecomputed,
-) -> u32 {
+) -> Index {
     let mut u = decode(index, keys, precomputed);
 
     while u >= num_elements {
@@ -66,7 +68,7 @@ pub fn invert_permute(
 /// Decompress the `precomputed` part of the algorithm into the initial `left` and
 /// `right` pieces `(L_0, R_0)` with the `right_mask` and `half_bits` to manipulate
 /// them.
-fn common_setup(index: u32, precomputed: FeistelPrecomputed) -> (u32, u32, u32, u32) {
+fn common_setup(index: Index, precomputed: FeistelPrecomputed) -> (Index, Index, Index, Index) {
     let (left_mask, right_mask, half_bits) = precomputed;
 
     let left = (index & left_mask) >> half_bits;
@@ -75,7 +77,7 @@ fn common_setup(index: u32, precomputed: FeistelPrecomputed) -> (u32, u32, u32, 
     (left, right, right_mask, half_bits)
 }
 
-fn encode(index: u32, keys: &[u32], precomputed: FeistelPrecomputed) -> u32 {
+fn encode(index: Index, keys: &[Index], precomputed: FeistelPrecomputed) -> Index {
     let (mut left, mut right, right_mask, half_bits) = common_setup(index, precomputed);
 
     for key in keys.iter().take(FEISTEL_ROUNDS) {
@@ -87,7 +89,7 @@ fn encode(index: u32, keys: &[u32], precomputed: FeistelPrecomputed) -> u32 {
     (left << half_bits) | right
 }
 
-fn decode(index: u32, keys: &[u32], precomputed: FeistelPrecomputed) -> u32 {
+fn decode(index: Index, keys: &[Index], precomputed: FeistelPrecomputed) -> Index {
     let (mut left, mut right, right_mask, half_bits) = common_setup(index, precomputed);
 
     for i in (0..FEISTEL_ROUNDS).rev() {
@@ -99,27 +101,65 @@ fn decode(index: u32, keys: &[u32], precomputed: FeistelPrecomputed) -> u32 {
     (left << half_bits) | right
 }
 
+const HALF_FEISTEL_BYTES: usize = mem::size_of::<Index>();
+const FEISTEL_BYTES: usize = 2 * HALF_FEISTEL_BYTES;
+
 // Round function of the Feistel network: `F(Ri, Ki)`. Joins the `right`
 // piece and the `key`, hashes it and returns the lower `u32` part of
 // the hash filtered trough the `right_mask`.
-fn feistel(right: u32, key: u32, right_mask: u32) -> u32 {
-    let mut data: [u8; 8] = [0; 8];
-    data[0] = (right >> 24) as u8;
-    data[1] = (right >> 16) as u8;
-    data[2] = (right >> 8) as u8;
-    data[3] = right as u8;
+fn feistel(right: Index, key: Index, right_mask: Index) -> Index {
+    let mut data: [u8; FEISTEL_BYTES] = [0; FEISTEL_BYTES];
 
-    data[4] = (key >> 24) as u8;
-    data[5] = (key >> 16) as u8;
-    data[6] = (key >> 8) as u8;
-    data[7] = key as u8;
+    // So ugly, but the price of (relative) speed.
+    let r = if FEISTEL_BYTES <= 8 {
+        data[0] = (right >> 24) as u8;
+        data[1] = (right >> 16) as u8;
+        data[2] = (right >> 8) as u8;
+        data[3] = right as u8;
 
-    let hash = Blake2s::digest(&data);
+        data[4] = (key >> 24) as u8;
+        data[5] = (key >> 16) as u8;
+        data[6] = (key >> 8) as u8;
+        data[7] = key as u8;
 
-    let r = u32::from(hash[0]) << 24
-        | u32::from(hash[1]) << 16
-        | u32::from(hash[2]) << 8
-        | u32::from(hash[3]);
+        let raw = blake2b(&data);
+        let hash = raw.as_bytes();
+
+        Index::from(hash[0]) << 24
+            | Index::from(hash[1]) << 16
+            | Index::from(hash[2]) << 8
+            | Index::from(hash[3])
+    } else {
+        data[0] = (right >> 56) as u8;
+        data[1] = (right >> 48) as u8;
+        data[2] = (right >> 40) as u8;
+        data[3] = (right >> 32) as u8;
+        data[4] = (right >> 24) as u8;
+        data[5] = (right >> 16) as u8;
+        data[6] = (right >> 8) as u8;
+        data[7] = right as u8;
+
+        data[0] = (key >> 56) as u8;
+        data[1] = (key >> 48) as u8;
+        data[2] = (key >> 40) as u8;
+        data[3] = (key >> 32) as u8;
+        data[4] = (key >> 24) as u8;
+        data[5] = (key >> 16) as u8;
+        data[6] = (key >> 8) as u8;
+        data[7] = key as u8;
+
+        let raw = blake2b(&data);
+        let hash = raw.as_bytes();
+
+        Index::from(hash[0]) << 56
+            | Index::from(hash[1]) << 48
+            | Index::from(hash[2]) << 40
+            | Index::from(hash[3]) << 32
+            | Index::from(hash[4]) << 24
+            | Index::from(hash[5]) << 16
+            | Index::from(hash[6]) << 8
+            | Index::from(hash[7])
+    };
 
     r & right_mask
 }
@@ -130,9 +170,9 @@ mod tests {
 
     // Some sample n-values which are not powers of four and also don't coincidentally happen to
     // encode/decode correctly.
-    const BAD_NS: &[u32] = &[5, 6, 8, 12, 17];
-
-    fn encode_decode(n: u32, expect_success: bool) {
+    const BAD_NS: &[Index] = &[5, 6, 8, 12, 17]; //
+                                                 //
+    fn encode_decode(n: Index, expect_success: bool) {
         let mut failed = false;
         let precomputed = precompute(n);
         for i in 0..n {
@@ -176,7 +216,7 @@ mod tests {
     #[test]
     fn test_feistel_on_arbitrary_set() {
         for n in BAD_NS.iter() {
-            let precomputed = precompute(*n as u32);
+            let precomputed = precompute(*n as Index);
             for i in 0..*n {
                 let p = permute(*n, i, &[1, 2, 3, 4], precomputed);
                 let v = invert_permute(*n, p, &[1, 2, 3, 4], precomputed);

--- a/storage-proofs/src/hasher/blake2b.rs
+++ b/storage-proofs/src/hasher/blake2b.rs
@@ -1,0 +1,7 @@
+use blake2::Blake2b;
+
+use super::{DigestHasher, Digester};
+
+impl Digester for Blake2b {}
+
+pub type Blake2bHasher = DigestHasher<Blake2b>;

--- a/storage-proofs/src/zigzag_drgporep.rs
+++ b/storage-proofs/src/zigzag_drgporep.rs
@@ -227,4 +227,31 @@ mod tests {
             prove_verify_tapered_32_5_3(5, 3);
         }
     }
+
+    #[test]
+    // We are seeing a bug, in which setup never terminates for some sector sizes.
+    // This test is to debug that and should remain as a regression teset.
+    fn setup_terminates() {
+        let degree = 5;
+        let expansion_degree = 8;
+        let nodes = 1024 * 1024 * 32 * 8; // This corresponds to 8GiB sectors (32-byte nodes)
+        let sloth_iter = 0;
+        let layer_challenges = LayerChallenges::new_tapered(10, 333, 7, 0.3);
+        let sp = SetupParams {
+            drg_porep_setup_params: drgporep::SetupParams {
+                drg: drgporep::DrgParams {
+                    nodes,
+                    degree,
+                    expansion_degree,
+                    seed: new_seed(),
+                },
+                sloth_iter,
+            },
+            layer_challenges: layer_challenges.clone(),
+        };
+
+        // When this fails, the call to setup should panic, but seems to actually hang (i.e. neither return nor panic) for some reason.
+        // When working as designed, the call to setup returns without error.
+        let _pp = ZigZagDrgPoRep::<PedersenHasher>::setup(&sp).unwrap();
+    }
 }

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -49,7 +49,7 @@ where
             },
             expansion_degree,
             reversed: false,
-            feistel_precomputed: feistel::precompute((expansion_degree * nodes) as u32),
+            feistel_precomputed: feistel::precompute((expansion_degree * nodes) as feistel::Index),
             _h: PhantomData,
         }
     }
@@ -193,19 +193,19 @@ where
     // to the index `4` that generated it earlier, corresponding to the node 2, inverting
     // in fact the child-parent relationship.
     fn correspondent(&self, node: usize, i: usize) -> usize {
-        let a = (node * self.expansion_degree) as u32 + i as u32;
+        let a = (node * self.expansion_degree) as feistel::Index + i as feistel::Index;
         let feistel_keys = &[1, 2, 3, 4];
 
         let transformed = if self.reversed {
             feistel::invert_permute(
-                self.size() as u32 * self.expansion_degree as u32,
+                self.size() as feistel::Index * self.expansion_degree as feistel::Index,
                 a,
                 feistel_keys,
                 self.feistel_precomputed,
             )
         } else {
             feistel::permute(
-                self.size() as u32 * self.expansion_degree as u32,
+                self.size() as feistel::Index * self.expansion_degree as feistel::Index,
                 a,
                 feistel_keys,
                 self.feistel_precomputed,
@@ -242,7 +242,9 @@ where
             base_graph: self.base_graph.clone(),
             expansion_degree: self.expansion_degree,
             reversed: !self.reversed,
-            feistel_precomputed: feistel::precompute((self.expansion_degree * self.size()) as u32),
+            feistel_precomputed: feistel::precompute(
+                (self.expansion_degree * self.size()) as feistel::Index,
+            ),
             _h: PhantomData,
         }
     }


### PR DESCRIPTION
### Problem

While trying to benchmark large(r) sectors, I (eventually) discovered that `setup` was hanging. The root cause turns out to be the known issue that our Feistel implementation permutes elements of type `u32`. Since we need `expansion_degree` (currently 8) elements per node, that means we can handle only up to 2^27 nodes. This corresponds to sectors of size 2^32 (2^27 * 32), which is 4GiB .

### Solution
The simple solution is to extend to use `u64`. In a perfect world, we might be able to select alternate generic implementations for `u32` or `u64` depending on the actual sector size, but that will/would be somewhat tricky and may not be worth it. Hopefully any benefits of smaller cache keys can be implemented just at the level of the cache while leaving the Feistel implementation to use `u64`. For now, if we must accept one or the other, the priority must be on supporting larger sectors. The current work at least moves the concrete type to a constant, and handles size-related logic with `size_of`. In order to support larger elements, I swapped `blake2s` (32-byte hashes) for `blake2b` (64-byte hashes).

### Breakdown
  - add regression test for non-terminating `setup()`.
  - add support for variable-sized feistel index.
  - set default `feistel::Index` to `u64`.
  - swap in `blake2b` for `blake2s` in support of `u64` indexes.

### NOTE
 - This does change the replication algorithm, so — for example — users of this code may become out of sync with the replication game server.
 - This also, unfortunately, seems to slow replication down a small amount (x 1.08). However, with caching (#455) that speed should be recovered. Being able to replicate large sectors at all is most important.

### Status

A replication test of 8 GiB is underway and proceeding as expected. Will update on completion or otherwise, but even if we hit another roadblock, the current work seems to have patched the first.