### PR TITLE
break out packaging from publishing script

### DIFF
--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+TAR_PATH=/tmp/release
+TAR_FILE=/tmp/release.tar.gz
+
+mkdir -p $TAR_PATH
+mkdir -p $TAR_PATH/bin
+mkdir -p $TAR_PATH/include
+mkdir -p $TAR_PATH/lib/pkgconfig
+mkdir -p $TAR_PATH/misc
+
+cp parameters.json $TAR_PATH/misc/
+cp target/release/paramcache $TAR_PATH/bin/
+cp target/release/paramfetch $TAR_PATH/bin/
+cp target/release/libfilecoin_proofs.h $TAR_PATH/include/
+cp target/release/libfilecoin_proofs.a $TAR_PATH/lib/
+cp target/release/libfilecoin_proofs.pc $TAR_PATH/lib/pkgconfig
+
+pushd $TAR_PATH
+
+tar -czf $TAR_FILE ./*
+
+popd

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
 
-TAR_PATH=/tmp/release
-TAR_FILE=/tmp/release.tar.gz
+if [ -z "$1" ]; then
+  TAR_FILE=`mktemp`.tar.gz
+else
+  TAR_FILE=$1
+fi
+
+TAR_PATH=`mktemp -d`
 
 mkdir -p $TAR_PATH
 mkdir -p $TAR_PATH/bin
@@ -21,3 +26,7 @@ pushd $TAR_PATH
 tar -czf $TAR_FILE ./*
 
 popd
+
+rm -rf $TAR_PATH
+
+echo $TAR_FILE

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
 
+set -e
+
 RELEASE_BRANCH="master"
 RELEASE_NAME="$CIRCLE_PROJECT_REPONAME-`uname`"
-RELEASE_PATH="$CIRCLE_ARTIFACTS/$RELEASE_NAME"
-RELEASE_FILE="$RELEASE_PATH.tar.gz"
+RELEASE_FILE="/tmp/$RELEASE_NAME.tar.gz"
 RELEASE_TAG="${CIRCLE_SHA1:0:16}"
 
 # make sure we're on the sanctioned branch
 if [ "$CIRCLE_BRANCH" != "$RELEASE_BRANCH" ]; then
-  echo "not on branch \"$BRANCH\", skipping publish"
+  echo "not on branch \"$RELEASE_BRANCH\", skipping publish"
   exit 0
 fi
 
@@ -20,24 +21,9 @@ fi
 
 echo "preparing release file"
 
-mkdir $RELEASE_PATH
-mkdir $RELEASE_PATH/bin
-mkdir $RELEASE_PATH/include
-mkdir -p $RELEASE_PATH/lib/pkgconfig
-mkdir $RELEASE_PATH/misc
+`dirname $0`/package-release.sh
 
-cp parameters.json $RELEASE_PATH/misc/
-cp target/release/paramcache $RELEASE_PATH/bin/
-cp target/release/paramfetch $RELEASE_PATH/bin/
-cp target/release/libfilecoin_proofs.h $RELEASE_PATH/include/
-cp target/release/libfilecoin_proofs.a $RELEASE_PATH/lib/
-cp target/release/libfilecoin_proofs.pc $RELEASE_PATH/lib/pkgconfig
-
-pushd $RELEASE_PATH
-
-tar -czf $RELEASE_FILE ./*
-
-popd
+mv /tmp/release.tar.gz $RELEASE_FILE
 
 echo "release file created: $RELEASE_FILE"
 

--- a/scripts/publish-release.sh
+++ b/scripts/publish-release.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 RELEASE_BRANCH="master"
 RELEASE_NAME="$CIRCLE_PROJECT_REPONAME-`uname`"
 RELEASE_FILE="/tmp/$RELEASE_NAME.tar.gz"
@@ -21,9 +19,7 @@ fi
 
 echo "preparing release file"
 
-`dirname $0`/package-release.sh
-
-mv /tmp/release.tar.gz $RELEASE_FILE
+`dirname $0`/package-release.sh $RELEASE_FILE
 
 echo "release file created: $RELEASE_FILE"
 


### PR DESCRIPTION
this is step 1ii of https://github.com/filecoin-project/go-filecoin/issues/2441

easier access to publishing `tar`s will remove the need for go-filecoin to understand the file structure of its dependencies