### PR TITLE
More zigzag example tweaks

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -15,6 +15,7 @@ storage-proofs = { path = "../storage-proofs" }
 ffi-toolkit = { path = "../ffi-toolkit" }
 logging-toolkit = { path = "../logging-toolkit" }
 bitvec = "0.5"
+chrono = "0.4"
 phase2 = "0.2.2"
 sapling-crypto = { git = "https://github.com/zcash-hackworks/sapling-crypto", branch = "master" }
 rand = "0.4"

--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -151,7 +151,7 @@ fn dump_proof_bytes<H: Hasher>(all_partition_proofs: &[layered_drgporep::Proof<H
     );
 
     if let Err(e) = serde_json::to_writer(file, all_partition_proofs) {
-        info!(
+        warn!(
             FCP_LOG,
             "Encountered error while writing serialized proofs: {}", e
         );

--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -149,7 +149,12 @@ fn dump_proof_bytes(serialized_proofs: &[u8]) {
         "dumping proofs ({} bytes)",
         serialized_proofs.len(); "target" => "status"
     );
-    let _ = file.write_all(serialized_proofs);
+    if let Err(e) = file.write_all(serialized_proofs) {
+        info!(
+            FCP_LOG,
+            "Encountered error while writing serialized proofs: {}", e
+        );
+    }
 }
 
 fn do_the_work<H: 'static>(


### PR DESCRIPTION
This PR contains small changes I needed while benchmarking replication and proving on a high-memory machine.

Specifically:
  - Optionally allow suppression of temp file, giving more control (should be more configurable later) over where the data resides.
 - Dump vanilla proofs so they can be reused for groth proving without replicating again (expensive!). We can't yet use these dumped proofs, but if I make it through a very long replication I don't want to lose the resulting artifact. Ability to restart groth proving without replication can be added when needed.
  - Don't generate random data, just zero the mmapped data by extending the file. This will save a lot of time on expensive machines.
