### PR TITLE
perf(drgporep): decode_domain_block: avoid data allocations

### DIFF
--- a/filecoin-proofs/examples/drgporep-vanilla-disk.rs
+++ b/filecoin-proofs/examples/drgporep-vanilla-disk.rs
@@ -89,7 +89,10 @@ fn do_the_work<H: Hasher>(data_size: usize, m: usize, sloth_iter: usize, challen
         tau: Some(tau),
     };
 
-    let priv_inputs = PrivateInputs::<H> { aux: &aux };
+    let priv_inputs = PrivateInputs::<H> {
+        tree_d: &aux.tree_d,
+        tree_r: &aux.tree_r,
+    };
 
     param_duration += start.elapsed();
     let samples: u32 = 30;

--- a/filecoin-proofs/examples/drgporep-vanilla.rs
+++ b/filecoin-proofs/examples/drgporep-vanilla.rs
@@ -102,7 +102,10 @@ fn do_the_work<H: Hasher>(data_size: usize, m: usize, sloth_iter: usize, challen
         tau: Some(tau),
     };
 
-    let priv_inputs = PrivateInputs::<H> { aux: &aux };
+    let priv_inputs = PrivateInputs::<H> {
+        tree_d: &aux.tree_d,
+        tree_r: &aux.tree_r,
+    };
 
     param_duration += start.elapsed();
     let samples: u32 = 30;

--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -278,6 +278,7 @@ fn do_the_work<H: 'static>(
         let vanilla_proving = start.elapsed();
         total_proving += vanilla_proving;
 
+        info!(FCP_LOG, "vanilla_proving_time: {:?}", vanilla_proving; "target" => "stats");
         if dump_proofs {
             dump_proof_bytes(&all_partition_proofs);
         }

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -524,7 +524,10 @@ mod tests {
             challenges: vec![challenge],
             tau: Some(tau.into()),
         };
-        let priv_inputs = drgporep::PrivateInputs::<PedersenHasher> { aux: &aux };
+        let priv_inputs = drgporep::PrivateInputs::<PedersenHasher> {
+            tree_d: &aux.tree_d,
+            tree_r: &aux.tree_r,
+        };
 
         let proof_nc =
             drgporep::DrgPoRep::<PedersenHasher, _>::prove(&pp, &pub_inputs, &priv_inputs)
@@ -686,7 +689,10 @@ mod tests {
             challenges,
             tau: Some(tau),
         };
