### PR TITLE
[WIP] deps: update `merkle_light::merkle` API

### DIFF
--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -27,7 +27,7 @@ use storage_proofs::fr32::{bytes_into_fr, fr_into_bytes, Fr32Ary};
 use storage_proofs::hasher::pedersen::{PedersenDomain, PedersenHasher};
 use storage_proofs::hasher::{Domain, Hasher};
 use storage_proofs::layered_drgporep::{self, LayerChallenges};
-use storage_proofs::merkle::MerkleTree;
+use storage_proofs::merkle::{MerkleTree, VecStore};
 use storage_proofs::porep::{replica_id, PoRep, Tau};
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::vdf_post::{self, VDFPoSt};
@@ -419,7 +419,8 @@ fn verify_post_fixed_sectors_count(
     Ok(VerifyPoStFixedSectorsCountOutput { is_valid: true })
 }
 
-type Tree = MerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function>;
+type Tree =
+    MerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function, VecStore<PedersenDomain>>;
 fn make_merkle_tree<T: Into<PathBuf> + AsRef<Path>>(
     sealed_path: T,
     bytes: PaddedBytesAmount,

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -12,7 +12,7 @@ bitvec = "0.5"
 sapling-crypto = { git = "https://github.com/zcash-hackworks/sapling-crypto", branch = "master" }
 rand = "0.4"
 libc = "0.2"
-merkle_light = { git = "https://github.com/filecoin-project/merkle_light", branch = "master" }
+merkle_light = { git = "https://github.com/filecoin-project/merkle_light", branch = "mmap-experiments" }
 failure = "0.1"
 bellman = "0.1"
 byteorder = "1"

--- a/storage-proofs/src/batchpost.rs
+++ b/storage-proofs/src/batchpost.rs
@@ -9,7 +9,7 @@ use serde::ser::Serialize;
 use crate::crypto::blake2s::blake2s;
 use crate::error::Result;
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::MerkleTree;
+use crate::merkle::{MerkleTree, VecStore};
 use crate::merklepor;
 use crate::proof::ProofScheme;
 use crate::util::data_at_node;
@@ -51,11 +51,14 @@ pub struct PrivateInputs<'a, H: 'a + Hasher> {
     /// The underlying data.
     pub data: &'a [u8],
     /// The underlying merkle tree.
-    pub tree: &'a MerkleTree<H::Domain, H::Function>,
+    pub tree: &'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
 }
 
 impl<'a, H: Hasher> PrivateInputs<'a, H> {
-    pub fn new(data: &'a [u8], tree: &'a MerkleTree<H::Domain, H::Function>) -> Self {
+    pub fn new(
+        data: &'a [u8],
+        tree: &'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
+    ) -> Self {
         PrivateInputs { data, tree }
     }
 }

--- a/storage-proofs/src/beacon_post.rs
+++ b/storage-proofs/src/beacon_post.rs
@@ -7,7 +7,7 @@ use serde::ser::Serialize;
 
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::MerkleTree;
+use crate::merkle::{MerkleTree, VecStore};
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::proof::ProofScheme;
 use crate::vdf::Vdf;
@@ -44,14 +44,14 @@ pub struct PublicInputs<T: Domain> {
 #[derive(Clone, Debug)]
 pub struct PrivateInputs<'a, H: 'a + Hasher> {
     pub replicas: &'a [&'a [u8]],
-    pub trees: &'a [&'a MerkleTree<H::Domain, H::Function>],
+    pub trees: &'a [&'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>],
     _h: PhantomData<H>,
 }
 
 impl<'a, H: 'a + Hasher> PrivateInputs<'a, H> {
     pub fn new(
         replicas: &'a [&'a [u8]],
