### PR TITLE
Feat/gf1586 integrate real post

### DIFF
--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -313,7 +313,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
         assert_eq!(1, (*resp).sectors_len);
     }
 
-    // generate and then verify a proof-of-spacetime for the sealed sectors
+    // generate and then verify a proof-of-spacetime for the sealed sector
     {
         let resp = get_sealed_sectors(sector_builder_b);
         defer!(destroy_get_sealed_sectors_response(resp));

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -293,21 +293,6 @@ pub fn generate_post(
     generate_post_collect_output(n, fixed_output)
 }
 
-pub fn fake_generate_post(
-    dynamic: GeneratePoStDynamicSectorsCountInput,
-) -> error::Result<GeneratePoStDynamicSectorsCountOutput> {
-    let faults: Vec<u64> = if !dynamic.input_parts.is_empty() {
-        vec![0]
-    } else {
-        Default::default()
-    };
-
-    Ok(GeneratePoStDynamicSectorsCountOutput {
-        proofs: vec![[42; 192]],
-        faults,
-    })
-}
-
 pub fn verify_post(
     dynamic: VerifyPoStDynamicSectorsCountInput,
 ) -> error::Result<VerifyPoStDynamicSectorsCountOutput> {

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -12,6 +12,7 @@ use sapling_crypto::jubjub::JubjubBls12;
 
 use crate::api::post_adapter::*;
 use crate::error;
+use crate::error::ExpectWithBacktrace;
 use crate::FCP_LOG;
 use sector_base::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount};
 use sector_base::api::sector_store::SectorConfig;
@@ -401,7 +402,13 @@ fn verify_post_fixed_sectors_count(
     let commitments = fixed
         .comm_rs
         .iter()
-        .map(|comm_r| PedersenDomain(bytes_into_fr::<Bls12>(comm_r).unwrap().into_repr()))
+        .map(|comm_r| {
+            PedersenDomain(
+                bytes_into_fr::<Bls12>(comm_r)
+                    .expects("could not could not map comm_r to Fr")
+                    .into_repr(),
+            )
+        })
         .collect::<Vec<PedersenDomain>>();
 
     let public_inputs = vdf_post::PublicInputs::<PedersenDomain> {

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -5,12 +5,14 @@ use crate::api::responses::FFIPieceMetadata;
 use crate::api::responses::FFISealStatus;
 use crate::api::sector_builder::metadata::SealStatus;
 use crate::api::sector_builder::SectorBuilder;
+use crate::FCP_LOG;
 use ffi_toolkit::rust_str_to_c_str;
 use ffi_toolkit::{c_str_to_rust_str, raw_ptr};
 use sector_base::api::disk_backed_storage::new_sector_config;
 use sector_base::api::disk_backed_storage::ConfiguredStore;
 
 use libc;
+use slog::*;
 use std::ffi::CString;
 use std::mem;
 use std::ptr;
@@ -49,6 +51,8 @@ pub unsafe extern "C" fn verify_seal(
     sector_id: &[u8; 31],
     proof: &[u8; API_POREP_PROOF_BYTES],
 ) -> *mut responses::VerifySealResponse {
+    info!(FCP_LOG, "verify_seal: {}", "start"; "target" => "FFI");
+
     let mut response: responses::VerifySealResponse = Default::default();
 
     if let Some(cfg) = cfg_ptr.as_ref() {
@@ -85,6 +89,8 @@ pub unsafe extern "C" fn verify_seal(
         mem::forget(msg);
     }
 
+    info!(FCP_LOG, "verify_seal: {}", "finish"; "target" => "FFI");
+
     raw_ptr(response)
 }
 
@@ -97,6 +103,8 @@ pub unsafe extern "C" fn generate_post(
     flattened_comm_rs_len: libc::size_t,
     challenge_seed: &[u8; 32],
 ) -> *mut responses::GeneratePoStResponse {
+    info!(FCP_LOG, "generate_post: {}", "start"; "target" => "FFI");
+
     let comm_rs = from_raw_parts(flattened_comm_rs_ptr, flattened_comm_rs_len)
         .iter()
         .step_by(32)
@@ -133,6 +141,8 @@ pub unsafe extern "C" fn generate_post(
         }
     }
 
+    info!(FCP_LOG, "generate_post: {}", "finish"; "target" => "FFI");
+
     raw_ptr(response)
 }
 
@@ -149,6 +159,8 @@ pub unsafe extern "C" fn verify_post(
     faults_ptr: *const u64,
     faults_len: libc::size_t,
 ) -> *mut responses::VerifyPoSTResponse {
+    info!(FCP_LOG, "verify_post: {}", "start"; "target" => "FFI");
+
     let mut response: responses::VerifyPoSTResponse = Default::default();
 
     if let Some(cfg) = cfg_ptr.as_ref() {
@@ -209,6 +221,8 @@ pub unsafe extern "C" fn verify_post(
         response.error_msg = msg.as_ptr();
         mem::forget(msg);
     }
+
+    info!(FCP_LOG, "verfiy_post: {}", "finish"; "target" => "FFI");
 
     Box::into_raw(Box::new(response))
 }

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -188,7 +188,7 @@ impl SectorMetadataManager {
         let mut seed = [0; 32];
         seed.copy_from_slice(challenge_seed);
 
-        let output = internal::fake_generate_post(GeneratePoStDynamicSectorsCountInput {
+        let output = internal::generate_post(GeneratePoStDynamicSectorsCountInput {
             sector_bytes: self.sector_store.inner.config().sector_bytes(),
             challenge_seed: seed,
             input_parts,


### PR DESCRIPTION
Fixes the rust-fil-proofs side of [this go-filecoin story](
https://github.com/filecoin-project/go-filecoin/issues/1586).

## What's in this PR?

1. Allow API consumers to call in to real PoSt generation and verification calls
1. Delete the old, fake PoSt generation function
1. Add some logging at the FFI layer using language that API consumers will grok

## Why's this PR needed?

1. API consumers are ready to generate and verify proofs!