### PR TITLE
use `MmapStore` for `MerkleTree` generation

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -12,7 +12,7 @@ bitvec = "0.5"
 sapling-crypto = { git = "https://github.com/zcash-hackworks/sapling-crypto", branch = "master" }
 rand = "0.4"
 libc = "0.2"
-merkle_light = { git = "https://github.com/filecoin-project/merkle_light", rev = "63a609decf3cc552b0aa79477b828f4a493f725d" }
+merkle_light = { git = "https://github.com/filecoin-project/merkle_light", branch = "master" }
 failure = "0.1"
 bellman = "0.1"
 byteorder = "1"

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -288,9 +288,8 @@ where
 
             let tree_d = &priv_inputs.tree_d;
             let tree_r = &priv_inputs.tree_r;
-            let domain_replica = tree_r.as_slice();
 
-            let data = domain_replica[challenge];
+            let data = tree_r.read_at(challenge);
 
             replica_nodes.push(DataProof {
                 proof: MerkleProof::new_from_proof(&tree_r.gen_proof(challenge)),
@@ -305,7 +304,7 @@ where
                     let proof = tree_r.gen_proof(*p);
                     DataProof {
                         proof: MerkleProof::new_from_proof(&proof),
-                        data: domain_replica[*p],
+                        data: tree_r.read_at(*p),
                     }
                 }));
             }