-        let private_inputs = drgporep::PrivateInputs { aux: &aux };
+        let private_inputs = drgporep::PrivateInputs {
+            tree_d: &aux.tree_d,
+            tree_r: &aux.tree_r,
+        };
 
         // This duplication is necessary so public_params don't outlive public_inputs and private_inputs.
         let setup_params = compound_proof::SetupParams {

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -24,7 +24,8 @@ pub struct PublicInputs<T: Domain> {
 
 #[derive(Debug)]
 pub struct PrivateInputs<'a, H: 'a + Hasher> {
-    pub aux: &'a porep::ProverAux<H>,
+    pub tree_d: &'a MerkleTree<H::Domain, H::Function>,
+    pub tree_r: &'a MerkleTree<H::Domain, H::Function>,
 }
 
 #[derive(Debug)]
@@ -270,8 +271,8 @@ where
             let challenge = pub_inputs.challenges[i] % pub_params.graph.size();
             assert_ne!(challenge, 0, "cannot prove the first node");
 
-            let tree_d = &priv_inputs.aux.tree_d;
-            let tree_r = &priv_inputs.aux.tree_r;
+            let tree_d = &priv_inputs.tree_d;
+            let tree_r = &priv_inputs.tree_r;
             let domain_replica = tree_r.as_slice();
 
             let data = domain_replica[challenge];
@@ -641,7 +642,10 @@ mod tests {
                 tau: Some(tau.clone().into()),
             };
 
-            let priv_inputs = PrivateInputs::<H> { aux: &aux };
+            let priv_inputs = PrivateInputs::<H> {
+                tree_d: &aux.tree_d,
+                tree_r: &aux.tree_r,
+            };
 
             let real_proof = DrgPoRep::<H, _>::prove(&pp, &pub_inputs, &priv_inputs).unwrap();
 

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -308,16 +308,14 @@ where
                 // )?;
 
                 let extracted = decode_domain_block::<H>(
-                    pub_params.graph.degree(),
                     pub_params.sloth_iter,
                     &pub_inputs.replica_id,
                     domain_replica,
                     challenge,
-                    parents,
-                )?
-                .into_bytes();
+                    &parents,
+                )?;
                 data_nodes.push(DataProof {
-                    data: H::Domain::try_from_bytes(&extracted)?,
+                    data: extracted,
                     proof: MerkleProof::new_from_proof(&node_proof),
                 });
             }

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -270,10 +270,8 @@ pub trait Layers {
                 let inner_layers = layers - layer;
 
                 let new_priv_inputs = drgporep::PrivateInputs {
-                    aux: &porep::ProverAux {
-                        tree_d: aux[layer].clone(),
-                        tree_r: aux[layer + 1].clone(),
-                    },
+                    tree_d: &aux[layer],
+                    tree_r: &aux[layer + 1],
                 };
                 let layer_diff = total_layers - inner_layers;
 

--- a/storage-proofs/src/vde.rs
+++ b/storage-proofs/src/vde.rs
@@ -98,13 +98,13 @@ pub fn decode_domain_block<H>(
 where
     H: Hasher,
 {
-    let key = create_key_domain::<H>(replica_id, node, parents, data)?;
+    let key = create_domain_key::<H>(replica_id, node, parents, data)?;
 
     Ok(H::sloth_decode(&key, &data[node], sloth_iter))
 }
 
 /// Creates the encoding key, using domain encoded data.
-fn create_key_domain<H: Hasher>(
+fn create_domain_key<H: Hasher>(
     id: &H::Domain,
     node: usize,
     parents: &[usize],

--- a/storage-proofs/src/vde.rs
+++ b/storage-proofs/src/vde.rs
@@ -85,31 +85,46 @@ where
     let key = create_key::<H>(replica_id, v, &parents, &data, graph.degree())?;
     let node_data = H::Domain::try_from_bytes(&data_at_node(data, v)?)?;
 
-    // TODO: round constant
     Ok(H::sloth_decode(&key, &node_data, sloth_iter))
 }
 
-pub fn decode_domain_block<'a, H>(
-    degree: usize,
+pub fn decode_domain_block<H>(
     sloth_iter: usize,
-    replica_id: &'a H::Domain,
-    data: &'a [H::Domain],
-    v: usize,
-    parents: Vec<usize>,
+    replica_id: &H::Domain,
+    data: &[H::Domain],
+    node: usize,
+    parents: &[usize],
 ) -> Result<H::Domain>
 where
     H: Hasher,
 {
-    let byte_data = data
-        .iter()
-        .flat_map(H::Domain::into_bytes)
-        .collect::<Vec<u8>>();
+    let key = create_key_domain::<H>(replica_id, node, parents, data)?;
 
-    let key = create_key::<H>(replica_id, v, &parents, &byte_data, degree)?;
-    let node_data = data[v];
+    Ok(H::sloth_decode(&key, &data[node], sloth_iter))
+}
 
-    // TODO: round constant
-    Ok(H::sloth_decode(&key, &node_data, sloth_iter))
+/// Creates the encoding key, using domain encoded data.
+fn create_key_domain<H: Hasher>(
+    id: &H::Domain,
+    node: usize,
+    parents: &[usize],
+    data: &[H::Domain],
+) -> Result<H::Domain> {
+    let mut hasher = Blake2s::new().hash_length(32).to_state();
+    hasher.update(id.as_ref());
+
+    for parent in parents.iter() {
+        // special super shitty case
+        // TODO: unsuck
+        if node == parents[0] {
+            // skip, as we would only write 0s
+        } else {
+            hasher.update(data[*parent].as_ref());
+        }
+    }
+
+    let hash = hasher.finalize();
+    Ok(bytes_into_fr_repr_safe(hash.as_ref()).into())
 }
 
 /// Creates the encoding key.


### PR DESCRIPTION
Should fix #537 

Speed improvements on my machine for `1MB` data zigzag (`cargo run -p filecoin-proofs --release --example zigzag -- --m 5 --expansion 8 --layers 10 --challenges 5 --size 1024 --no-bench`)

- `master`:  vanilla_proving_time: `495.295015ms`
- `perf-vanilla-proving`: vanilla_proving_time: `4.295946ms`