### PR TITLE
feat(storage-proofs): zizag, drgporep and por abstract over the hasher in circuits

### DIFF
--- a/filecoin-proofs/examples/drgporep.rs
+++ b/filecoin-proofs/examples/drgporep.rs
@@ -14,8 +14,8 @@ use sapling_crypto::jubjub::{JubjubBls12, JubjubEngine};
 
 use storage_proofs::circuit;
 use storage_proofs::circuit::variables::Root;
-
 use storage_proofs::example_helper::Example;
+use storage_proofs::hasher::PedersenHasher;
 use storage_proofs::test_helper::fake_drgpoprep_proof;
 
 struct DrgPoRepExample<'a, E: JubjubEngine> {
@@ -35,7 +35,7 @@ struct DrgPoRepExample<'a, E: JubjubEngine> {
 
 impl<'a> Circuit<Bls12> for DrgPoRepExample<'a, Bls12> {
     fn synthesize<CS: ConstraintSystem<Bls12>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
-        circuit::drgporep::DrgPoRepCircuit::synthesize(
+        circuit::drgporep::DrgPoRepCircuit::<_, PedersenHasher>::synthesize(
             cs.namespace(|| "drgporep"),
             self.params,
             self.sloth_iter,

--- a/parameters.json
+++ b/parameters.json
@@ -1,31 +1,31 @@
 {
-  "v10-zigzag-proof-of-replication-b8f3290335d11af86f8193cc2c3bbf451b4b2cc33e59e8ecad060999f3bebe77": {
-    "cid": "QmeAwbo2CM4t58kV7byr1X2beA7pzbGvStCVSDSG4ydu2E",
-    "digest": "a30003a7b2b2512cd5e66cfefdd9fe7b"
-  },
-  "v10-zigzag-proof-of-replication-b8f3290335d11af86f8193cc2c3bbf451b4b2cc33e59e8ecad060999f3bebe77.vk": {
-    "cid": "QmeubWLDsLvL5ULFote1Gce1RfNKcHicCkcwsNyBkhtWuv",
-    "digest": "61eb4d1b2862feb1149284108c29386b"
-  },
   "v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6.vk": {
     "cid": "QmTKL1MiWSWFUMEECZPaBX6ddoZy9HCAA4mdaW65BKDoEp",
     "digest": "2684b87a68d3a02118584e524a3f073a"
   },
-  "v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6": {
-    "cid": "QmPuZ1fZGVDBTjsARTWuMesKjaXqUeNENsQrWBLh7PAjEU",
-    "digest": "71f6673c73376cca102390150174bbe4"
-  },
-  "v10-zigzag-proof-of-replication-733b035c440d8b0e4a03ab5e4c58553b6c674cc64bd6a130e8764f7abeb38f69.vk": {
-    "cid": "QmRkiXN7RTWjTgTz3DTjCjDaVNS5vNd8z174UrZLyMowmS",
-    "digest": "d9f8f2c3a74c45cce4dfa26b65ccc3c9"
+  "v10-zigzag-proof-of-replication-6648cd509799c8b76f944bbc971692c69d1480fa60c569bfc1284f0bd8ead988": {
+    "cid": "QmeAwbo2CM4t58kV7byr1X2beA7pzbGvStCVSDSG4ydu2E",
+    "digest": "a30003a7b2b2512cd5e66cfefdd9fe7b"
   },
   "v10-vdf-post-912e5a392c09cbfa0bf369ac77f939a45e0f2aec968cf3846cbe356a19b76685": {
     "cid": "QmP1PkagfiC9cUEh3r7NEWaJfnBGEnqfABxXxh3PSoiMtX",
     "digest": "ff7fa52e9bf2a3b5261f6d5740156f79"
   },
-  "v10-zigzag-proof-of-replication-733b035c440d8b0e4a03ab5e4c58553b6c674cc64bd6a130e8764f7abeb38f69": {
+  "v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6": {
+    "cid": "QmPuZ1fZGVDBTjsARTWuMesKjaXqUeNENsQrWBLh7PAjEU",
+    "digest": "71f6673c73376cca102390150174bbe4"
+  },
+  "v10-zigzag-proof-of-replication-56360c4554216174de15d2c76acbd0f360e0fabf07dd470ca50f7d39676e7874": {
     "cid": "QmbPHbry667qc7JEhYDWpvs6mj6rD9UQRi9ZpQb6q6pcoq",
     "digest": "9268d86f4e3c23eb8483d65834e27c0d"
+  },
+  "v10-zigzag-proof-of-replication-6648cd509799c8b76f944bbc971692c69d1480fa60c569bfc1284f0bd8ead988.vk": {
+    "cid": "QmeubWLDsLvL5ULFote1Gce1RfNKcHicCkcwsNyBkhtWuv",
+    "digest": "61eb4d1b2862feb1149284108c29386b"
+  },
+  "v10-zigzag-proof-of-replication-56360c4554216174de15d2c76acbd0f360e0fabf07dd470ca50f7d39676e7874.vk": {
+    "cid": "QmRkiXN7RTWjTgTz3DTjCjDaVNS5vNd8z174UrZLyMowmS",
+    "digest": "d9f8f2c3a74c45cce4dfa26b65ccc3c9"
   },
   "v10-vdf-post-912e5a392c09cbfa0bf369ac77f939a45e0f2aec968cf3846cbe356a19b76685.vk": {
     "cid": "QmaNXg87KFw4pKxa9mXThprpDns7aJZCN5k9WCtneMBkoY",

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_por_input_circuit_with_bls12_381_pedersen() {
-        test_por_input_circuit_with_bls12_381::<PedersenHasher>(4148);
+        test_por_input_circuit_with_bls12_381::<PedersenHasher>(4149);
     }
 
     #[test]

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -7,12 +7,11 @@ use sapling_crypto::jubjub::JubjubEngine;
 
 use crate::circuit::constraint;
 use crate::circuit::drgporep::{ComponentPrivateInputs, DrgPoRepCompound};
-use crate::circuit::pedersen::pedersen_md_no_padding;
 use crate::circuit::variables::Root;
 use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::drgporep::{self, DrgPoRep};
 use crate::drgraph::Graph;
-use crate::hasher::Hasher;
+use crate::hasher::{HashFunction, Hasher};
 use crate::layered_drgporep::{self, Layers as LayersTrait};
 use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
 use crate::porep;
@@ -226,10 +225,10 @@ impl<'a, H: Hasher> Circuit<Bls12> for ZigZagCircuit<'a, Bls12, H> {
             }
 
             // Calculate the pedersen hash.
-            let computed_comm_r_star = pedersen_md_no_padding(
+            let computed_comm_r_star = H::Function::hash_circuit(
                 cs.namespace(|| "comm_r_star"),
-                self.params,
                 &crs_boolean[..],
+                self.params,
             )?;
 
             // Allocate the resulting hash.

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -585,8 +585,8 @@ mod tests {
         let nodes = 5;
         let degree = 2;
         let expansion_degree = 1;
-        let num_layers = 4;
-        let layer_challenges = LayerChallenges::new_tapered(num_layers, 4, num_layers, 1.0 / 3.0);
+        let num_layers = 2;
+        let layer_challenges = LayerChallenges::new_tapered(num_layers, 3, num_layers, 1.0 / 3.0);
         let sloth_iter = 1;
         let partition_count = 1;
 

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -378,7 +378,7 @@ mod tests {
     use crate::drgporep;
     use crate::drgraph::new_seed;
     use crate::fr32::fr_into_bytes;
-    use crate::hasher::pedersen::*;
+    use crate::hasher::{Blake2sHasher, Hasher, PedersenHasher};
     use crate::layered_drgporep::{self, LayerChallenges};
     use crate::porep::PoRep;
     use crate::proof::ProofScheme;
@@ -429,7 +429,7 @@ mod tests {
 
         let simplified_tau = tau.clone().simplify();
 
-        let pub_inputs = layered_drgporep::PublicInputs::<PedersenDomain> {
+        let pub_inputs = layered_drgporep::PublicInputs::<<PedersenHasher as Hasher>::Domain> {
             replica_id: replica_id.into(),
             tau: Some(tau.simplify().into()),
             comm_r_star: tau.comm_r_star.into(),
@@ -571,7 +571,17 @@ mod tests {
 
     #[test]
     #[ignore] // Slow test – run only when compiled for release.
-    fn zigzag_test_compound() {
+    fn test_zigzag_compound_pedersen() {
+        zigzag_test_compound::<PedersenHasher>();
+    }
+
+    #[test]
+    #[ignore] // Slow test – run only when compiled for release.
+    fn test_zigzag_compound_blake2s() {
+        zigzag_test_compound::<Blake2sHasher>();
+    }
+
+    fn zigzag_test_compound<H: 'static + Hasher>() {
         let params = &JubjubBls12::new();
         let nodes = 5;
         let degree = 2;
@@ -620,13 +630,13 @@ mod tests {
         .unwrap();
         assert_ne!(data, data_copy);
 
-        let public_inputs = layered_drgporep::PublicInputs::<PedersenDomain> {
+        let public_inputs = layered_drgporep::PublicInputs::<H::Domain> {
             replica_id: replica_id.into(),
             tau: Some(tau.simplify()),
             comm_r_star: tau.comm_r_star,
             k: None,
         };
-        let private_inputs = layered_drgporep::PrivateInputs::<PedersenHasher> {
+        let private_inputs = layered_drgporep::PrivateInputs::<H> {
             aux,
             tau: tau.layer_taus,
         };

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -107,8 +107,10 @@ impl<H: Hasher> ParameterSetIdentifier for BucketGraph<H> {
     fn parameter_set_identifier(&self) -> String {
         // NOTE: Seed is not included because it does not influence parameter generation.
         format!(
-            "drgraph::BucketGraph{{size: {}; degree: {}}}",
-            self.nodes, self.base_degree,
+            "drgraph::BucketGraph{{size: {}; degree: {}; hasher: {}}}",
+            self.nodes,
+            self.base_degree,
+            H::name(),
         )
     }
 }

--- a/storage-proofs/src/hasher/blake2b.rs
+++ b/storage-proofs/src/hasher/blake2b.rs
@@ -2,6 +2,10 @@ use blake2::Blake2b;
 
 use super::{DigestHasher, Digester};
 
-impl Digester for Blake2b {}
+impl Digester for Blake2b {
+    fn name() -> String {
+        "Blake2b".into()
+    }
+}
 
 pub type Blake2bHasher = DigestHasher<Blake2b>;

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -195,7 +195,7 @@ impl HashFunction<Blake2sDomain> for Blake2sFunction {
         left: &[boolean::Boolean],
         right: &[boolean::Boolean],
         height: usize,
-        _params: &E::Params,
+        params: &E::Params,
     ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
         let mut preimage: Vec<boolean::Boolean> = vec![];
         let mut height_bytes = vec![];
@@ -226,9 +226,17 @@ impl HashFunction<Blake2sDomain> for Blake2sFunction {
             preimage.push(boolean::Boolean::Constant(false));
         }
 
+        Self::hash_circuit(cs, &preimage[..], params)
+    }
+
+    fn hash_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        mut cs: CS,
+        bits: &[boolean::Boolean],
+        _params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
         let personalization = vec![0u8; 8];
         let alloc_bits =
-            blake2s_circuit::blake2s(cs.namespace(|| "hash"), &preimage[..], &personalization)?;
+            blake2s_circuit::blake2s(cs.namespace(|| "hash"), &bits[..], &personalization)?;
         let fr = match alloc_bits[0].get_value() {
             Some(_) => {
                 let bits = alloc_bits

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::hash::Hasher as StdHasher;
 
 use bellman::{ConstraintSystem, SynthesisError};
-use blake2s_simd::{blake2s, Hash as Blake2sHash, Params as Blake2s, State};
+use blake2s_simd::{Hash as Blake2sHash, Params as Blake2s, State};
 use byteorder::{LittleEndian, WriteBytesExt};
 use merkle_light::hash::{Algorithm, Hashable};
 use pairing::bls12_381::{Bls12, Fr, FrRepr};
@@ -182,7 +182,12 @@ impl Into<Blake2sDomain> for Blake2sHash {
 
 impl HashFunction<Blake2sDomain> for Blake2sFunction {
     fn hash(data: &[u8]) -> Blake2sDomain {
-        blake2s(data).into()
+        Blake2s::new()
+            .hash_length(32)
+            .to_state()
+            .update(data)
+            .finalize()
+            .into()
     }
 
     fn hash_leaf_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -1,7 +1,280 @@
-use blake2::Blake2s;
+use std::fmt;
+use std::hash::Hasher as StdHasher;
 
-use super::{DigestHasher, Digester};
+use bellman::{ConstraintSystem, SynthesisError};
+use blake2s_simd::{blake2s, Hash as Blake2sHash, Params as Blake2s, State};
+use byteorder::{LittleEndian, WriteBytesExt};
+use merkle_light::hash::{Algorithm, Hashable};
+use pairing::bls12_381::{Bls12, Fr, FrRepr};
+use pairing::{PrimeField, PrimeFieldRepr};
+use rand::{Rand, Rng};
+use sapling_crypto::circuit::{blake2s as blake2s_circuit, boolean, multipack, num};
+use sapling_crypto::jubjub::JubjubEngine;
 
-impl Digester for Blake2s {}
+use super::{Domain, HashFunction, Hasher};
+use crate::crypto::sloth;
+use crate::error::*;
 
-pub type Blake2sHasher = DigestHasher<Blake2s>;
+#[derive(Default, Copy, Clone, PartialEq, Eq, Debug)]
+pub struct Blake2sHasher {}
+
+impl Hasher for Blake2sHasher {
+    type Domain = Blake2sDomain;
+    type Function = Blake2sFunction;
+
+    fn name() -> String {
+        "Blake2sHasher".into()
+    }
+
+    fn kdf(data: &[u8], m: usize) -> Self::Domain {
+        assert_eq!(
+            data.len(),
+            32 * (1 + m),
+            "invalid input length: data.len(): {} m: {}",
+            data.len(),
+            m
+        );
+
+        <Self::Function as HashFunction<Self::Domain>>::hash(data)
+    }
+
+    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain, rounds: usize) -> Self::Domain {
+        // TODO: validate this is how sloth should work in this case
+        let k = (*key).into();
+        let c = (*ciphertext).into();
+
+        sloth::encode::<Bls12>(&k, &c, rounds).into()
+    }
+
+    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain, rounds: usize) -> Self::Domain {
+        // TODO: validate this is how sloth should work in this case
+        sloth::decode::<Bls12>(&(*key).into(), &(*ciphertext).into(), rounds).into()
+    }
+}
+
+#[derive(Clone)]
+pub struct Blake2sFunction(State);
+
+impl Default for Blake2sFunction {
+    fn default() -> Self {
+        Blake2sFunction(Blake2s::new().hash_length(32).to_state())
+    }
+}
+
+impl PartialEq for Blake2sFunction {
+    fn eq(&self, other: &Self) -> bool {
+        format!("{:?}", self) == format!("{:?}", other)
+    }
+}
+
+impl Eq for Blake2sFunction {}
+
+impl fmt::Debug for Blake2sFunction {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Blake2sFunction({:?})", self.0)
+    }
+}
+
+impl StdHasher for Blake2sFunction {
+    #[inline]
+    fn write(&mut self, msg: &[u8]) {
+        self.0.update(msg);
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        unreachable!("unused by Function -- should never be called")
+    }
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug, PartialOrd, Ord, Default, Serialize, Deserialize)]
+pub struct Blake2sDomain(pub [u8; 32]);
+
+impl Blake2sDomain {
+    fn trim_to_fr32(&mut self) {
+        // strip last two bits, to ensure result is in Fr.
+        self.0[31] &= 0b0011_1111;
+    }
+}
+
+impl Rand for Blake2sDomain {
+    fn rand<R: Rng>(rng: &mut R) -> Self {
+        // generating an Fr and converting it, to ensure we stay in the field
+        rng.gen::<Fr>().into()
+    }
+}
+
+impl AsRef<[u8]> for Blake2sDomain {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl Hashable<Blake2sFunction> for Blake2sDomain {
+    fn hash(&self, state: &mut Blake2sFunction) {
+        state.write(self.as_ref())
+    }
+}
+
+impl From<Fr> for Blake2sDomain {
+    fn from(val: Fr) -> Self {
+        let mut res = Self::default();
+        val.into_repr().write_le(&mut res.0[0..32]).unwrap();
+
+        res
+    }
+}
+
+impl From<FrRepr> for Blake2sDomain {
+    fn from(val: FrRepr) -> Self {
+        let mut res = Self::default();
+        val.write_le(&mut res.0[0..32]).unwrap();
+
+        res
+    }
+}
+
+impl From<Blake2sDomain> for Fr {
+    fn from(val: Blake2sDomain) -> Self {
+        let mut res = FrRepr::default();
+        res.read_le(&val.0[0..32]).unwrap();
+
+        Fr::from_repr(res).unwrap()
+    }
+}
+
+impl Domain for Blake2sDomain {
+    fn serialize(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    fn into_bytes(&self) -> Vec<u8> {
+        self.0.to_vec()
+    }
+
+    fn try_from_bytes(raw: &[u8]) -> Result<Self> {
+        if raw.len() != 32 {
+            return Err(Error::InvalidInputSize);
+        }
+        let mut res = Blake2sDomain::default();
+        res.0.copy_from_slice(&raw[0..32]);
+        Ok(res)
+    }
+
+    fn write_bytes(&self, dest: &mut [u8]) -> Result<()> {
+        if dest.len() < 32 {
+            return Err(Error::InvalidInputSize);
+        }
+        dest[0..32].copy_from_slice(&self.0[..]);
+        Ok(())
+    }
+}
+
+impl Into<Blake2sDomain> for Blake2sHash {
+    fn into(self) -> Blake2sDomain {
+        let mut res = Blake2sDomain::default();
+        res.0[..].copy_from_slice(self.as_ref());
+        res.trim_to_fr32();
+
+        res
+    }
+}
+
+impl HashFunction<Blake2sDomain> for Blake2sFunction {
+    fn hash(data: &[u8]) -> Blake2sDomain {
+        blake2s(data).into()
+    }
+
+    fn hash_leaf_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        mut cs: CS,
+        left: &[boolean::Boolean],
+        right: &[boolean::Boolean],
+        height: usize,
+        _params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
+        let mut preimage: Vec<boolean::Boolean> = vec![];
+        let mut height_bytes = vec![];
+        height_bytes
+            .write_u64::<LittleEndian>(height as u64)
+            .expect("failed to write height");
+
+        preimage.extend(
+            multipack::bytes_to_bits_le(&height_bytes)
+                .iter()
+                .enumerate()
+                .map(|(i, b)| {
+                    boolean::AllocatedBit::alloc(
+                        cs.namespace(|| format!("height_bit {}", i)),
+                        Some(*b),
+                    )
+                    .map(boolean::Boolean::Is)
+                })
+                .collect::<::std::result::Result<Vec<boolean::Boolean>, _>>()?,
+        );
+        preimage.extend_from_slice(left);
+        while preimage.len() % 8 != 0 {
+            preimage.push(boolean::Boolean::Constant(false));
+        }
+
+        preimage.extend_from_slice(right);
+        while preimage.len() % 8 != 0 {
+            preimage.push(boolean::Boolean::Constant(false));
+        }
+
+        let personalization = vec![0u8; 8];
+        let alloc_bits =
+            blake2s_circuit::blake2s(cs.namespace(|| "hash"), &preimage[..], &personalization)?;
+        let fr = match alloc_bits[0].get_value() {
+            Some(_) => {
+                let bits = alloc_bits
+                    .iter()
+                    .map(|v| v.get_value().unwrap())
+                    .collect::<Vec<bool>>();
+                // TODO: figure out if we can avoid this
+                let frs = multipack::compute_multipacking::<E>(&bits);
+                Ok(frs[0])
+            }
+            None => Err(SynthesisError::AssignmentMissing),
+        };
+
+        num::AllocatedNum::<E>::alloc(cs.namespace(|| "num"), || fr)
+    }
+}
+
+impl Algorithm<Blake2sDomain> for Blake2sFunction {
+    #[inline]
+    fn hash(&mut self) -> Blake2sDomain {
+        self.0.clone().finalize().into()
+    }
+
+    #[inline]
+    fn reset(&mut self) {
+        self.0 = Blake2s::new().hash_length(32).to_state()
+    }
+
+    fn leaf(&mut self, leaf: Blake2sDomain) -> Blake2sDomain {
+        leaf
+    }
+
+    fn node(&mut self, left: Blake2sDomain, right: Blake2sDomain, height: usize) -> Blake2sDomain {
+        height.hash(self);
+
+        left.hash(self);
+        right.hash(self);
+        self.hash()
+    }
+}
+
+impl From<[u8; 32]> for Blake2sDomain {
+    #[inline]
+    fn from(val: [u8; 32]) -> Self {
+        Blake2sDomain(val)
+    }
+}
+
+impl From<Blake2sDomain> for [u8; 32] {
+    #[inline]
+    fn from(val: Blake2sDomain) -> Self {
+        val.0
+    }
+}

--- a/storage-proofs/src/hasher/digest.rs
+++ b/storage-proofs/src/hasher/digest.rs
@@ -193,6 +193,13 @@ impl<D: Digester> HashFunction<DigestDomain> for DigestFunction<D> {
         _height: usize,
         _params: &E::Params,
     ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
+        unimplemented!("circuit leaf hash");
+    }
+    fn hash_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        _cs: CS,
+        _bits: &[boolean::Boolean],
+        _params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
         unimplemented!("circuit hash");
     }
 }

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -13,9 +13,10 @@ use sapling_crypto::pedersen_hash::{pedersen_hash, Personalization};
 use serde::de::{Deserialize, Deserializer};
 use serde::ser::Serializer;
 
-use super::{Domain, HashFunction, Hasher};
+use crate::circuit::pedersen::pedersen_md_no_padding;
 use crate::crypto::{kdf, pedersen, sloth};
 use crate::error::{Error, Result};
+use crate::hasher::{Domain, HashFunction, Hasher};
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct PedersenHasher {}
@@ -236,6 +237,14 @@ impl HashFunction<PedersenDomain> for PedersenFunction {
         )?
         .get_x()
         .clone())
+    }
+
+    fn hash_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        cs: CS,
+        bits: &[boolean::Boolean],
+        params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
+        pedersen_md_no_padding(cs, params, bits)
     }
 }
 

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -2,7 +2,11 @@ use sha2::Sha256;
 
 use super::{DigestHasher, Digester};
 
-impl Digester for Sha256 {}
+impl Digester for Sha256 {
+    fn name() -> String {
+        "Sha256".into()
+    }
+}
 
 pub type Sha256Hasher = DigestHasher<Sha256>;
 

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -1,9 +1,13 @@
-use crate::error::Result;
+use bellman::{ConstraintSystem, SynthesisError};
 use merkle_light::hash::{Algorithm as LightAlgorithm, Hashable as LightHashable};
 use pairing::bls12_381::{Fr, FrRepr};
 use rand::Rand;
+use sapling_crypto::circuit::{boolean, num};
+use sapling_crypto::jubjub::JubjubEngine;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
+
+use crate::error::Result;
 
 pub trait Domain:
     Ord
@@ -46,6 +50,14 @@ pub trait HashFunction<T: Domain>:
         data.hash(&mut a);
         a.hash()
     }
+
+    fn hash_leaf_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        cs: CS,
+        left: &[boolean::Boolean],
+        right: &[boolean::Boolean],
+        height: usize,
+        params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError>;
 }
 
 pub trait Hasher: Clone + ::std::fmt::Debug + Eq + Default + Send + Sync {
@@ -55,4 +67,6 @@ pub trait Hasher: Clone + ::std::fmt::Debug + Eq + Default + Send + Sync {
     fn kdf(data: &[u8], m: usize) -> Self::Domain;
     fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain, rounds: usize) -> Self::Domain;
     fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain, rounds: usize) -> Self::Domain;
+
+    fn name() -> String;
 }

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -58,6 +58,12 @@ pub trait HashFunction<T: Domain>:
         height: usize,
         params: &E::Params,
     ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError>;
+
+    fn hash_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        cs: CS,
+        bits: &[boolean::Boolean],
+        params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError>;
 }
 
 pub trait Hasher: Clone + ::std::fmt::Debug + Eq + Default + Send + Sync {


### PR DESCRIPTION
Basic tests are passing. Needs some more checks

- make por and drgporep circuits abstract over the hasher
- implement blake2s hasher using blake2s_simd


Ref #531  