### PR TITLE
feat(vde): improve performance of create_key

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -37,6 +37,7 @@ serde = "1.0"
 serde_derive = "1.0"
 base64 = "0.10.0"
 blake2b_simd = "0.4.1"
+blake2s_simd = { git = "https://github.com/oconnor663/blake2s_simd", branch = "master"}
 
 [dependencies.pairing]
 version = "0.14.2"

--- a/storage-proofs/src/circuit/kdf.rs
+++ b/storage-proofs/src/circuit/kdf.rs
@@ -93,7 +93,7 @@ mod tests {
             acc
         });
 
-        let expected = crypto::kdf::kdf::<Bls12>(input_bytes.as_slice(), m);
+        let expected = crypto::kdf::kdf(input_bytes.as_slice(), m);
 
         assert_eq!(
             expected,

--- a/storage-proofs/src/crypto/sloth.rs
+++ b/storage-proofs/src/crypto/sloth.rs
@@ -21,6 +21,7 @@ const SLOTH_V: [u64; 4] = [
 const FIVE: [u64; 1] = [5];
 
 /// Sloth based encoding.
+#[inline]
 pub fn encode<E: Engine>(key: &E::Fr, plaintext: &E::Fr, rounds: usize) -> E::Fr {
     let mut ciphertext = *plaintext;
 
@@ -37,6 +38,7 @@ pub fn encode<E: Engine>(key: &E::Fr, plaintext: &E::Fr, rounds: usize) -> E::Fr
 }
 
 /// Sloth based decoding.
+#[inline]
 pub fn decode<E: Engine>(key: &E::Fr, ciphertext: &E::Fr, rounds: usize) -> E::Fr {
     let mut plaintext = *ciphertext;
 

--- a/storage-proofs/src/hasher/digest.rs
+++ b/storage-proofs/src/hasher/digest.rs
@@ -124,6 +124,15 @@ impl From<Fr> for DigestDomain {
     }
 }
 
+impl From<FrRepr> for DigestDomain {
+    fn from(val: FrRepr) -> Self {
+        let mut res = Self::default();
+        val.write_le(&mut res.0[0..32]).unwrap();
+
+        res
+    }
+}
+
 impl From<DigestDomain> for Fr {
     fn from(val: DigestDomain) -> Self {
         let mut res = FrRepr::default();

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -22,15 +22,17 @@ impl Hasher for PedersenHasher {
     type Function = PedersenFunction;
 
     fn kdf(data: &[u8], m: usize) -> Self::Domain {
-        kdf::kdf::<Bls12>(data, m).into()
+        kdf::kdf(data, m).into()
     }
 
+    #[inline]
     fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain, rounds: usize) -> Self::Domain {
         let key = Fr::from_repr(key.0).unwrap();
         let ciphertext = Fr::from_repr(ciphertext.0).unwrap();
         sloth::encode::<Bls12>(&key, &ciphertext, rounds).into()
     }
 
+    #[inline]
     fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain, rounds: usize) -> Self::Domain {
         let key = Fr::from_repr(key.0).unwrap();
         let ciphertext = Fr::from_repr(ciphertext.0).unwrap();
@@ -253,6 +255,13 @@ impl From<Fr> for PedersenDomain {
     #[inline]
     fn from(val: Fr) -> Self {
         PedersenDomain(val.into_repr())
+    }
+}
+
+impl From<FrRepr> for PedersenDomain {
+    #[inline]
+    fn from(val: FrRepr) -> Self {
+        PedersenDomain(val)
     }
 }
 

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use merkle_light::hash::{Algorithm as LightAlgorithm, Hashable as LightHashable};
-use pairing::bls12_381::Fr;
+use pairing::bls12_381::{Fr, FrRepr};
 use rand::Rand;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
@@ -16,6 +16,7 @@ pub trait Domain:
     + Send
     + Sync
     + From<Fr>
+    + From<FrRepr>
     + Into<Fr>
     + Rand
     + Serialize

--- a/storage-proofs/src/test_helper.rs
+++ b/storage-proofs/src/test_helper.rs
@@ -70,7 +70,7 @@ pub fn fake_drgpoprep_proof<R: Rng>(
         )
         .unwrap();
 
-    let key = crypto::kdf::kdf::<Bls12>(ciphertexts.as_slice(), m);
+    let key = crypto::kdf::kdf(ciphertexts.as_slice(), m);
     // run sloth(key, node)
     let replica_node: Fr = crypto::sloth::encode::<Bls12>(&key, &data_node, sloth_rounds);
     // run fake merkle with only the first 1+m real leaves


### PR DESCRIPTION
- Avoid allocations by updating the hasher directly, instead of allocating a vector.
- Use [`blake2s_simd`](https://github.com/oconnor663/blake2s_simd) to speed up the actual hashing operations.
- Avoid some conversions from `Fr` to `FrRepr` and back.

Performance Improvements

- Testcase: `32 MB - zigzag default`

| variant                  | replication time |
|--------------------------|------------------|
| master |    178.938245178s, |
| this branch    |  169.802207285s |


Note: this currently uses an unpublished version of https://github.com/oconnor663/blake2s_simd
