### PR TITLE
various improvements to paramfetch

### DIFF
--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -39,6 +39,12 @@ Defaults to '{}'
                 .long("all")
                 .help("Download all available parameter files"),
         )
+        .arg(
+            Arg::with_name("verbose")
+                .short("a")
+                .long("verbose")
+                .help("Print diagnostic information to stdout"),
+        )
         .get_matches();
 
     match fetch(&matches) {
@@ -83,8 +89,15 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
             print!("downloading parameter file... ");
             io::stdout().flush().unwrap();
 
-            match fetch_parameter_file(&parameter_map, &parameter_id) {
-                Ok(_) => println!("ok\n"),
+            match spawn_fetch_parameter_file(
+                matches.is_present("verbose"),
+                &parameter_map,
+                &parameter_id,
+            ) {
+                Ok(mut child) => match child.wait() {
+                    Ok(_) => println!("ok\n"),
+                    Err(err) => println!("error: {}\n", err),
+                },
                 Err(err) => println!("error: {}\n", err),
             }
         }

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -131,8 +131,30 @@ pub fn spawn_fetch_parameter_file(
 
     create_dir_all(parameter_cache_dir())?;
 
+    let output_styling = if is_verbose {
+        &["--verbose", "--progress-bar"]
+    } else {
+        &["--silent", "--show-error"]
+    };
+
+
+    let connect_timeout = &[
+        "--connect-timeout",
+        "30",
+    ];
+
+    // time out if speed stays at below 1000 bytes/second for >= 15 seconds
+    let speed_timeout = &[
+        "--speed-time",
+        "15",
+        "--speed-limit",
+        "1000",
+    ];
+
     Command::new("curl")
-        .args(if is_verbose { &["--verbose", "--progress-bar"] } else { &["--silent", "--show-error"] })
+        .args(output_styling)
+        .args(connect_timeout)
+        .args(speed_timeout)
         .arg("--output")
         .arg(&path)
         .arg(format!("https://ipfs.io/ipfs/{}", parameter_data.cid))

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -132,8 +132,8 @@ pub fn spawn_fetch_parameter_file(
     create_dir_all(parameter_cache_dir())?;
 
     Command::new("curl")
-        .arg(if is_verbose { "-v" } else { "-s" })
-        .arg("-o")
+        .args(if is_verbose { &["--verbose", "--progress-bar"] } else { &["--silent", "--show-error"] })
+        .arg("--output")
         .arg(&path)
         .arg(format!("https://ipfs.io/ipfs/{}", parameter_data.cid))
         .stdout(Stdio::inherit())

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -137,19 +137,10 @@ pub fn spawn_fetch_parameter_file(
         &["--silent", "--show-error"]
     };
 
-
-    let connect_timeout = &[
-        "--connect-timeout",
-        "30",
-    ];
+    let connect_timeout = &["--connect-timeout", "30"];
 
     // time out if speed stays at below 1000 bytes/second for >= 15 seconds
-    let speed_timeout = &[
-        "--speed-time",
-        "15",
-        "--speed-limit",
-        "1000",
-    ];
+    let speed_timeout = &["--speed-time", "15", "--speed-limit", "1000"];
 
     Command::new("curl")
         .args(output_styling)


### PR DESCRIPTION
Fixes [go-filecoin issue 2041](https://github.com/filecoin-project/go-filecoin/issues/2041).

## Why is this PR needed?

1. `paramfetch` didn't set any curl timeout, so IPFS gateway problems (post-connection) meant `paramfetch` would hang indefinitely
1. `paramfetch` didn't give users any diagnostic information from curl, such as URL, request metadata, transfer progress, etc.

## What's in this PR?

This PR adds a new flag to `paramfetch` which makes it print curl-related stuff to stdout:

```
07:42 $ yes | ./target/release/paramfetch --all --retry --verbose
checking 8 parameter files...

checking: v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6.vk
does parameter file exist... yes
is parameter file valid... yes

checking: v10-zigzag-proof-of-replication-b8f3290335d11af86f8193cc2c3bbf451b4b2cc33e59e8ecad060999f3bebe77
does parameter file exist... no

checking: v10-vdf-post-912e5a392c09cbfa0bf369ac77f939a45e0f2aec968cf3846cbe356a19b76685.vk
does parameter file exist... yes
is parameter file valid... yes

checking: v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6
does parameter file exist... no

checking: v10-zigzag-proof-of-replication-b8f3290335d11af86f8193cc2c3bbf451b4b2cc33e59e8ecad060999f3bebe77.vk
does parameter file exist... yes
is parameter file valid... yes

checking: v10-zigzag-proof-of-replication-733b035c440d8b0e4a03ab5e4c58553b6c674cc64bd6a130e8764f7abeb38f69.vk
does parameter file exist... yes
is parameter file valid... yes

checking: v10-zigzag-proof-of-replication-733b035c440d8b0e4a03ab5e4c58553b6c674cc64bd6a130e8764f7abeb38f69
does parameter file exist... no

checking: v10-vdf-post-912e5a392c09cbfa0bf369ac77f939a45e0f2aec968cf3846cbe356a19b76685
does parameter file exist... yes
is parameter file valid... no

4 parameter files to fetch...

fetching: v10-zigzag-proof-of-replication-b8f3290335d11af86f8193cc2c3bbf451b4b2cc33e59e8ecad060999f3bebe77
downloading parameter file... *   Trying 2602:fea2:2::1...
* TCP_NODELAY set
* Connected to ipfs.io (2602:fea2:2::1) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
} [213 bytes data]
* TLSv1.2 (IN), TLS handshake, Server hello (2):
{ [102 bytes data]
* TLSv1.2 (IN), TLS handshake, Certificate (11):
{ [2656 bytes data]
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
{ [300 bytes data]
* TLSv1.2 (IN), TLS handshake, Server finished (14):
{ [4 bytes data]
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
} [37 bytes data]
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
} [1 bytes data]
* TLSv1.2 (OUT), TLS handshake, Finished (20):
} [16 bytes data]
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
{ [1 bytes data]
* TLSv1.2 (IN), TLS handshake, Finished (20):
{ [16 bytes data]
* SSL connection using TLSv1.2 / ECDHE-RSA-AES256-GCM-SHA384
* ALPN, server accepted to use h2
* Server certificate:
*  subject: CN=ipfs.io
*  start date: Feb 13 16:08:49 2019 GMT
*  expire date: May 14 16:08:49 2019 GMT
*  subjectAltName: host "ipfs.io" matched cert's "ipfs.io"
*  issuer: C=US; O=Let's Encrypt; CN=Let's Encrypt Authority X3
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7fd140002c00)
> GET /ipfs/QmeAwbo2CM4t58kV7byr1X2beA7pzbGvStCVSDSG4ydu2E HTTP/2
> Host: ipfs.io
> User-Agent: curl/7.54.0
> Accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
< HTTP/2 200
< server: nginx
< date: Wed, 13 Mar 2019 14:42:48 GMT
< content-type: application/octet-stream
< content-length: 770899320
< accept-ranges: bytes
< access-control-allow-methods: GET
< cache-control: public, max-age=29030400, immutable
< etag: "QmeAwbo2CM4t58kV7byr1X2beA7pzbGvStCVSDSG4ydu2E"
< last-modified: Thu, 01 Jan 1970 00:00:01 GMT
< suborigin: ipfs000bciqowpsidepnncehugnts2ibpgnffkyxohtimxurvoresrewr7b6pvy
< x-ipfs-gateway-host: gateway-bank1-sjc1
< x-ipfs-path: /ipfs/QmeAwbo2CM4t58kV7byr1X2beA7pzbGvStCVSDSG4ydu2E
< access-control-allow-origin: *
< access-control-allow-methods: GET, POST, OPTIONS
< access-control-allow-headers: X-Requested-With, Range, Content-Range, X-Chunked-Output, X-Stream-Output
< access-control-expose-headers: Content-Range, X-Chunked-Output, X-Stream-Output
< x-ipfs-pop: gateway-bank1-sjc1
< strict-transport-security: max-age=31536000; includeSubDomains; preload
<
{ [3232 bytes data]
###                                                                        4.7%
```