### PR TITLE
add piece through FFI w/out buffering piece into memory

### DIFF
--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -55,6 +55,7 @@ unsafe fn create_and_add_piece(
     let p = { String::from(file.path().to_str().unwrap().clone()) };
     let _ = file.write_all(&piece_bytes);
     let c_piece_path = rust_str_to_c_str(p);
+    defer!(free_c_str(c_piece_path));
 
     (
         piece_bytes.clone(),

--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -54,7 +54,7 @@ unsafe fn create_and_add_piece(
     let mut file = NamedTempFile::new().unwrap();
     let p = { String::from(file.path().to_str().unwrap().clone()) };
     let _ = file.write_all(&piece_bytes);
-    let c_piece_read_pipe = rust_str_to_c_str(p);
+    let c_piece_path = rust_str_to_c_str(p);
 
     (
         piece_bytes.clone(),
@@ -63,7 +63,7 @@ unsafe fn create_and_add_piece(
             sector_builder,
             c_piece_key,
             piece_bytes.len() as u64,
-            c_piece_read_pipe,
+            c_piece_path,
         ),
     )
 }

--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -15,6 +15,7 @@ include!(concat!(env!("OUT_DIR"), "/libfilecoin_proofs.rs"));
 use ffi_toolkit::c_str_to_rust_str;
 use ffi_toolkit::free_c_str;
 use ffi_toolkit::rust_str_to_c_str;
+use filecoin_proofs::error::ExpectWithBacktrace;
 use rand::{thread_rng, Rng};
 use std::env;
 use std::error::Error;
@@ -51,8 +52,8 @@ unsafe fn create_and_add_piece(
     defer!(free_c_str(c_piece_key));
 
     // write piece bytes to a temporary file
-    let mut file = NamedTempFile::new().unwrap();
-    let p = { String::from(file.path().to_str().unwrap().clone()) };
+    let mut file = NamedTempFile::new().expects("could not create named temp file");
+    let p = file.path().to_string_lossy().to_string();
     let _ = file.write_all(&piece_bytes);
     let c_piece_path = rust_str_to_c_str(p);
     defer!(free_c_str(c_piece_path));

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -676,6 +676,8 @@ mod tests {
     use std::fs::create_dir_all;
     use std::fs::File;
     use std::io::Read;
+    use std::io::Seek;
+    use std::io::SeekFrom;
     use std::io::Write;
     use std::thread;
     use tempfile::NamedTempFile;
@@ -726,10 +728,12 @@ mod tests {
                 BytesAmount::Offset(m) => make_random_bytes(max - m),
             };
 
+            // write contents to temp file and return mutable handle
             let mut file = {
                 let mut file = NamedTempFile::new().unwrap();
                 let _ = file.write_all(&contents);
-                File::open(file.path().to_str().unwrap()).unwrap()
+                let _ = file.seek(SeekFrom::Start(0)).unwrap();
+                file
             };
 
             assert_eq!(

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -726,8 +726,11 @@ mod tests {
                 BytesAmount::Offset(m) => make_random_bytes(max - m),
             };
 
-            let mut file = NamedTempFile::new().unwrap();
-            let _ = file.write_all(&contents);
+            let mut file = {
+                let mut file = NamedTempFile::new().unwrap();
+                let _ = file.write_all(&contents);
+                File::open(file.path().to_str().unwrap()).unwrap()
+            };
 
             assert_eq!(
                 contents.len(),
@@ -1073,7 +1076,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] // Slow test – run only when compiled for release.
     fn seal_unsealed_range_roundtrip_test() {
         seal_unsealed_range_roundtrip_aux(ConfiguredStore::Test, BytesAmount::Max);
         seal_unsealed_range_roundtrip_aux(ConfiguredStore::Test, BytesAmount::Offset(5));

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -727,13 +727,12 @@ mod tests {
             };
 
             let mut file = NamedTempFile::new().unwrap();
-            let path = { String::from(file.path().to_str().unwrap().clone()) };
             let _ = file.write_all(&contents);
 
             assert_eq!(
                 contents.len(),
                 usize::from(
-                    mgr.write_and_preprocess(&staged_access, &path)
+                    mgr.write_and_preprocess(&staged_access, &mut file)
                         .expect("failed to write and preprocess")
                 )
             );

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -676,7 +676,9 @@ mod tests {
     use std::fs::create_dir_all;
     use std::fs::File;
     use std::io::Read;
+    use std::io::Write;
     use std::thread;
+    use tempfile::NamedTempFile;
 
     struct Harness {
         prover_id: FrSafe,
@@ -724,10 +726,14 @@ mod tests {
                 BytesAmount::Offset(m) => make_random_bytes(max - m),
             };
 
+            let mut file = NamedTempFile::new().unwrap();
+            let path = { String::from(file.path().to_str().unwrap().clone()) };
+            let _ = file.write_all(&contents);
+
             assert_eq!(
                 contents.len(),
                 usize::from(
-                    mgr.write_and_preprocess(&staged_access, &contents)
+                    mgr.write_and_preprocess(&staged_access, &path)
                         .expect("failed to write and preprocess")
                 )
             );

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -1080,6 +1080,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore] // Slow test – run only when compiled for release.
     fn seal_unsealed_range_roundtrip_test() {
         seal_unsealed_range_roundtrip_aux(ConfiguredStore::Test, BytesAmount::Max);
         seal_unsealed_range_roundtrip_aux(ConfiguredStore::Test, BytesAmount::Offset(5));

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -730,9 +730,11 @@ mod tests {
 
             // write contents to temp file and return mutable handle
             let mut file = {
-                let mut file = NamedTempFile::new().unwrap();
+                let mut file = NamedTempFile::new().expects("could not create named temp file");
                 let _ = file.write_all(&contents);
-                let _ = file.seek(SeekFrom::Start(0)).unwrap();
+                let _ = file
+                    .seek(SeekFrom::Start(0))
+                    .expects("failed to seek to beginning of file");
                 file
             };
 

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -286,15 +286,19 @@ pub unsafe extern "C" fn destroy_sector_builder(ptr: *mut SectorBuilder) {
 pub unsafe extern "C" fn add_piece(
     ptr: *mut SectorBuilder,
     piece_key: *const libc::c_char,
-    piece_ptr: *const u8,
-    piece_len: libc::size_t,
+    piece_bytes_amount: u64,
+    piece_path: *const libc::c_char,
 ) -> *mut responses::AddPieceResponse {
     let piece_key = c_str_to_rust_str(piece_key);
-    let piece_bytes = from_raw_parts(piece_ptr, piece_len);
+    let piece_path = c_str_to_rust_str(piece_path);
 
     let mut response: responses::AddPieceResponse = Default::default();
 
-    match (*ptr).add_piece(String::from(piece_key), piece_bytes) {
+    match (*ptr).add_piece(
+        String::from(piece_key),
+        piece_bytes_amount,
+        String::from(piece_path),
+    ) {
         Ok(sector_id) => {
             response.status_code = FCPResponseStatus::FCPNoError;
             response.sector_id = sector_id;

--- a/filecoin-proofs/src/api/sector_builder/helpers/add_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/add_piece.rs
@@ -13,12 +13,13 @@ pub fn add_piece(
     sector_store: &Arc<WrappedSectorStore>,
     mut staged_state: &mut StagedState,
     piece_key: String,
-    piece_bytes: &[u8],
+    piece_bytes_amount: u64,
+    piece_path: String,
 ) -> error::Result<SectorId> {
     let sector_mgr = sector_store.inner.manager();
     let sector_max = sector_store.inner.config().max_unsealed_bytes_per_sector();
 
-    let piece_bytes_len = UnpaddedBytesAmount(piece_bytes.len() as u64);
+    let piece_bytes_len = UnpaddedBytesAmount(piece_bytes_amount);
 
     let opt_dest_sector_id = {
         let candidates: Vec<StagedSectorMetadata> = staged_state
@@ -39,7 +40,7 @@ pub fn add_piece(
         sector_store
             .inner
             .manager()
-            .write_and_preprocess(&s.sector_access, &piece_bytes)
+            .write_and_preprocess(&s.sector_access, &piece_path)
             .map_err(Into::into)
             .and_then(|num_bytes_written| {
                 if num_bytes_written != piece_bytes_len {

--- a/filecoin-proofs/src/api/sector_builder/helpers/add_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/add_piece.rs
@@ -1,3 +1,4 @@
+use std::fs::File;
 use std::sync::Arc;
 
 use crate::api::sector_builder::errors::*;
@@ -37,10 +38,12 @@ pub fn add_piece(
         .or_else(|_| provision_new_staged_sector(sector_mgr, &mut staged_state))?;
 
     if let Some(s) = staged_state.sectors.get_mut(&dest_sector_id) {
+        let mut file = File::open(piece_path)?;
+
         sector_store
             .inner
             .manager()
-            .write_and_preprocess(&s.sector_access, &piece_path)
+            .write_and_preprocess(&s.sector_access, &mut file)
             .map_err(Into::into)
             .and_then(|num_bytes_written| {
                 if num_bytes_written != piece_bytes_len {

--- a/filecoin-proofs/src/api/sector_builder/mod.rs
+++ b/filecoin-proofs/src/api/sector_builder/mod.rs
@@ -117,8 +117,17 @@ impl SectorBuilder {
 
     // Stages user piece-bytes for sealing. Note that add_piece calls are
     // processed sequentially to make bin packing easier.
-    pub fn add_piece(&self, piece_key: String, piece_bytes: &[u8]) -> Result<SectorId> {
-        log_unrecov(self.run_blocking(|tx| Request::AddPiece(piece_key, piece_bytes.to_vec(), tx)))
+    pub fn add_piece(
+        &self,
+        piece_key: String,
+        piece_bytes_amount: u64,
+        piece_path: String,
+    ) -> Result<SectorId> {
+        log_unrecov(
+            self.run_blocking(|tx| {
+                Request::AddPiece(piece_key, piece_bytes_amount, piece_path, tx)
+            }),
+        )
     }
 
     // Returns sealing status for the sector with specified id. If no sealed or

--- a/sector-base/src/api/disk_backed_storage.rs
+++ b/sector-base/src/api/disk_backed_storage.rs
@@ -310,8 +310,12 @@ pub mod tests {
         // shared amongst test cases
         let contents = &[2u8; 500];
 
-        let mut file = NamedTempFile::new().unwrap();
-        let _ = file.write_all(contents);
+        // write contents to temp file and return mutable handle
+        let mut file = {
+            let mut file = NamedTempFile::new().unwrap();
+            let _ = file.write_all(contents);
+            File::open(file.path().to_str().unwrap()).unwrap()
+        };
 
         // write_and_preprocess
         {

--- a/sector-base/src/api/disk_backed_storage.rs
+++ b/sector-base/src/api/disk_backed_storage.rs
@@ -121,17 +121,17 @@ impl SectorManager for DiskManager {
     fn write_and_preprocess(
         &self,
         access: &str,
-        byte_source: &mut dyn Read,
+        data: &mut dyn Read,
     ) -> Result<UnpaddedBytesAmount, SectorManagerErr> {
         OpenOptions::new()
             .read(true)
             .write(true)
             .open(access)
             .map_err(|err| SectorManagerErr::CallerError(format!("{:?}", err)))
-            .and_then(|mut dest_file| {
-                write_padded(byte_source, &mut dest_file)
-                    .map(|n| UnpaddedBytesAmount(n as u64))
+            .and_then(|mut file| {
+                write_padded(data, &mut file)
                     .map_err(|err| SectorManagerErr::ReceiverError(format!("{:?}", err)))
+                    .map(|n| UnpaddedBytesAmount(n as u64))
             })
     }
 

--- a/sector-base/src/api/disk_backed_storage.rs
+++ b/sector-base/src/api/disk_backed_storage.rs
@@ -314,7 +314,8 @@ pub mod tests {
         let mut file = {
             let mut file = NamedTempFile::new().unwrap();
             let _ = file.write_all(contents);
-            File::open(file.path().to_str().unwrap()).unwrap()
+            let _ = file.seek(SeekFrom::Start(0)).unwrap();
+            file
         };
 
         // write_and_preprocess

--- a/sector-base/src/api/disk_backed_storage.rs
+++ b/sector-base/src/api/disk_backed_storage.rs
@@ -312,9 +312,11 @@ pub mod tests {
 
         // write contents to temp file and return mutable handle
         let mut file = {
-            let mut file = NamedTempFile::new().unwrap();
+            let mut file = NamedTempFile::new().expect("could not create named temp file");
             let _ = file.write_all(contents);
-            let _ = file.seek(SeekFrom::Start(0)).unwrap();
+            let _ = file
+                .seek(SeekFrom::Start(0))
+                .expect("failed to seek to beginning of file");
             file
         };
 

--- a/sector-base/src/api/sector_store.rs
+++ b/sector-base/src/api/sector_store.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use crate::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount};
 use crate::api::errors::SectorManagerErr;
 
@@ -26,7 +28,7 @@ pub trait SectorManager {
     fn write_and_preprocess(
         &self,
         access: &str,
-        piece_path: &str,
+        byte_source: &mut dyn Read,
     ) -> Result<UnpaddedBytesAmount, SectorManagerErr>;
 
     fn delete_staging_sector_access(&self, access: &str) -> Result<(), SectorManagerErr>;

--- a/sector-base/src/api/sector_store.rs
+++ b/sector-base/src/api/sector_store.rs
@@ -28,7 +28,7 @@ pub trait SectorManager {
     fn write_and_preprocess(
         &self,
         access: &str,
-        byte_source: &mut dyn Read,
+        data: &mut dyn Read,
     ) -> Result<UnpaddedBytesAmount, SectorManagerErr>;
 
     fn delete_staging_sector_access(&self, access: &str) -> Result<(), SectorManagerErr>;

--- a/sector-base/src/api/sector_store.rs
+++ b/sector-base/src/api/sector_store.rs
@@ -26,7 +26,7 @@ pub trait SectorManager {
     fn write_and_preprocess(
         &self,
         access: &str,
-        data: &[u8],
+        piece_path: &str,
     ) -> Result<UnpaddedBytesAmount, SectorManagerErr>;
 
     fn delete_staging_sector_access(&self, access: &str) -> Result<(), SectorManagerErr>;

--- a/sector-base/src/io/fr32.rs
+++ b/sector-base/src/io/fr32.rs
@@ -635,20 +635,25 @@ pub fn clear_right_bits(byte: &mut u8, offset: usize) {
     *(byte) &= !((1 << offset) - 1)
 }
 
-pub fn write_padded<W: ?Sized>(source: &[u8], target: &mut W) -> io::Result<usize>
+const N: usize = 1000;
+const CHUNK_SIZE: usize = 127 * N;
+
+pub fn write_padded<R, W>(source: &mut R, target: &mut W) -> io::Result<usize>
 where
-    W: Read + Write + Seek,
+    R: Read,
+    W: Read + Write + Seek + ?Sized,
 {
     // In order to optimize alignment in the common case of writing from an aligned start,
     // we should make the chunk a multiple of 127 (4 full elements, see `PaddingMap#alignment`).
-    // n was hand-tuned to do reasonably well in the benchmarks.
-    let n = 1000;
-    let chunk_size = 127 * n;
-
+    // N was hand-tuned to do reasonably well in the benchmarks.
+    let mut buffer = [0; CHUNK_SIZE];
     let mut written = 0;
 
-    for chunk in source.chunks(chunk_size) {
-        written += write_padded_aux(&FR32_PADDING_MAP, chunk, target)?;
+    while let Ok(bytes_read) = source.read(&mut buffer) {
+        if bytes_read == 0 {
+            break;
+        }
+        written += write_padded_aux(&FR32_PADDING_MAP, &buffer[..bytes_read], target)?;
     }
 
     Ok(written)
@@ -1092,10 +1097,10 @@ mod tests {
     // `write_padded` for 151 bytes of 1s, check padding.
     #[test]
     fn test_write_padded() {
-        let data = vec![255u8; 151];
+        let mut data: Vec<u8> = vec![255u8; 151];
         let buf = Vec::new();
         let mut cursor = Cursor::new(buf);
-        let written = write_padded(&data, &mut cursor).unwrap();
+        let written = write_padded(&mut data[..].as_ref(), &mut cursor).unwrap();
         let padded = cursor.into_inner();
         assert_eq!(written, 151);
         assert_eq!(
@@ -1115,11 +1120,11 @@ mod tests {
     // aligning the calls with the padded element boundaries, check padding.
     #[test]
     fn test_write_padded_multiple_aligned() {
-        let data = vec![255u8; 254];
+        let mut data = vec![255u8; 254];
         let buf = Vec::new();
         let mut cursor = Cursor::new(buf);
-        let mut written = write_padded(&data[0..127], &mut cursor).unwrap();
-        written += write_padded(&data[127..], &mut cursor).unwrap();
+        let mut written = write_padded(&mut data[0..127].as_ref(), &mut cursor).unwrap();
+        written += write_padded(&mut data[127..].as_ref(), &mut cursor).unwrap();
         let padded = cursor.into_inner();
 
         assert_eq!(written, 254);
@@ -1138,11 +1143,11 @@ mod tests {
     // aligning the calls with the padded element boundaries, check padding.
     #[test]
     fn test_write_padded_multiple_first_aligned() {
-        let data = vec![255u8; 265];
+        let mut data = vec![255u8; 265];
         let buf = Vec::new();
         let mut cursor = Cursor::new(buf);
-        let mut written = write_padded(&data[0..127], &mut cursor).unwrap();
-        written += write_padded(&data[127..], &mut cursor).unwrap();
+        let mut written = write_padded(&mut data[0..127].as_ref(), &mut cursor).unwrap();
+        written += write_padded(&mut data[127..].as_ref(), &mut cursor).unwrap();
         let padded = cursor.into_inner();
 
         assert_eq!(written, 265);
@@ -1175,11 +1180,11 @@ mod tests {
         // Use 127 for this test because it unpads to 128 – a multiple of 32.
         // Otherwise the last chunk will be too short and cannot be converted to Fr.
         for i in 1..126 {
-            let data = vec![255u8; 127];
+            let mut data = vec![255u8; 127];
             let buf = Vec::new();
             let mut cursor = Cursor::new(buf);
-            let mut written = write_padded(&data[0..i], &mut cursor).unwrap();
-            written += write_padded(&data[i..], &mut cursor).unwrap();
+            let mut written = write_padded(&mut data[0..i].as_ref(), &mut cursor).unwrap();
+            written += write_padded(&mut data[i..].as_ref(), &mut cursor).unwrap();
             let padded = cursor.into_inner();
             validate_fr32(&padded);
             assert_eq!(written, 127);
@@ -1217,7 +1222,7 @@ mod tests {
 
         let buf = Vec::new();
         let mut cursor = Cursor::new(buf);
-        write_padded(&source, &mut cursor).unwrap();
+        write_padded(&mut source[..].as_ref(), &mut cursor).unwrap();
         let buf = cursor.into_inner();
 
         for i in 0..31 {
@@ -1243,10 +1248,10 @@ mod tests {
     #[test]
     fn test_read_write_padded() {
         let len = 1016; // Use a multiple of 254.
-        let data = vec![255u8; len];
+        let mut data = vec![255u8; len];
         let buf = Vec::new();
         let mut cursor = Cursor::new(buf);
-        let padded_written = write_padded(&data, &mut cursor).unwrap();
+        let padded_written = write_padded(&mut data[..].as_ref(), &mut cursor).unwrap();
         let padded = cursor.into_inner();
 
         assert_eq!(padded_written, len);
@@ -1269,10 +1274,10 @@ mod tests {
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
         let len = 1016;
-        let data: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
+        let mut data: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
         let buf = Vec::new();
         let mut cursor = Cursor::new(buf);
-        write_padded(&data, &mut cursor).unwrap();
+        write_padded(&mut data[..].as_ref(), &mut cursor).unwrap();
         let padded = cursor.into_inner();
 
         {

--- a/sector-base/src/io/fr32.rs
+++ b/sector-base/src/io/fr32.rs
@@ -640,7 +640,7 @@ const CHUNK_SIZE: usize = 127 * N;
 
 pub fn write_padded<R, W>(source: &mut R, target: &mut W) -> io::Result<usize>
 where
-    R: Read,
+    R: Read + ?Sized,
     W: Read + Write + Seek + ?Sized,
 {
     // In order to optimize alignment in the common case of writing from an aligned start,

--- a/sector-base/src/io/fr32.rs
+++ b/sector-base/src/io/fr32.rs
@@ -635,6 +635,10 @@ pub fn clear_right_bits(byte: &mut u8, offset: usize) {
     *(byte) &= !((1 << offset) - 1)
 }
 
+// In order to optimize alignment in the common case of writing from an aligned
+// start, we should make the chunk a multiple of 127 (4 full elements, see
+// `PaddingMap#alignment`). N was hand-tuned to do reasonably well in the
+// benchmarks.
 const N: usize = 1000;
 const CHUNK_SIZE: usize = 127 * N;
 
@@ -643,9 +647,6 @@ where
     R: Read + ?Sized,
     W: Read + Write + Seek + ?Sized,
 {
-    // In order to optimize alignment in the common case of writing from an aligned start,
-    // we should make the chunk a multiple of 127 (4 full elements, see `PaddingMap#alignment`).
-    // N was hand-tuned to do reasonably well in the benchmarks.
     let mut buffer = [0; CHUNK_SIZE];
     let mut written = 0;
 

--- a/storage-proofs/benches/preprocessing.rs
+++ b/storage-proofs/benches/preprocessing.rs
@@ -27,22 +27,23 @@ fn preprocessing_benchmark(c: &mut Criterion) {
         ParameterizedBenchmark::new(
             "write_padded",
             |b, size| {
-                let data = &random_data(*size);
+                let data = random_data(*size);
 
                 b.iter(|| {
                     let mut tmpfile: File = tempfile::tempfile().unwrap();
 
-                    write_padded_bench(&mut tmpfile, data);
+                    write_padded_bench(&mut tmpfile, data.clone());
                 })
             },
             vec![128, 256, 512, 256_000, 512_000, 1024_000, 2048_000],
         )
         .with_function("write_padded + unpadded", |b, size| {
-            let data = &random_data(*size);
+            let data = random_data(*size);
+
             b.iter(|| {
                 let mut tmpfile: File = tempfile::tempfile().unwrap();
 
-                write_padded_unpadded_bench(&mut tmpfile, &data);
+                write_padded_unpadded_bench(&mut tmpfile, data.clone());
             })
         })
         .sample_size(2)
@@ -51,16 +52,15 @@ fn preprocessing_benchmark(c: &mut Criterion) {
     );
 }
 
-fn write_padded_bench(file: &mut File, data: &[u8]) {
-    write_padded(&data, file).unwrap();
-
+fn write_padded_bench(file: &mut File, mut data: Vec<u8>) {
+    let _ = write_padded(&mut data[..].as_ref(), file).unwrap();
     let padded_written = file.seek(SeekFrom::End(0)).unwrap() as usize;
 
     assert!(padded_written > data.len());
 }
 
-fn write_padded_unpadded_bench(file: &mut File, data: &[u8]) {
-    write_padded(&data, file).unwrap();
+fn write_padded_unpadded_bench(file: &mut File, mut data: Vec<u8>) {
+    write_padded(&mut data[..].as_ref(), file).unwrap();
 
     let padded_written = file.seek(SeekFrom::End(0)).unwrap() as usize;
 


### PR DESCRIPTION
## What's in this PR?

- `write_padded` now polymorphic over `Read`, which allows stream processing of inbound bytes
- `write_and_preprocess` also polymorphic over `Read` for same reasons
- `write_and_preprocess` consumers (e.g. FFI) can pass a `File`, which satisfies `Read`
- FFI consumers provide path, which can point to a named pipe or normal file

## Why's this PR needed?

- Buffering client pieces completely into memory for padding is bad
- We'd like to stream to `write_padded` from the go-filecoin `DagReader` (we do so by way of a named pipe)