@@ -326,9 +325,11 @@ where
                 let extracted = decode_domain_block::<H>(
                     pub_params.sloth_iter,
                     &pub_inputs.replica_id.expect("missing replica_id"),
-                    domain_replica,
+                    tree_r.as_ref(),
                     challenge,
+                    tree_r.read_at(challenge),
                     &parents,
+                    pub_params.graph.degree(),
                 )?;
                 data_nodes.push(DataProof {
                     data: extracted,

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -5,6 +5,7 @@ use bellman::{ConstraintSystem, SynthesisError};
 use blake2s_simd::{Hash as Blake2sHash, Params as Blake2s, State};
 use byteorder::{LittleEndian, WriteBytesExt};
 use merkle_light::hash::{Algorithm, Hashable};
+use merkle_light::merkle::Element;
 use pairing::bls12_381::{Bls12, Fr, FrRepr};
 use pairing::{PrimeField, PrimeFieldRepr};
 use rand::{Rand, Rng};
@@ -131,6 +132,19 @@ impl From<FrRepr> for Blake2sDomain {
         val.write_le(&mut res.0[0..32]).unwrap();
 
         res
+    }
+}
+
+impl Element for Blake2sDomain {
+    fn byte_len() -> usize {
+        32
+    }
+
+    fn from_slice(bytes: &[u8]) -> Self {
+        match Blake2sDomain::try_from_bytes(bytes) {
+            Ok(res) => res,
+            Err(err) => panic!(err),
+        }
     }
 }
 

--- a/storage-proofs/src/hasher/digest.rs
+++ b/storage-proofs/src/hasher/digest.rs
@@ -4,6 +4,7 @@ use std::marker::PhantomData;
 
 use bellman::{ConstraintSystem, SynthesisError};
 use merkle_light::hash::{Algorithm, Hashable};
+use merkle_light::merkle::Element;
 use pairing::bls12_381::{Bls12, Fr, FrRepr};
 use pairing::{PrimeField, PrimeFieldRepr};
 use rand::{Rand, Rng};
@@ -161,20 +162,33 @@ impl Domain for DigestDomain {
     }
 
     fn try_from_bytes(raw: &[u8]) -> Result<Self> {
-        if raw.len() != 32 {
+        if raw.len() != DigestDomain::byte_len() {
             return Err(Error::InvalidInputSize);
         }
         let mut res = DigestDomain::default();
-        res.0.copy_from_slice(&raw[0..32]);
+        res.0.copy_from_slice(&raw[0..DigestDomain::byte_len()]);
         Ok(res)
     }
 
     fn write_bytes(&self, dest: &mut [u8]) -> Result<()> {
-        if dest.len() < 32 {
+        if dest.len() < DigestDomain::byte_len() {
             return Err(Error::InvalidInputSize);
         }
-        dest[0..32].copy_from_slice(&self.0[..]);
+        dest[0..DigestDomain::byte_len()].copy_from_slice(&self.0[..]);
         Ok(())
+    }
+}
+
+impl Element for DigestDomain {
+    fn byte_len() -> usize {
+        32
+    }
+
+    fn from_slice(bytes: &[u8]) -> Self {
+        match DigestDomain::try_from_bytes(bytes) {
+            Ok(res) => res,
+            Err(err) => panic!(err),
+        }
     }
 }
 

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -17,8 +17,8 @@ mod tests {
     use std::fmt;
     use std::iter::FromIterator;
 
+    use crate::merkle::VecMerkleTree;
     use merkle_light::hash::{Algorithm, Hashable};
-    use merkle_light::merkle::MerkleTree;
 
     use super::super::{DigestDomain, Hasher};
 
@@ -109,8 +109,12 @@ mod tests {
 
         let v: Vec<DigestDomain> = vec![h1.into(), h2.into(), h3.into()];
         let v2: Vec<DigestDomain> = vec![h1.into(), h2.into()];
-        let t = MerkleTree::<<Sha256Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Function>::from_iter(v);
-        let t2 = MerkleTree::<<Sha256Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Function>::from_iter(v2);
+        let t = VecMerkleTree::<<Sha256Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Function>::from_iter(v);
+        let t2 = VecMerkleTree::<
+            <Sha256Hasher as Hasher>::Domain,
+            <Sha256Hasher as Hasher>::Function,
+        >::from_iter(v2);
+        // Using `VecMerkleTree` since the `MmapStore` of `MerkleTree` doesn't support `Deref` (`as_slice`).
 
         assert_eq!(t2.as_slice()[0].as_ref(), l1.as_ref());
         assert_eq!(t2.as_slice()[1].as_ref(), l2.as_ref());

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -1,5 +1,6 @@
 use bellman::{ConstraintSystem, SynthesisError};
 use merkle_light::hash::{Algorithm as LightAlgorithm, Hashable as LightHashable};
+use merkle_light::merkle::Element;
 use pairing::bls12_381::{Fr, FrRepr};
 use rand::Rand;
 use sapling_crypto::circuit::{boolean, num};
@@ -25,6 +26,7 @@ pub trait Domain:
     + Rand
     + Serialize
     + DeserializeOwned
+    + Element
 {
     fn serialize(&self) -> Vec<u8>;
     fn into_bytes(&self) -> Vec<u8>;

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -4,11 +4,19 @@ use std::marker::PhantomData;
 
 // Reexport here, so we don't depend on merkle_light directly in other places.
 use merkle_light::hash::Algorithm;
-pub use merkle_light::merkle::MerkleTree;
+use merkle_light::merkle;
+use merkle_light::merkle::MmapStore;
+use merkle_light::merkle::VecStore;
 use merkle_light::proof;
 use pairing::bls12_381::Fr;
 
 use crate::hasher::{Domain, Hasher};
+
+// `mmap`ed `MerkleTree` (replacing the previously `Vec`-backed
+// `MerkleTree`, now encapsulated in `merkle::VecStore` and exposed
+// as `VecMerkleTree`).
+pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, MmapStore<T>>;
+pub type VecMerkleTree<T, A> = merkle::MerkleTree<T, A, VecStore<T>>;
 
 /// Representation of a merkle proof.
 /// Each element in the `path` vector consists of a tuple `(hash, is_right)`, with `hash` being the the hash of the node at the current level and `is_right` a boolean indicating if the path is taking the right path.

--- a/storage-proofs/src/vde.rs
+++ b/storage-proofs/src/vde.rs
@@ -91,40 +91,18 @@ where
 pub fn decode_domain_block<H>(
     sloth_iter: usize,
     replica_id: &H::Domain,
-    data: &[H::Domain],
+    byte_data: &[u8],
     node: usize,
+    node_data: <H as Hasher>::Domain,
     parents: &[usize],
+    _m: usize,
 ) -> Result<H::Domain>
 where
     H: Hasher,
 {
-    let key = create_domain_key::<H>(replica_id, node, parents, data)?;
+    let key = create_key::<H>(replica_id, node, parents, &byte_data, _m)?;
 
-    Ok(H::sloth_decode(&key, &data[node], sloth_iter))
-}
-
-/// Creates the encoding key, using domain encoded data.
-fn create_domain_key<H: Hasher>(
-    id: &H::Domain,
-    node: usize,
-    parents: &[usize],
-    data: &[H::Domain],
-) -> Result<H::Domain> {
-    let mut hasher = Blake2s::new().hash_length(32).to_state();
-    hasher.update(id.as_ref());
-
-    for parent in parents.iter() {
-        // special super shitty case
-        // TODO: unsuck
-        if node == parents[0] {
-            // skip, as we would only write 0s
-        } else {
-            hasher.update(data[*parent].as_ref());
-        }
-    }
-
-    let hash = hasher.finalize();
-    Ok(bytes_into_fr_repr_safe(hash.as_ref()).into())
+    Ok(H::sloth_decode(&key, &node_data, sloth_iter))
 }
 
 /// Creates the encoding key.


### PR DESCRIPTION
~Blocked on https://github.com/filecoin-project/merkle_light/pull/13, after that is merged the dependency here should point to `merkle_light/master`.~

-----------------------------------------------------------


This is now dropping the allocated memory an order of magnitude:

```
# master:

Total: 309.4 MB
   309.0  99.9%  99.9%    309.0  99.9% ::allocate_in (inline) /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/liballoc/raw_vec.rs:109
     0.3   0.1% 100.0%      0.3   0.1% ::reserve_internal (inline) /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/liballoc/raw_vec.rs:683
     0.1   0.0% 100.0%      0.1   0.0% sapling_crypto::jubjub::JubjubBls12::new (inline) ??:0

# This PR with mmap'ed MT:

Total: 19.4 MB
    13.0  67.1%  67.1%     13.0  67.1% ::allocate_in (inline) /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/liballoc/raw_vec.rs:109
     4.3  22.0%  89.1%      4.3  22.0% ::reserve_internal (inline) /rustc/14997d56a550f4aa99fe737593cd2758227afc56/src/liballoc/raw_vec.rs:683
     2.0  10.3%  99.4%      2.0  10.3% rayon::iter::collect::special_extend@1594e0 (inline) :0

```