### PR TITLE
refactor(storage_proofs): move condition outside of the loop

### DIFF
--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -66,6 +66,10 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
     }
 
     /// Returns a sorted list of all parents of this node. The parents may be repeated.
+    ///
+    /// If a node doesn't have any parents, then this vector needs to return a vector where
+    /// the first element is the requested node. This will be used as indicator for nodes
+    /// without parents.
     fn parents(&self, node: usize) -> Vec<usize>;
 
     /// Returns the size of the graph (number of nodes).

--- a/storage-proofs/src/vde.rs
+++ b/storage-proofs/src/vde.rs
@@ -118,12 +118,9 @@ pub fn create_key<H: Hasher>(
     let mut hasher = Blake2s::new().hash_length(NODE_SIZE).to_state();
     hasher.update(id.as_ref());
 
-    for parent in parents.iter() {
-        // special super shitty case
-        // TODO: unsuck
-        if node == parents[0] {
-            // skip, as we would only write 0s
-        } else {
+    // The hash is about the parents, hence skip if a node doesn't have any parents
+    if node != parents[0] {
+        for parent in parents.iter() {
             let offset = data_at_node_offset(*parent);
             hasher.update(&data[offset..offset + NODE_SIZE]);
         }


### PR DESCRIPTION
Also adding documentation that a node without parents is indicated by
the first parent being the node itself.

I'd like to note that something here is strange though. When I was looking into "unsuckifying" the code, i first thought i could change the if statement to `node != 0` as only the first node doesn't have any parents. But that  would make the tests fail (more specifically the `zigzag_drgporep::tests::extract_all_*`ones).

It turns out that there's also parents where every element is a `2`, so it's not the first node, but it's self-referencing itself nonetheless. From reading the code at https://github.com/filecoin-project/rust-fil-proofs/blob/808dc884642acbf7b78b282eb7d933c7cc2cc3a7/storage-proofs/src/drgraph.rs#L118 I thought only the first node has no parents.