### PR TITLE
refactor(storage_proofs): make fixed node size in drgraph more explicit

### DIFF
--- a/storage-proofs/src/error.rs
+++ b/storage-proofs/src/error.rs
@@ -14,8 +14,6 @@ pub enum Error {
         _0, _1, _2
     )]
     InvalidMerkleTreeArgs(usize, usize, usize),
-    #[fail(display = "invalid node size ({}), must be 16, 32 or 64", _0)]
-    InvalidNodeSize(usize),
     #[fail(display = "{}", _0)]
     Synthesis(#[cause] SynthesisError),
     #[fail(display = "{}", _0)]


### PR DESCRIPTION
The node size in the depth robust graph was already hard-coded to 32 bytes,
but this value was still used on a few occasions as a magic number. Change
the code to rely on those 32 bytes which is defined by the NODE_SIZE constant.

I'm not sure if I should do those kind of refactors without having all the context,
please let me know.