### PR TITLE
refactor(layered-drgporep): restructure parallelized proving

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -12,7 +12,7 @@ bitvec = "0.5"
 sapling-crypto = { git = "https://github.com/zcash-hackworks/sapling-crypto", branch = "master" }
 rand = "0.4"
 libc = "0.2"
-merkle_light = { git = "https://github.com/filecoin-project/merkle_light", rev = "63a609decf3cc552b0aa79477b828f4a493f725d" }
+merkle_light = { git = "https://github.com/filecoin-project/merkle_light", branch = "master" }
 failure = "0.1"
 bellman = "0.1"
 byteorder = "1"
@@ -36,6 +36,7 @@ serde = { version = "1.0", features = ["derive"]}
 base64 = "0.10.0"
 blake2b_simd = "0.4.1"
 blake2s_simd = { git = "https://github.com/oconnor663/blake2s_simd", branch = "master"}
+crossbeam = "0.7.1"
 toml = "0.4"
 
 [dependencies.pairing]

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -16,7 +16,6 @@ merkle_light = { git = "https://github.com/filecoin-project/merkle_light", rev =
 failure = "0.1"
 bellman = "0.1"
 byteorder = "1"
-crossbeam-utils = "0.6"
 itertools = "0.7.3"
 lazy_static = "1.2"
 memmap = "0.6"

--- a/storage-proofs/src/lib.rs
+++ b/storage-proofs/src/lib.rs
@@ -17,7 +17,6 @@ extern crate bitvec;
 extern crate blake2;
 extern crate block_modes;
 extern crate byteorder;
-extern crate crossbeam_utils;
 extern crate fs2;
 extern crate itertools;
 extern crate libc;


### PR DESCRIPTION
Perf is usually a bit better than master for me, but variance is too high for me to be sure. 

- no arcs or cell types
- only `rayon::join` (meaning it uses a work stealing thread pool under the hood)
- no channels
- no reliance on `panic`, but returning `Result` types
- a little less cloning and allocations than before
- 2/3 of the code

