### PR TITLE
shortflag for --verbose should be -v, not -a

### DIFF
--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -41,7 +41,7 @@ Defaults to '{}'
         )
         .arg(
             Arg::with_name("verbose")
-                .short("a")
+                .short("v")
                 .long("verbose")
                 .help("Print diagnostic information to stdout"),
         )


### PR DESCRIPTION
Fixes #556 

## What's in this PR?

- fix short flag for `--verbose` option, which should have been `-v` and not `-a`