### PR TITLE
fix misspellings of "verifiable" and "verify"

### DIFF
--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -222,7 +222,7 @@ pub unsafe extern "C" fn verify_post(
         mem::forget(msg);
     }
 
-    info!(FCP_LOG, "verfiy_post: {}", "finish"; "target" => "FFI");
+    info!(FCP_LOG, "verify_post: {}", "finish"; "target" => "FFI");
 
     Box::into_raw(Box::new(response))
 }

--- a/storage-proofs/src/vdf.rs
+++ b/storage-proofs/src/vdf.rs
@@ -3,7 +3,7 @@ use crate::hasher::Domain;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
-/// Generic trait to represent any Verfiable Delay Function (VDF).
+/// Generic trait to represent any Verifiable Delay Function (VDF).
 pub trait Vdf<T: Domain>: Clone + ::std::fmt::Debug {
     type SetupParams: Clone + ::std::fmt::Debug;
     type PublicParams: Clone + ::std::fmt::Debug;


### PR DESCRIPTION
Fixes #568 

## Notes

- spelling "misspelling" was the most difficult part of this PR