### PR TITLE
deps: lock `merkle_light` dependency to the current `master` commit

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -12,7 +12,7 @@ bitvec = "0.5"
 sapling-crypto = { git = "https://github.com/zcash-hackworks/sapling-crypto", branch = "master" }
 rand = "0.4"
 libc = "0.2"
-merkle_light = { git = "https://github.com/filecoin-project/merkle_light", branch = "master" }
+merkle_light = { git = "https://github.com/filecoin-project/merkle_light", rev = "63a609decf3cc552b0aa79477b828f4a493f725d" }
 failure = "0.1"
 bellman = "0.1"
 byteorder = "1"


### PR DESCRIPTION
Lock `merkle_light` dependency to the current `master` commit to land some API-braking changes in https://github.com/filecoin-project/merkle_light/pull/13, https://github.com/filecoin-project/rust-fil-proofs/pull/529 will restore it to `master` once everything is working as expected (or preferably, we'll cut a stable release for `merkle_light` to stabilize this dependency).