### PR TITLE
perf(feistel): use blake2b_simd

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -36,6 +36,7 @@ slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_tr
 serde = "1.0"
 serde_derive = "1.0"
 base64 = "0.10.0"
+blake2b_simd = "0.4.1"
 
 [dependencies.pairing]
 version = "0.14.2"

--- a/storage-proofs/src/crypto/feistel.rs
+++ b/storage-proofs/src/crypto/feistel.rs
@@ -1,4 +1,5 @@
-use blake2::{Blake2b, Digest};
+// use blake2::{Blake2b, Digest};
+use blake2b_simd::blake2b;
 use std::mem;
 
 pub const FEISTEL_ROUNDS: usize = 3;
@@ -7,7 +8,7 @@ pub const FEISTEL_ROUNDS: usize = 3;
 // (and also https://en.wikipedia.org/wiki/Feistel_cipher#Theoretical_work).
 
 pub type Index = u64;
-pub type FeistelHash = Blake2b;
+// pub type FeistelHash = Blake2b;
 
 pub type FeistelPrecomputed = (Index, Index, Index);
 
@@ -133,12 +134,12 @@ fn feistel(right: Index, key: Index, right_mask: Index) -> Index {
         }
     }
 
-    let hash = FeistelHash::digest(&data);
+    let hash = blake2b(&data);
 
     {
         let mut r = 0;
         let mut shift = HALF_FEISTEL_BYTES * 8;
-        for item in hash.iter().take(HALF_FEISTEL_BYTES) {
+        for item in hash.as_ref().iter().take(HALF_FEISTEL_BYTES) {
             shift -= 8;
             r |= Index::from(*item) << shift;
         }


### PR DESCRIPTION
before

```
replication_time: 4.609915269s, target: stats, place: filecoin-proofs/examples/zigzag.rs:193 zigzag, root: filecoin-proofs
replication_time/byte: 4.395µs, target: stats, place: filecoin-proofs/examples/zigzag.rs:194 zigzag, root: filecoin-proofs
```

after
```
replication_time: 3.887283333s, target: stats, place: filecoin-proofs/examples/zigzag.rs:193 zigzag, root: filecoin-proofs
replication_time/byte: 3.707µs, target: stats, place: filecoin-proofs/examples/zigzag.rs:194 zigzag, root: filecoin-proofs
```