### PR TITLE
Adding a macro to free memory in the FFI automatically

### DIFF
--- a/drop-struct-macro-derive/.gitignore
+++ b/drop-struct-macro-derive/.gitignore
@@ -1,0 +1,3 @@
+/target
+**/*.rs.bk
+Cargo.lock

--- a/drop-struct-macro-derive/Cargo.toml
+++ b/drop-struct-macro-derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "drop_struct_macro_derive"
+version = "0.1.0"
+authors = ["Volker Mische <volker.mische@gmail.com>"]
+edition = "2018"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = { version = "0.15", features = ["extra-traits"] }
+quote = "0.6.3"
+proc-macro2 = "0.4.27"

--- a/drop-struct-macro-derive/LICENSE-APACHE
+++ b/drop-struct-macro-derive/LICENSE-APACHE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/drop-struct-macro-derive/LICENSE-MIT
+++ b/drop-struct-macro-derive/LICENSE-MIT
@@ -1,0 +1,23 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.

--- a/drop-struct-macro-derive/README.md
+++ b/drop-struct-macro-derive/README.md
@@ -1,0 +1,63 @@
+# Drop struct macro derive
+
+A derive macro to free (drop) memory for structs that are used in the FFI.
+
+Currently only c-strings (`libc::c_char`) and arrays (represented as a pointer and a length field) are supported.
+
+Example:
+
+```rust
+#[repr(C)]
+#[derive(DropStructMacro)]
+pub struct FFIStagedSectorMetadata {
+    pub sector_access: *const libc::c_char,
+    pub sector_id: u64,
+    pub pieces_len: libc::size_t,
+    pub pieces_ptr: *const FFIPieceMetadata,
+
+    // must be one of: Pending, Failed, Sealing
+    pub seal_status_code: FFISealStatus,
+
+    // if sealing failed - here's the error
+    pub seal_error_msg: *const libc::c_char,
+}
+```
+
+Will automatically create:
+
+```rust
+impl Drop for FFIStagedSectorMetadata {
+    fn drop(&mut self) {
+        unsafe {
+            free_c_str(self.sector_access as *mut libc::c_char);
+            drop(Vec::from_raw_parts(
+                self.pieces_ptr as *mut FFIPieceMetadata,
+                self.pieces_len,
+                self.pieces_len,
+            ));
+            free_c_str(self.seal_error_msg as *mut libc::c_char);
+        };
+    }
+}
+```
+
+To view the generated output after the macro was applied, you can use [cargo-expand](https://github.com/dtolnay/cargo-expand):
+
+```console
+$ cd filecoin-proofs
+$ cargo expand --lib api::responses
+    Checking filecoin-proofs v0.1.0 (/home/vmx/src/pl/filecoin/rust-fil-proofs/filecoin-proofs)
+    Finished dev [unoptimized + debuginfo] target(s) in 0.70s
+
+pub mod responses {
+    use crate::api::sector_builder::errors::SectorBuilderErr;
+    use crate::api::sector_builder::SectorBuilder;
+    use crate::api::API_POREP_PROOF_BYTES;
+    use drop_struct_macro_derive::DropStructMacro;
+    use failure::Error;
+…
+```
+
+## License
+
+MIT or Apache 2.0

--- a/drop-struct-macro-derive/src/lib.rs
+++ b/drop-struct-macro-derive/src/lib.rs
@@ -1,0 +1,107 @@
+extern crate proc_macro;
+use crate::proc_macro::TokenStream;
+use proc_macro2::{Ident, Span};
+use quote::{quote, ToTokens};
+use syn;
+
+/// A struct that contains the name of a struct field and the corresponding type
+#[derive(Debug)]
+struct FieldNameType {
+    field_name: String,
+    field_type: proc_macro2::TokenStream,
+}
+
+/// The actual code to free the *const pointers
+impl quote::ToTokens for FieldNameType {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let field_type = &self.field_type;
+        // Convert field type to string for easy pattern matching
+        let field_type_string = self
+            .field_type
+            .clone()
+            .into_iter()
+            .map(|token| token.to_string())
+            .collect::<String>();
+        match &field_type_string[..] {
+            // Free string with `free_c_str`
+            "libc::c_char" => {
+                let field_name = Ident::new(&self.field_name, Span::call_site());
+                let gen = quote! {
+                    free_c_str(self.#field_name as *mut #field_type);
+                };
+                gen.to_tokens(tokens);
+            }
+            // Expect all others to be vectors
+            _ => {
+                if !self.field_name.ends_with("_ptr") {
+                    panic!(
+                        "Pointer needs to have field with `_ptr` as suffix. \
+                         This field is named `{}`.",
+                        self.field_name
+                    )
+                }
+                // Field ends with `_ptr` so we can re-construct the corresponding length field
+                let field_name_len = Ident::new(
+                    &format!(
+                        "{}{}",
+                        &self.field_name[..&self.field_name.len() - 4],
+                        "_len"
+                    ),
+                    Span::call_site(),
+                );
+                let field_name_ptr = Ident::new(&self.field_name, Span::call_site());
+                let gen = quote! {
+                    drop(Vec::from_raw_parts(
+                            self.#field_name_ptr as *mut #field_type,
+                            self.#field_name_len,
+                            self.#field_name_len,
+                    ));
+                };
+                gen.to_tokens(tokens);
+            }
+        }
+    }
+}
+
+#[proc_macro_derive(DropStructMacro)]
+pub fn drop_struct_macro_derive(input: TokenStream) -> TokenStream {
+    let ast: syn::DeriveInput = syn::parse(input).unwrap();
+
+    // A list of fields that should get dropped
+    let mut to_be_dropped = Vec::new();
+
+    // Only take *const pointers into account (also not *mut)
+    match ast.data {
+        syn::Data::Struct(ref data_struct) => {
+            if let syn::Fields::Named(ref fields_named) = data_struct.fields {
+                for field in fields_named.named.iter() {
+                    if let syn::Type::Ptr(ref type_ptr) = field.ty {
+                        if type_ptr.const_token.is_some() {
+                            if let syn::Type::Path(ref type_path) = *type_ptr.elem {
+                                let field_name = field.ident.clone().unwrap().to_string();
+                                let field_type = type_path.path.clone().into_token_stream();
+                                to_be_dropped.push(FieldNameType {
+                                    field_name,
+                                    field_type,
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        _ => panic!("Works only with structs"),
+    }
+
+    let name = &ast.ident;
+    let gen = quote! {
+        impl Drop for #name {
+            fn drop(&mut self) {
+                unsafe {
+                    #(#to_be_dropped)*
+                };
+            }
+        }
+    };
+    gen.into()
+}

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = "1.0"
 blake2 = "0.8"
 slog = { version = "2.4.1", features = ["max_level_trace", "release_max_level_trace"] }
 regex = "1"
+drop_struct_macro_derive = { path = "../drop-struct-macro-derive" }
 
 [dev-dependencies]
 gperftools = "0.2"

--- a/filecoin-proofs/src/api/responses.rs
+++ b/filecoin-proofs/src/api/responses.rs
@@ -1,6 +1,7 @@
 use crate::api::sector_builder::errors::SectorBuilderErr;
 use crate::api::sector_builder::SectorBuilder;
 use crate::api::API_POREP_PROOF_BYTES;
+use drop_struct_macro_derive::DropStructMacro;
 use failure::Error;
 use ffi_toolkit::free_c_str;
 use libc;
@@ -33,6 +34,7 @@ pub enum FFISealStatus {
 //////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct VerifySealResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -49,14 +51,6 @@ impl Default for VerifySealResponse {
     }
 }
 
-impl Drop for VerifySealResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-        };
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn destroy_verify_seal_response(ptr: *mut VerifySealResponse) {
     let _ = Box::from_raw(ptr);
@@ -67,6 +61,7 @@ pub unsafe extern "C" fn destroy_verify_seal_response(ptr: *mut VerifySealRespon
 //////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct GeneratePoStResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -89,26 +84,6 @@ impl Default for GeneratePoStResponse {
     }
 }
 
-impl Drop for GeneratePoStResponse {
-    fn drop(&mut self) {
-        unsafe {
-            drop(Vec::from_raw_parts(
-                self.faults_ptr as *mut u8,
-                self.faults_len,
-                self.faults_len,
-            ));
-
-            drop(Vec::from_raw_parts(
-                self.flattened_proofs_ptr as *mut u8,
-                self.flattened_proofs_len,
-                self.flattened_proofs_len,
-            ));
-
-            free_c_str(self.error_msg as *mut libc::c_char);
-        };
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn destroy_generate_post_response(ptr: *mut GeneratePoStResponse) {
     let _ = Box::from_raw(ptr);
@@ -119,6 +94,7 @@ pub unsafe extern "C" fn destroy_generate_post_response(ptr: *mut GeneratePoStRe
 ////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct VerifyPoSTResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -132,14 +108,6 @@ impl Default for VerifyPoSTResponse {
             error_msg: ptr::null(),
             is_valid: false,
         }
-    }
-}
-
-impl Drop for VerifyPoSTResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-        };
     }
 }
 
@@ -181,6 +149,7 @@ pub fn err_code_and_msg(err: &Error) -> (FCPResponseStatus, *const libc::c_char)
 /////////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct InitSectorBuilderResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -197,14 +166,6 @@ impl Default for InitSectorBuilderResponse {
     }
 }
 
-impl Drop for InitSectorBuilderResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-        };
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn destroy_init_sector_builder_response(ptr: *mut InitSectorBuilderResponse) {
     let _ = Box::from_raw(ptr);
@@ -215,6 +176,7 @@ pub unsafe extern "C" fn destroy_init_sector_builder_response(ptr: *mut InitSect
 ////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct AddPieceResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -231,14 +193,6 @@ impl Default for AddPieceResponse {
     }
 }
 
-impl Drop for AddPieceResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-        };
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn destroy_add_piece_response(ptr: *mut AddPieceResponse) {
     let _ = Box::from_raw(ptr);
@@ -249,6 +203,7 @@ pub unsafe extern "C" fn destroy_add_piece_response(ptr: *mut AddPieceResponse) 
 /////////////////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct ReadPieceFromSealedSectorResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -267,20 +222,6 @@ impl Default for ReadPieceFromSealedSectorResponse {
     }
 }
 
-impl Drop for ReadPieceFromSealedSectorResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-
-            drop(Vec::from_raw_parts(
-                self.data_ptr as *mut u8,
-                self.data_len,
-                self.data_len,
-            ));
-        };
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn destroy_read_piece_from_sealed_sector_response(
     ptr: *mut ReadPieceFromSealedSectorResponse,
@@ -293,6 +234,7 @@ pub unsafe extern "C" fn destroy_read_piece_from_sealed_sector_response(
 ////////////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct SealAllStagedSectorsResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -304,14 +246,6 @@ impl Default for SealAllStagedSectorsResponse {
             status_code: FCPResponseStatus::FCPNoError,
             error_msg: ptr::null(),
         }
-    }
-}
-
-impl Drop for SealAllStagedSectorsResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-        };
     }
 }
 
@@ -327,6 +261,7 @@ pub unsafe extern "C" fn destroy_seal_all_staged_sectors_response(
 //////////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct GetMaxStagedBytesPerSector {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -343,14 +278,6 @@ impl Default for GetMaxStagedBytesPerSector {
     }
 }
 
-impl Drop for GetMaxStagedBytesPerSector {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-        };
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn destroy_get_max_user_bytes_per_staged_sector_response(
     ptr: *mut GetMaxStagedBytesPerSector,
@@ -363,6 +290,7 @@ pub unsafe extern "C" fn destroy_get_max_user_bytes_per_staged_sector_response(
 /////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct GetSealStatusResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -384,17 +312,10 @@ pub struct GetSealStatusResponse {
 }
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct FFIPieceMetadata {
     pub piece_key: *const libc::c_char,
     pub num_bytes: u64,
-}
-
-impl Drop for FFIPieceMetadata {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.piece_key as *mut libc::c_char);
-        }
-    }
 }
 
 impl Default for GetSealStatusResponse {
@@ -419,21 +340,6 @@ impl Default for GetSealStatusResponse {
     }
 }
 
-impl Drop for GetSealStatusResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-            free_c_str(self.seal_error_msg as *mut libc::c_char);
-            free_c_str(self.sector_access as *mut libc::c_char);
-            drop(Vec::from_raw_parts(
-                self.pieces_ptr as *mut FFIPieceMetadata,
-                self.pieces_len,
-                self.pieces_len,
-            ));
-        };
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn destroy_get_seal_status_response(ptr: *mut GetSealStatusResponse) {
     let _ = Box::from_raw(ptr);
@@ -444,6 +350,7 @@ pub unsafe extern "C" fn destroy_get_seal_status_response(ptr: *mut GetSealStatu
 ///////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct FFIStagedSectorMetadata {
     pub sector_access: *const libc::c_char,
     pub sector_id: u64,
@@ -457,25 +364,12 @@ pub struct FFIStagedSectorMetadata {
     pub seal_error_msg: *const libc::c_char,
 }
 
-impl Drop for FFIStagedSectorMetadata {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.sector_access as *mut libc::c_char);
-            free_c_str(self.seal_error_msg as *mut libc::c_char);
-            drop(Vec::from_raw_parts(
-                self.pieces_ptr as *mut FFIPieceMetadata,
-                self.pieces_len,
-                self.pieces_len,
-            ));
-        }
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 /// FFISealedSectorMetadata
 ///////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct FFISealedSectorMetadata {
     pub comm_d: [u8; 32],
     pub comm_r: [u8; 32],
@@ -487,24 +381,12 @@ pub struct FFISealedSectorMetadata {
     pub pieces_ptr: *const FFIPieceMetadata,
 }
 
-impl Drop for FFISealedSectorMetadata {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.sector_access as *mut libc::c_char);
-            drop(Vec::from_raw_parts(
-                self.pieces_ptr as *mut FFIPieceMetadata,
-                self.pieces_len,
-                self.pieces_len,
-            ));
-        }
-    }
-}
-
 ///////////////////////////////////////////////////////////////////////////////
 /// GetSealedSectorsResponse
 ////////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct GetSealedSectorsResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -524,19 +406,6 @@ impl Default for GetSealedSectorsResponse {
     }
 }
 
-impl Drop for GetSealedSectorsResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-            drop(Vec::from_raw_parts(
-                self.sectors_ptr as *mut FFISealedSectorMetadata,
-                self.sectors_len,
-                self.sectors_len,
-            ));
-        }
-    }
-}
-
 #[no_mangle]
 pub unsafe extern "C" fn destroy_get_sealed_sectors_response(ptr: *mut GetSealedSectorsResponse) {
     let _ = Box::from_raw(ptr);
@@ -547,6 +416,7 @@ pub unsafe extern "C" fn destroy_get_sealed_sectors_response(ptr: *mut GetSealed
 ////////////////////////////
 
 #[repr(C)]
+#[derive(DropStructMacro)]
 pub struct GetStagedSectorsResponse {
     pub status_code: FCPResponseStatus,
     pub error_msg: *const libc::c_char,
@@ -562,19 +432,6 @@ impl Default for GetStagedSectorsResponse {
             error_msg: ptr::null(),
             sectors_len: 0,
             sectors_ptr: ptr::null(),
-        }
-    }
-}
-
-impl Drop for GetStagedSectorsResponse {
-    fn drop(&mut self) {
-        unsafe {
-            free_c_str(self.error_msg as *mut libc::c_char);
-            drop(Vec::from_raw_parts(
-                self.sectors_ptr as *mut FFIStagedSectorMetadata,
-                self.sectors_len,
-                self.sectors_len,
-            ));
         }
     }
 }


### PR DESCRIPTION
Dropping memory is a large part of the reposonses FFI code. With
this new macro `#[derive(DropStructMacro)]` the `Drop` implementation
will be auto-generated based on the struct.

Example:

```rust
pub struct FFIStagedSectorMetadata {
    pub sector_access: *const libc::c_char,
    pub sector_id: u64,
    pub pieces_len: libc::size_t,
    pub pieces_ptr: *const FFIPieceMetadata,

    // must be one of: Pending, Failed, Sealing
    pub seal_status_code: FFISealStatus,

    // if sealing failed - here's the error
    pub seal_error_msg: *const libc::c_char,
}
```

Will automatically create:

```rust
impl Drop for FFIStagedSectorMetadata {
    fn drop(&mut self) {
        unsafe {
            free_c_str(self.sector_access as *mut libc::c_char);
            drop(Vec::from_raw_parts(
                self.pieces_ptr as *mut FFIPieceMetadata,
                self.pieces_len,
                self.pieces_len,
            ));
            free_c_str(self.seal_error_msg as *mut libc::c_char);
        };
    }
}
```

To view the generated output after the macro was applied, you can use
[cargo-expand](https://github.com/dtolnay/cargo-expand):

```console
$ cd filecoin-proofs
$ cargo expand --lib api::responses
…
```

The diff between the original code and the generated code after running
`cargo expand --lib api::responses` and re-arranging it a bit (just
moving the `Drop` to the same place) the diff is:

```diff
164c164
<                     self.faults_ptr as *mut u8,
---
>                     self.faults_ptr as *mut u64,
417c417
<             }
---
>             };
476c476
<             }
---
>             };
500c500
<             }
---
>             };
530c530
<             }
---
>             };
566c566
<             }
---
>             };
```

Closes #303.