-        trees: &'a [&'a MerkleTree<H::Domain, H::Function>],
+        trees: &'a [&'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>],
     ) -> Self {
         PrivateInputs {
             replicas,

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -7,7 +7,7 @@ use serde::ser::Serialize;
 use crate::drgraph::Graph;
 use crate::error::Result;
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::{MerkleProof, MerkleTree};
+use crate::merkle::{MerkleProof, MerkleTree, VecStore};
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::porep::{self, PoRep};
 use crate::proof::ProofScheme;
@@ -422,7 +422,7 @@ where
         pp: &Self::PublicParams,
         replica_id: &H::Domain,
         data: &mut [u8],
-        data_tree: Option<MerkleTree<H::Domain, H::Function>>,
+        data_tree: Option<MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>>,
     ) -> Result<(porep::Tau<H::Domain>, porep::ProverAux<H>)> {
         let tree_d = match data_tree {
             Some(tree) => tree,

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 use crate::error::*;
 use crate::hasher::pedersen::PedersenHasher;
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::MerkleTree;
+use crate::merkle::{MerkleTree, VecStore};
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::util::data_at_node;
 /// The default hasher currently in use.
@@ -23,7 +23,10 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
     }
 
     /// Builds a merkle tree based on the given data.
-    fn merkle_tree<'a>(&self, data: &'a [u8]) -> Result<MerkleTree<H::Domain, H::Function>> {
+    fn merkle_tree<'a>(
+        &self,
+        data: &'a [u8],
+    ) -> Result<MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>> {
         self.merkle_tree_aux(data, 32, PARALLEL_MERKLE)
     }
 
@@ -33,7 +36,7 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
         data: &'a [u8],
         node_size: usize,
         parallel: bool,
-    ) -> Result<MerkleTree<H::Domain, H::Function>> {
+    ) -> Result<MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>> {
         if data.len() != (node_size * self.size()) as usize {
             return Err(Error::InvalidMerkleTreeArgs(
                 data.len(),

--- a/storage-proofs/src/hasher/digest.rs
+++ b/storage-proofs/src/hasher/digest.rs
@@ -3,6 +3,7 @@ use std::hash::Hasher as StdHasher;
 use std::marker::PhantomData;
 
 use merkle_light::hash::{Algorithm, Hashable};
+use merkle_light::merkle::Element;
 use pairing::bls12_381::{Bls12, Fr, FrRepr};
 use pairing::{PrimeField, PrimeFieldRepr};
 use rand::{Rand, Rng};
@@ -143,20 +144,33 @@ impl Domain for DigestDomain {
     }
 
     fn try_from_bytes(raw: &[u8]) -> Result<Self> {
-        if raw.len() != 32 {
+        if raw.len() != DigestDomain::byte_len() {
             return Err(Error::InvalidInputSize);
         }
         let mut res = DigestDomain::default();
-        res.0.copy_from_slice(&raw[0..32]);
+        res.0.copy_from_slice(&raw[0..DigestDomain::byte_len()]);
         Ok(res)
     }
 
     fn write_bytes(&self, dest: &mut [u8]) -> Result<()> {
-        if dest.len() < 32 {
+        if dest.len() < DigestDomain::byte_len() {
             return Err(Error::InvalidInputSize);
         }
-        dest[0..32].copy_from_slice(&self.0[..]);
+        dest[0..DigestDomain::byte_len()].copy_from_slice(&self.0[..]);
         Ok(())
+    }
+}
+
+impl Element for DigestDomain {
+    fn byte_len() -> usize {
+        32
+    }
+
+    fn from_slice(bytes: &[u8]) -> Self {
+        match DigestDomain::try_from_bytes(bytes) {
+            Ok(res) => res,
+            Err(err) => panic!(err),
+        }
     }
 }
 

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -13,8 +13,8 @@ mod tests {
     use std::fmt;
     use std::iter::FromIterator;
 
+    use crate::merkle::{MerkleTree, VecStore};
     use merkle_light::hash::{Algorithm, Hashable};
-    use merkle_light::merkle::MerkleTree;
 
     use super::super::{DigestDomain, Hasher};
 
@@ -105,8 +105,16 @@ mod tests {
 
         let v: Vec<DigestDomain> = vec![h1.into(), h2.into(), h3.into()];
         let v2: Vec<DigestDomain> = vec![h1.into(), h2.into()];
-        let t = MerkleTree::<<Sha256Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Function>::from_iter(v);
-        let t2 = MerkleTree::<<Sha256Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Function>::from_iter(v2);
+        let t = MerkleTree::<
+            <Sha256Hasher as Hasher>::Domain,
+            <Sha256Hasher as Hasher>::Function,
+            VecStore<_>,
+        >::from_iter(v);
+        let t2 = MerkleTree::<
+            <Sha256Hasher as Hasher>::Domain,
+            <Sha256Hasher as Hasher>::Function,
+            VecStore<_>,
+        >::from_iter(v2);
 
         assert_eq!(t2.as_slice()[0].as_ref(), l1.as_ref());
         assert_eq!(t2.as_slice()[1].as_ref(), l2.as_ref());

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use merkle_light::hash::{Algorithm as LightAlgorithm, Hashable as LightHashable};
+use merkle_light::merkle::Element;
 use pairing::bls12_381::Fr;
 use rand::Rand;
 use serde::de::DeserializeOwned;
@@ -20,6 +21,7 @@ pub trait Domain:
     + Rand
     + Serialize
     + DeserializeOwned
+    + Element
 {
     fn serialize(&self) -> Vec<u8>;
     fn into_bytes(&self) -> Vec<u8>;

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -12,14 +12,15 @@ use crate::drgporep::{self, DrgPoRep};
 use crate::drgraph::Graph;
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, HashFunction, Hasher};
-use crate::merkle::MerkleTree;
+use crate::merkle::{MerkleTree, VecStore};
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::porep::{self, PoRep};
 use crate::proof::ProofScheme;
 use crate::vde;
 use crate::SP_LOG;
 
-type Tree<H> = MerkleTree<<H as Hasher>::Domain, <H as Hasher>::Function>;
+type Tree<H> =
+    MerkleTree<<H as Hasher>::Domain, <H as Hasher>::Function, VecStore<<H as Hasher>::Domain>>;
 
 #[derive(Debug, Clone)]
 pub enum LayerChallenges {
@@ -429,7 +430,7 @@ pub trait Layers {
 
             sorted_trees.iter().fold(
                 None,
-                |previous_tree: Option<&MerkleTree<_, _>>, (i, replica_tree)| {
+                |previous_tree: Option<&MerkleTree<_, _, _>>, (i, replica_tree)| {
                     // Each iteration's replica_tree becomes the next iteration's previous_tree (data_tree).
                     // The first iteration has no previous_tree.
                     if let Some(data_tree) = previous_tree {

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -5,6 +5,7 @@ use std::marker::PhantomData;
 // Reexport here, so we don't depend on merkle_light directly in other places.
 use merkle_light::hash::Algorithm;
 pub use merkle_light::merkle::MerkleTree;
+pub use merkle_light::merkle::VecStore;
 use merkle_light::proof;
 use pairing::bls12_381::Fr;
 

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -4,7 +4,7 @@ use crate::drgporep::DataProof;
 use crate::drgraph::graph_height;
 use crate::error::*;
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::{MerkleProof, MerkleTree};
+use crate::merkle::{MerkleProof, MerkleTree, VecStore};
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::proof::ProofScheme;
 
@@ -40,12 +40,15 @@ pub struct PrivateInputs<'a, H: 'a + Hasher> {
     /// The data of the leaf.
     pub leaf: H::Domain,
     /// The underlying merkle tree.
-    pub tree: &'a MerkleTree<H::Domain, H::Function>,
+    pub tree: &'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
     _h: PhantomData<H>,
 }
 
 impl<'a, H: Hasher> PrivateInputs<'a, H> {
-    pub fn new(leaf: H::Domain, tree: &'a MerkleTree<H::Domain, H::Function>) -> Self {
+    pub fn new(
+        leaf: H::Domain,
+        tree: &'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
+    ) -> Self {
         PrivateInputs {
             leaf,
             tree,

--- a/storage-proofs/src/piece_inclusion_proof.rs
+++ b/storage-proofs/src/piece_inclusion_proof.rs
@@ -5,8 +5,7 @@ use merkle_light::proof::Proof;
 
 use crate::error::*;
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::MerkleTree;
-
+use crate::merkle::{MerkleTree, VecStore};
 type InclusionProof<T> = Proof<T>;
 
 /// A FileInclusionProof contains a merkle inclusion proof for the first and last node
@@ -28,7 +27,7 @@ pub struct PieceInclusionProof<H: Hasher> {
 /// For this method to work, the piece data used to validate pieces will need to be padded as necessary,
 /// and pieces will need to be aligned (to 128-byte chunks for Fr32 bit-padding) when written.
 pub fn file_inclusion_proofs<H: Hasher>(
-    tree: &MerkleTree<H::Domain, H::Function>,
+    tree: &MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
     piece_lengths: &[usize],
 ) -> Vec<PieceInclusionProof<H>> {
     bounds(piece_lengths)
@@ -53,7 +52,7 @@ fn bounds(lengths: &[usize]) -> Vec<(usize, usize)> {
 /// of the piece whose inclusion should be proved. It returns a corresponding file_inclusion_proof.
 /// For the resulting proof to be valid, first_node must be <= last_node.
 pub fn file_inclusion_proof<H: Hasher>(
-    tree: &MerkleTree<H::Domain, H::Function>,
+    tree: &MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
     first_node: usize,
     last_node: usize,
 ) -> PieceInclusionProof<H> {

--- a/storage-proofs/src/porc.rs
+++ b/storage-proofs/src/porc.rs
@@ -8,7 +8,7 @@ use serde::ser::Serialize;
 use crate::drgraph::graph_height;
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::{MerkleProof, MerkleTree};
+use crate::merkle::{MerkleProof, MerkleTree, VecStore};
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::proof::ProofScheme;
 
@@ -49,7 +49,7 @@ pub struct PublicInputs<'a, T: 'a + Domain> {
 
 #[derive(Debug, Clone)]
 pub struct PrivateInputs<'a, H: 'a + Hasher> {
-    pub trees: &'a [&'a MerkleTree<H::Domain, H::Function>],
+    pub trees: &'a [&'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>],
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/storage-proofs/src/porep.rs
+++ b/storage-proofs/src/porep.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::hasher::{Domain, HashFunction, Hasher};
-use crate::merkle::MerkleTree;
+use crate::merkle::{MerkleTree, VecStore};
 use crate::proof::ProofScheme;
 
 #[derive(Debug)]
@@ -34,14 +34,14 @@ pub struct PrivateInputs<'a> {
 
 #[derive(Debug, Clone)]
 pub struct ProverAux<H: Hasher> {
-    pub tree_d: MerkleTree<H::Domain, H::Function>,
-    pub tree_r: MerkleTree<H::Domain, H::Function>,
+    pub tree_d: MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
+    pub tree_r: MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
 }
 
 impl<H: Hasher> ProverAux<H> {
     pub fn new(
-        tree_d: MerkleTree<H::Domain, H::Function>,
-        tree_r: MerkleTree<H::Domain, H::Function>,
+        tree_d: MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
+        tree_r: MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>,
     ) -> Self {
         ProverAux { tree_d, tree_r }
     }
@@ -55,7 +55,7 @@ pub trait PoRep<'a, H: Hasher>: ProofScheme<'a> {
         pub_params: &'a Self::PublicParams,
         replica_id: &H::Domain,
         data: &mut [u8],
-        data_tree: Option<MerkleTree<H::Domain, H::Function>>,
+        data_tree: Option<MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>>,
     ) -> Result<(Self::Tau, Self::ProverAux)>;
 
     fn extract_all(

--- a/storage-proofs/src/test_helper.rs
+++ b/storage-proofs/src/test_helper.rs
@@ -8,8 +8,7 @@ use crate::crypto;
 use crate::error;
 use crate::fr32::{bytes_into_fr, fr_into_bytes};
 use crate::hasher::pedersen::{PedersenDomain, PedersenFunction, PedersenHasher};
-use crate::merkle::{MerkleProof, MerkleTree};
-
+use crate::merkle::{MerkleProof, MerkleTree, VecStore};
 #[macro_export]
 macro_rules! table_tests {
     ($property_test_func:ident {
@@ -83,7 +82,7 @@ pub fn fake_drgpoprep_proof<R: Rng>(
     }
 
     // get commR
-    let subtree = MerkleTree::<PedersenDomain, PedersenFunction>::from_data(leaves);
+    let subtree = MerkleTree::<PedersenDomain, PedersenFunction, VecStore<_>>::from_data(leaves);
     let subtree_root: Fr = subtree.root().into();
     let subtree_depth = subtree.height() - 1; // .height() inludes the leaf
     let remaining_depth = tree_depth - subtree_depth;

--- a/storage-proofs/src/vdf_post.rs
+++ b/storage-proofs/src/vdf_post.rs
@@ -12,7 +12,7 @@ use serde::ser::Serialize;
 use crate::error::{Error, Result};
 use crate::fr32::fr_into_bytes;
 use crate::hasher::{Domain, HashFunction, Hasher};
-use crate::merkle::MerkleTree;
+use crate::merkle::{MerkleTree, VecStore};
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::porc::{self, PoRC};
 use crate::proof::ProofScheme;
@@ -71,12 +71,12 @@ pub struct PublicInputs<T: Domain> {
 
 #[derive(Clone, Debug)]
 pub struct PrivateInputs<'a, H: 'a + Hasher> {
-    pub trees: &'a [&'a MerkleTree<H::Domain, H::Function>],
+    pub trees: &'a [&'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>],
     _h: PhantomData<H>,
 }
 
 impl<'a, H: 'a + Hasher> PrivateInputs<'a, H> {
-    pub fn new(trees: &'a [&'a MerkleTree<H::Domain, H::Function>]) -> Self {
+    pub fn new(trees: &'a [&'a MerkleTree<H::Domain, H::Function, VecStore<H::Domain>>]) -> Self {
         PrivateInputs {
             trees,
             _h: PhantomData,


### PR DESCRIPTION
```
Update use of `MerkleTree` with new `Store` trait. Set for now all `Store`s to
`VecStore`s which was the implicit `Store` when the trait didn't exist to
preserve the current memory behavior.
```


---------------------------------------------


The PR itself is done, the WIP part is waiting for https://github.com/filecoin-project/merkle_light/pull/13 to get merged and return the `merkle_light` dependency `branch` to `master` (from the contingent `mmap-experiments`).

-----------------------------------------------

Local memory profiling reports same memory consumption compared to master:

```
Total: 309.4 MB
   309.0  99.9%  99.9%    309.0  99.9% ::allocate_in (inline) /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/liballoc/raw_vec.rs:109
     0.3   0.1% 100.0%      0.3   0.1% ::reserve_internal (inline) /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/liballoc/raw_vec.rs:683
     0.1   0.0% 100.0%      0.1   0.0% sapling_crypto::jubjub::JubjubBls12::new (inline) ??:0
     0.0   0.0% 100.0%      0.0   0.0% core::ptr::::is_null (inline) /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/libcore/ptr.rs:1602
     0.0   0.0% 100.0%      0.0   0.0% _dl_mcount ??:0
     0.0   0.0% 100.0%      0.0   0.0% __cxa_thread_atexit_impl ??:0
     0.0   0.0% 100.0%      0.0   0.0% ::allocate_in (inline) /rustc/14997d56a550f4aa99fe737593cd2758227afc56//src/liballoc/raw_vec.rs:109
     0.0   0.0% 100.0%      0.0   0.0% ::build /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/slog-async-2.3.0/lib.rs:592
     0.0   0.0% 100.0%      5.4   1.7% ::build::{{closure}} (inline) /usr/local/cargo/git/checkouts/merkle_light-16b81cab1b05c5b8/ff18b53/merkle/src/merkle.rs:278
```
(both runs show the same, compare with https://github.com/filecoin-project/rust-fil-proofs/pull/518).