### PR TITLE
publish v10 Groth parameters + paramcache always generates PoSt parameters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
       - run:
           name: Ensure cache is hydrated with PoRep and PoSt Groth parameters (for test)
           command: |
-            cargo run --release --color=always --package filecoin-proofs --bin paramcache -- --include-post --test-only
+            cargo run --release --color=always --package filecoin-proofs --bin paramcache -- --test-only
       - run:
           name: run regression tests (examples) against FFI-exposed filecoin-proofs API
           command: RUSTFLAGS="-Z sanitizer=leak" cargo run --release --package filecoin-proofs --example ffi --target x86_64-unknown-linux-gnu

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -74,28 +74,15 @@ pub fn main() {
                 .help("generate only parameters useful for testing")
                 .takes_value(false),
         )
-        .arg(
-            Arg::with_name("include-post")
-                .long("include-post")
-                .help("generate PoSt parameters in addition to PoRep")
-                .takes_value(false),
-        )
         .get_matches();
 
-    let include_post: bool = matches.is_present("include-post");
     let test_only: bool = matches.is_present("test-only");
 
     cache_porep_params(TEST_SECTOR_SIZE);
+    cache_post_params(TEST_SECTOR_SIZE);
 
     if !test_only {
         cache_porep_params(LIVE_SECTOR_SIZE);
-    }
-
-    if include_post {
-        cache_post_params(TEST_SECTOR_SIZE);
-
-        if !test_only {
-            cache_post_params(LIVE_SECTOR_SIZE);
-        }
+        cache_post_params(LIVE_SECTOR_SIZE);
     }
 }

--- a/parameters.json
+++ b/parameters.json
@@ -1,18 +1,34 @@
 {
-  "v9-zigzag-proof-of-replication-f8b6b5b4f1015da3984944b4aef229b63ce950f65c7f41055a995718a452204d": {
-    "cid": "QmY8UR7sPGgfeoVB381mrvcdVK4QF28qV5cdoyZFfPuUfM",
-    "digest": "8a8e8c1f71927fd93c3c6f0d0f8c3ece"
+  "v10-zigzag-proof-of-replication-b8f3290335d11af86f8193cc2c3bbf451b4b2cc33e59e8ecad060999f3bebe77": {
+    "cid": "QmeAwbo2CM4t58kV7byr1X2beA7pzbGvStCVSDSG4ydu2E",
+    "digest": "a30003a7b2b2512cd5e66cfefdd9fe7b"
   },
-  "v9-zigzag-proof-of-replication-f8b6b5b4f1015da3984944b4aef229b63ce950f65c7f41055a995718a452204d.vk": {
-    "cid": "QmUtdjzNLxVDRJV1zYZaZTcuVDZUuvtcfou5Fcdgqph7Ws",
-    "digest": "de91e6df768b455e14748e78693d272b"
+  "v10-zigzag-proof-of-replication-b8f3290335d11af86f8193cc2c3bbf451b4b2cc33e59e8ecad060999f3bebe77.vk": {
+    "cid": "QmeubWLDsLvL5ULFote1Gce1RfNKcHicCkcwsNyBkhtWuv",
+    "digest": "61eb4d1b2862feb1149284108c29386b"
   },
-  "v9-zigzag-proof-of-replication-52431242c129794fe51d373ae29953f2ff52abd94c78756e318ce45f3e4946d8.vk": {
-    "cid": "QmVLfMXHHthzpZo2raxZkF34KLNJQTuNJzkhTTMzxhWfVi",
-    "digest": "76684f54c4b473693a53dfe52e21bb54"
+  "v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6.vk": {
+    "cid": "QmTKL1MiWSWFUMEECZPaBX6ddoZy9HCAA4mdaW65BKDoEp",
+    "digest": "2684b87a68d3a02118584e524a3f073a"
   },
-  "v9-zigzag-proof-of-replication-52431242c129794fe51d373ae29953f2ff52abd94c78756e318ce45f3e4946d8": {
-    "cid": "QmP7yBN63YRmnQt7p7ZTQWgahwniNgSoJL5KD1b8eKmGWr",
-    "digest": "ad932f2b7b635ee0219cc8d349d06f80"
+  "v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6": {
+    "cid": "QmPuZ1fZGVDBTjsARTWuMesKjaXqUeNENsQrWBLh7PAjEU",
+    "digest": "71f6673c73376cca102390150174bbe4"
+  },
+  "v10-zigzag-proof-of-replication-733b035c440d8b0e4a03ab5e4c58553b6c674cc64bd6a130e8764f7abeb38f69.vk": {
+    "cid": "QmRkiXN7RTWjTgTz3DTjCjDaVNS5vNd8z174UrZLyMowmS",
+    "digest": "d9f8f2c3a74c45cce4dfa26b65ccc3c9"
+  },
+  "v10-vdf-post-912e5a392c09cbfa0bf369ac77f939a45e0f2aec968cf3846cbe356a19b76685": {
+    "cid": "QmP1PkagfiC9cUEh3r7NEWaJfnBGEnqfABxXxh3PSoiMtX",
+    "digest": "ff7fa52e9bf2a3b5261f6d5740156f79"
+  },
+  "v10-zigzag-proof-of-replication-733b035c440d8b0e4a03ab5e4c58553b6c674cc64bd6a130e8764f7abeb38f69": {
+    "cid": "QmbPHbry667qc7JEhYDWpvs6mj6rD9UQRi9ZpQb6q6pcoq",
+    "digest": "9268d86f4e3c23eb8483d65834e27c0d"
+  },
+  "v10-vdf-post-912e5a392c09cbfa0bf369ac77f939a45e0f2aec968cf3846cbe356a19b76685.vk": {
+    "cid": "QmaNXg87KFw4pKxa9mXThprpDns7aJZCN5k9WCtneMBkoY",
+    "digest": "3e97aff1d9d2d712163befee897c8b5d"
   }
 }


### PR DESCRIPTION
Fixes #510 

## Why does this PR exist?

- dig updated Groth param cache-keys, so we needed to regen parameters
- adding PoSt params to `parameters.json`
- enabling PoSt (soon) in go-filecoin will require PoSt Groth params