### PR TITLE
Next round for post

### DIFF
--- a/filecoin-proofs/examples/beacon-post.rs
+++ b/filecoin-proofs/examples/beacon-post.rs
@@ -115,6 +115,8 @@ fn do_the_work(
 
     let pub_inputs = PublicInputs {
         commitments: trees.iter().map(|t| t.root()).collect(),
+        challenge_seed: rng.gen(),
+        faults: Vec::new(),
     };
 
     let trees_ref: Vec<_> = trees.iter().collect();

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -252,7 +252,7 @@ type PostSetupParams = beacon_post::SetupParams<PedersenDomain, vdf_sloth::Sloth
 pub type PostPublicParams = beacon_post::PublicParams<PedersenDomain, vdf_sloth::Sloth>;
 
 const POST_CHALLENGE_COUNT: usize = 30;
-const POST_EPOCHS: usize = 0;
+const POST_EPOCHS: usize = 1;
 const POST_PERIODS_COUNT: usize = 1;
 pub const POST_SECTORS_COUNT: usize = 2;
 const POST_VDF_ROUNDS: usize = 0;

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -151,7 +151,7 @@ fn get_post_params(post_config: PoStConfig) -> error::Result<Arc<groth16::Parame
     let post_public_params = post_public_params(post_config);
 
     let get_params = || {
-        <VDFPostCompound as CompoundProof<
+        <VDFPostCompound<PedersenHasher> as CompoundProof<
             Bls12,
             VDFPoSt<PedersenHasher, Sloth>,
             VDFPoStCircuit<Bls12>,
@@ -187,7 +187,7 @@ fn get_post_verifying_key(post_config: PoStConfig) -> error::Result<Arc<Bls12Ver
     let post_public_params = post_public_params(post_config);
 
     let get_verifying_key = || {
-        <VDFPostCompound as CompoundProof<
+        <VDFPostCompound<PedersenHasher> as CompoundProof<
             Bls12,
             VDFPoSt<PedersenHasher, Sloth>,
             VDFPoStCircuit<Bls12>,

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -21,8 +21,9 @@ use sector_base::api::porep_config::PoRepProofPartitions;
 use sector_base::api::post_config::PoStConfig;
 use sector_base::api::post_config::PoStProofPartitions;
 use sector_base::io::fr32::write_unpadded;
+use storage_proofs::beacon_post::{self, BeaconPoSt};
+use storage_proofs::circuit::beacon_post::{BeaconPoStCircuit, BeaconPoStCompound};
 use storage_proofs::circuit::multi_proof::MultiProof;
-use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::{self, CompoundProof};
 use storage_proofs::drgporep::DrgParams;
@@ -34,7 +35,7 @@ use storage_proofs::layered_drgporep::{self, LayerChallenges};
 use storage_proofs::merkle::MerkleTree;
 use storage_proofs::porep::{replica_id, PoRep, Tau};
 use storage_proofs::proof::ProofScheme;
-use storage_proofs::vdf_post::{self, VDFPoSt};
+use storage_proofs::vdf_post;
 use storage_proofs::vdf_sloth::{self, Sloth};
 use storage_proofs::zigzag_drgporep::ZigZagDrgPoRep;
 use storage_proofs::zigzag_graph::ZigZagBucketGraph;
@@ -44,6 +45,8 @@ pub type ChallengeSeed = Fr32Ary;
 
 /// FrSafe is an array of the largest whole number of bytes guaranteed not to overflow the field.
 type FrSafe = [u8; 31];
+
+type Tree = MerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function>;
 
 /// How big, in bytes, is the SNARK proof exposed by the API?
 ///
@@ -151,10 +154,10 @@ fn get_post_params(post_config: PoStConfig) -> error::Result<Arc<groth16::Parame
     let post_public_params = post_public_params(post_config);
 
     let get_params = || {
-        <VDFPostCompound<PedersenHasher> as CompoundProof<
-            Bls12,
-            VDFPoSt<PedersenHasher, Sloth>,
-            VDFPoStCircuit<Bls12>,
+        <BeaconPoStCompound<PedersenHasher> as CompoundProof<
+            _,
+            BeaconPoSt<PedersenHasher, Sloth>,
+            BeaconPoStCircuit<_, PedersenHasher, Sloth>,
         >>::groth_params(&post_public_params, &ENGINE_PARAMS)
         .map_err(Into::into)
     };
@@ -187,10 +190,10 @@ fn get_post_verifying_key(post_config: PoStConfig) -> error::Result<Arc<Bls12Ver
     let post_public_params = post_public_params(post_config);
 
     let get_verifying_key = || {
-        <VDFPostCompound<PedersenHasher> as CompoundProof<
+        <BeaconPoStCompound<PedersenHasher> as CompoundProof<
             Bls12,
-            VDFPoSt<PedersenHasher, Sloth>,
-            VDFPoStCircuit<Bls12>,
+            BeaconPoSt<PedersenHasher, Sloth>,
+            BeaconPoStCircuit<Bls12, PedersenHasher, Sloth>,
         >>::verifying_key(&post_public_params, &ENGINE_PARAMS)
         .map_err(Into::into)
     };
@@ -245,14 +248,16 @@ pub fn public_params(
     ZigZagDrgPoRep::<DefaultTreeHasher>::setup(&setup_params(sector_bytes)).unwrap()
 }
 
-type PostSetupParams = vdf_post::SetupParams<PedersenDomain, vdf_sloth::Sloth>;
-pub type PostPublicParams = vdf_post::PublicParams<PedersenDomain, vdf_sloth::Sloth>;
+type PostSetupParams = beacon_post::SetupParams<PedersenDomain, vdf_sloth::Sloth>;
+pub type PostPublicParams = beacon_post::PublicParams<PedersenDomain, vdf_sloth::Sloth>;
 
 const POST_CHALLENGE_COUNT: usize = 30;
-const POST_EPOCHS: usize = 3;
+const POST_EPOCHS: usize = 0;
+const POST_PERIODS_COUNT: usize = 1;
 pub const POST_SECTORS_COUNT: usize = 2;
-const POST_VDF_ROUNDS: usize = 1;
+const POST_VDF_ROUNDS: usize = 0;
 
+// Note: the current setup does not actually use the vdf_key
 lazy_static! {
     static ref POST_VDF_KEY: PedersenDomain =
         PedersenDomain(Fr::from_str("12345").unwrap().into_repr());
@@ -261,20 +266,23 @@ lazy_static! {
 fn post_setup_params(post_config: PoStConfig) -> PostSetupParams {
     let size = PaddedBytesAmount::from(post_config);
 
-    vdf_post::SetupParams::<PedersenDomain, vdf_sloth::Sloth> {
-        challenge_count: POST_CHALLENGE_COUNT,
-        sector_size: size.into(),
-        post_epochs: POST_EPOCHS,
-        setup_params_vdf: vdf_sloth::SetupParams {
-            key: *POST_VDF_KEY,
-            rounds: POST_VDF_ROUNDS,
+    beacon_post::SetupParams::<PedersenDomain, vdf_sloth::Sloth> {
+        vdf_post_setup_params: vdf_post::SetupParams::<_, _> {
+            challenge_count: POST_CHALLENGE_COUNT,
+            sector_size: size.into(),
+            post_epochs: POST_EPOCHS,
+            setup_params_vdf: vdf_sloth::SetupParams {
+                key: *POST_VDF_KEY,
+                rounds: POST_VDF_ROUNDS,
+            },
+            sectors_count: POST_SECTORS_COUNT,
         },
-        sectors_count: POST_SECTORS_COUNT,
+        post_periods_count: POST_PERIODS_COUNT,
     }
 }
 
 pub fn post_public_params(post_config: PoStConfig) -> PostPublicParams {
-    VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&post_setup_params(post_config)).unwrap()
+    BeaconPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&post_setup_params(post_config)).unwrap()
 }
 
 fn commitment_from_fr<E: Engine>(fr: E::Fr) -> Commitment {
@@ -328,8 +336,8 @@ pub fn generate_post_fixed_sectors_count(
 
     let pub_params: compound_proof::PublicParams<
         _,
-        vdf_post::VDFPoSt<PedersenHasher, vdf_sloth::Sloth>,
-    > = VDFPostCompound::setup(&setup_params).expect("setup failed");
+        beacon_post::BeaconPoSt<PedersenHasher, vdf_sloth::Sloth>,
+    > = BeaconPoStCompound::setup(&setup_params).expect("setup failed");
 
     let commitments = fixed
         .input_parts
@@ -344,35 +352,43 @@ pub fn generate_post_fixed_sectors_count(
         cs
     };
 
-    let pub_inputs = vdf_post::PublicInputs {
+    let pub_inputs = beacon_post::PublicInputs {
         challenge_seed: PedersenDomain::try_from_bytes(&safe_challenge_seed).unwrap(),
         commitments,
         faults: Vec::new(),
     };
 
-    let trees: Vec<Tree> = fixed
-        .input_parts
-        .iter()
-        .map(|(access, _)| {
-            if let Some(s) = &access {
-                make_merkle_tree(
-                    s,
-                    PaddedBytesAmount(pub_params.vanilla_params.sector_size as u64),
-                )
-                .unwrap()
-            } else {
-                panic!("faults are not yet supported")
-            }
-        })
-        .collect();
+    let sector_size = pub_params.vanilla_params.vdf_post_pub_params.sector_size as u64;
+    let bytes = PaddedBytesAmount(sector_size);
 
+    let mut replicas = Vec::with_capacity(fixed.input_parts.len());
+    let mut trees = Vec::with_capacity(fixed.input_parts.len());
+
+    for (access, _) in &fixed.input_parts {
+        if let Some(sealed_path) = access {
+            let mut f_in = File::open(sealed_path).expect("invalid path");
+            let mut replica = Vec::new();
+            f_in.read_to_end(&mut replica)
+                .expect("failed to read replica");
+
+            trees.push(public_params(bytes).graph.merkle_tree(&replica)?);
+            replicas.push(replica);
+        } else {
+            panic!("faults are not yet supported")
+        }
+    }
+
+    let borrowed_replicas: Vec<&[u8]> = replicas.iter().map(|t| &t[..]).collect();
     let borrowed_trees: Vec<&Tree> = trees.iter().map(|t| t).collect();
 
-    let priv_inputs = vdf_post::PrivateInputs::<PedersenHasher>::new(&borrowed_trees[..]);
+    let priv_inputs = beacon_post::PrivateInputs::<PedersenHasher>::new(
+        &borrowed_replicas[..],
+        &borrowed_trees[..],
+    );
 
     let groth_params = get_post_params(fixed.post_config)?;
 
-    let proof = VDFPostCompound::prove(&pub_params, &pub_inputs, &priv_inputs, &groth_params)
+    let proof = BeaconPoStCompound::prove(&pub_params, &pub_inputs, &priv_inputs, &groth_params)
         .expect("failed while proving");
 
     let mut buf = Vec::with_capacity(POST_PROOF_BYTES);
@@ -406,8 +422,8 @@ fn verify_post_fixed_sectors_count(
 
     let compound_public_params: compound_proof::PublicParams<
         _,
-        vdf_post::VDFPoSt<PedersenHasher, vdf_sloth::Sloth>,
-    > = VDFPostCompound::setup(&compound_setup_params).expect("setup failed");
+        beacon_post::BeaconPoSt<PedersenHasher, vdf_sloth::Sloth>,
+    > = BeaconPoStCompound::setup(&compound_setup_params).expect("setup failed");
 
     let commitments = fixed
         .comm_rs
@@ -421,7 +437,7 @@ fn verify_post_fixed_sectors_count(
         })
         .collect::<Vec<PedersenDomain>>();
 
-    let public_inputs = vdf_post::PublicInputs::<PedersenDomain> {
+    let public_inputs = beacon_post::PublicInputs::<PedersenDomain> {
         commitments,
         challenge_seed: PedersenDomain::try_from_bytes(&safe_challenge_seed)?,
         faults: fixed.faults.clone(),
@@ -439,23 +455,11 @@ fn verify_post_fixed_sectors_count(
     // However, everything up to that point does/should work — so we want to continue to exercise
     // for integration purposes.
     let _fixme_ignore: error::Result<bool> =
-        VDFPostCompound::verify(&compound_public_params, &public_inputs, &proof)
+        BeaconPoStCompound::verify(&compound_public_params, &public_inputs, &proof)
             .map_err(Into::into);
 
     // Since callers may rely on previous mocked success, just pretend verification succeeded, for now.
     Ok(VerifyPoStFixedSectorsCountOutput { is_valid: true })
-}
-
-type Tree = MerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function>;
-fn make_merkle_tree<T: Into<PathBuf> + AsRef<Path>>(
-    sealed_path: T,
-    bytes: PaddedBytesAmount,
-) -> storage_proofs::error::Result<Tree> {
-    let mut f_in = File::open(sealed_path.into())?;
-    let mut data = Vec::new();
-    f_in.read_to_end(&mut data)?;
-
-    public_params(bytes).graph.merkle_tree(&data)
 }
 
 pub struct SealOutput {

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -30,12 +30,14 @@ fn cache_porep_params(porep_config: PoRepConfig) {
     let public_params = internal::public_params(PaddedBytesAmount::from(porep_config));
     {
         let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
-
-        let _ = ZigZagCompound::get_groth_params(circuit, &public_params);
+        ZigZagCompound::get_groth_params(circuit, &public_params)
+            .expect("failed to generate zigzag groth params");
     }
+
     {
         let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);
-        let _ = ZigZagCompound::get_verifying_key(circuit, &public_params);
+        ZigZagCompound::get_verifying_key(circuit, &public_params)
+            .expect("failed to generate zigzag verifying key");
     }
 }
 
@@ -46,22 +48,24 @@ fn cache_post_params(post_config: PoStConfig) {
     let post_public_params = internal::post_public_params(post_config);
     {
         let post_circuit: VDFPoStCircuit<Bls12> =
-            <VDFPostCompound as CompoundProof<
+            <VDFPostCompound<PedersenHasher> as CompoundProof<
                 Bls12,
                 VDFPoSt<PedersenHasher, Sloth>,
                 VDFPoStCircuit<Bls12>,
             >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
-        let _ = VDFPostCompound::get_groth_params(post_circuit, &post_public_params);
+        VDFPostCompound::<PedersenHasher>::get_groth_params(post_circuit, &post_public_params)
+            .expect("failed to generate post params");
     }
     {
         let post_circuit: VDFPoStCircuit<Bls12> =
-            <VDFPostCompound as CompoundProof<
+            <VDFPostCompound<PedersenHasher> as CompoundProof<
                 Bls12,
                 VDFPoSt<PedersenHasher, Sloth>,
                 VDFPoStCircuit<Bls12>,
             >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
 
-        let _ = VDFPostCompound::get_verifying_key(post_circuit, &post_public_params);
+        VDFPostCompound::<PedersenHasher>::get_verifying_key(post_circuit, &post_public_params)
+            .expect("failed to generate post verifying key");
     }
 }
 

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -7,12 +7,12 @@ use filecoin_proofs::api::internal;
 use filecoin_proofs::FCP_LOG;
 use pairing::bls12_381::Bls12;
 use sector_base::api::bytes_amount::PaddedBytesAmount;
-use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
+use storage_proofs::beacon_post::BeaconPoSt;
+use storage_proofs::circuit::beacon_post::{BeaconPoStCircuit, BeaconPoStCompound};
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::CompoundProof;
 use storage_proofs::hasher::pedersen::PedersenHasher;
 use storage_proofs::parameter_cache::CacheableParameters;
-use storage_proofs::vdf_post::VDFPoSt;
 use storage_proofs::vdf_sloth::Sloth;
 
 use clap::{App, Arg};
@@ -47,24 +47,24 @@ fn cache_post_params(post_config: PoStConfig) {
 
     let post_public_params = internal::post_public_params(post_config);
     {
-        let post_circuit: VDFPoStCircuit<Bls12> =
-            <VDFPostCompound<PedersenHasher> as CompoundProof<
+        let post_circuit: BeaconPoStCircuit<_, _, _> =
+            <BeaconPoStCompound<PedersenHasher> as CompoundProof<
                 Bls12,
-                VDFPoSt<PedersenHasher, Sloth>,
-                VDFPoStCircuit<Bls12>,
+                BeaconPoSt<PedersenHasher, Sloth>,
+                BeaconPoStCircuit<Bls12, PedersenHasher, Sloth>,
             >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
-        VDFPostCompound::<PedersenHasher>::get_groth_params(post_circuit, &post_public_params)
+        BeaconPoStCompound::<PedersenHasher>::get_groth_params(post_circuit, &post_public_params)
             .expect("failed to generate post params");
     }
     {
-        let post_circuit: VDFPoStCircuit<Bls12> =
-            <VDFPostCompound<PedersenHasher> as CompoundProof<
+        let post_circuit: BeaconPoStCircuit<_, _, _> =
+            <BeaconPoStCompound<PedersenHasher> as CompoundProof<
                 Bls12,
-                VDFPoSt<PedersenHasher, Sloth>,
-                VDFPoStCircuit<Bls12>,
+                BeaconPoSt<PedersenHasher, Sloth>,
+                BeaconPoStCircuit<Bls12, PedersenHasher, Sloth>,
             >>::blank_circuit(&post_public_params, &internal::ENGINE_PARAMS);
 
-        VDFPostCompound::<PedersenHasher>::get_verifying_key(post_circuit, &post_public_params)
+        BeaconPoStCompound::<PedersenHasher>::get_verifying_key(post_circuit, &post_public_params)
             .expect("failed to generate post verifying key");
     }
 }

--- a/storage-proofs/src/beacon_post.rs
+++ b/storage-proofs/src/beacon_post.rs
@@ -39,6 +39,7 @@ impl<T: Domain, V: Vdf<T>> ParameterSetIdentifier for PublicParams<T, V> {
 pub struct PublicInputs<T: Domain> {
     /// The root hashes of the merkle trees of the sealed sectors.
     pub commitments: Vec<T>,
+    pub challenge_seed: T,
 }
 
 #[derive(Clone, Debug)]
@@ -251,6 +252,7 @@ mod tests {
 
         let pub_inputs = PublicInputs {
             commitments: vec![tree0.root(), tree1.root()],
+            challenge_seed: rng.gen(),
         };
 
         let priv_inputs = PrivateInputs::<PedersenHasher> {

--- a/storage-proofs/src/beacon_post.rs
+++ b/storage-proofs/src/beacon_post.rs
@@ -40,6 +40,8 @@ pub struct PublicInputs<T: Domain> {
     /// The root hashes of the merkle trees of the sealed sectors.
     pub commitments: Vec<T>,
     pub challenge_seed: T,
+    // TODO: Actually use the faults once faults are designed.
+    pub faults: Vec<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -253,6 +255,7 @@ mod tests {
         let pub_inputs = PublicInputs {
             commitments: vec![tree0.root(), tree1.root()],
             challenge_seed: rng.gen(),
+            faults: Vec::new(),
         };
 
         let priv_inputs = PrivateInputs::<PedersenHasher> {

--- a/storage-proofs/src/circuit/beacon_post.rs
+++ b/storage-proofs/src/circuit/beacon_post.rs
@@ -196,6 +196,8 @@ where
         let challenge_count = pub_params.vdf_post_pub_params.challenge_count;
         let post_epochs = pub_params.vdf_post_pub_params.post_epochs;
 
+        assert!(post_epochs > 0);
+
         let challenges_vec_vec =
             vec![vec![vec![None; challenge_count]; post_epochs]; post_periods_count];
         let challenged_sectors_vec_vec =

--- a/storage-proofs/src/circuit/beacon_post.rs
+++ b/storage-proofs/src/circuit/beacon_post.rs
@@ -171,8 +171,6 @@ where
 
         BeaconPoStCircuit::<_, _, _> {
             params,
-            // beacon_randomness_vec,
-            // challenges_vec,
             challenges_vec_vec,
             challenged_sectors_vec_vec,
             challenge_seed: Some(pub_inputs.challenge_seed.into()),
@@ -219,8 +217,6 @@ where
 
         BeaconPoStCircuit::<_, _, _> {
             params,
-            // beacon_randomness_vec,
-            // challenges_vec,
             challenges_vec_vec,
             challenged_sectors_vec_vec,
             challenge_seed: None,
@@ -338,6 +334,7 @@ mod tests {
         let pub_inputs = beacon_post::PublicInputs {
             commitments: vec![tree0.root(), tree1.root()],
             challenge_seed: beacon.get::<PedersenDomain>(0),
+            faults: Vec::new(),
         };
         let replicas = [&data0[..], &data1[..]];
         let trees = [&tree0, &tree1];
@@ -437,8 +434,6 @@ mod tests {
 
         let instance = BeaconPoStCircuit::<Bls12, PedersenHasher, vdf_sloth::Sloth> {
             params,
-            // beacon_randomness_vec,
-            // challenges_vec,
             challenges_vec_vec,
             challenged_sectors_vec_vec,
             challenge_seed: Some(pub_inputs.challenge_seed.into()),
@@ -461,7 +456,7 @@ mod tests {
         assert!(cs.is_satisfied(), "constraints not satisfied");
 
         assert_eq!(cs.num_inputs(), 7, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 398118, "wrong number of constraints");
+        assert_eq!(cs.num_constraints(), 132696, "wrong number of constraints");
         assert_eq!(cs.get_input(0, "ONE"), Fr::one());
     }
 
@@ -510,6 +505,7 @@ mod tests {
         let pub_inputs = beacon_post::PublicInputs {
             commitments: vec![tree0.root(), tree1.root()],
             challenge_seed: rng.gen(),
+            faults: Vec::new(),
         };
 
         let trees = [&tree0, &tree1];

--- a/storage-proofs/src/vdf.rs
+++ b/storage-proofs/src/vdf.rs
@@ -3,10 +3,15 @@ use crate::hasher::Domain;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
+pub trait VdfPublicParams<T: Domain>: Clone + ::std::fmt::Debug {
+    fn key(&self) -> T;
+    fn rounds(&self) -> usize;
+}
+
 /// Generic trait to represent any Verifiable Delay Function (VDF).
 pub trait Vdf<T: Domain>: Clone + ::std::fmt::Debug {
     type SetupParams: Clone + ::std::fmt::Debug;
-    type PublicParams: Clone + ::std::fmt::Debug;
+    type PublicParams: VdfPublicParams<T>;
     type Proof: Clone + ::std::fmt::Debug + Serialize + DeserializeOwned;
 
     fn setup(setup_params: &Self::SetupParams) -> Result<Self::PublicParams>;

--- a/storage-proofs/src/vdf_sloth.rs
+++ b/storage-proofs/src/vdf_sloth.rs
@@ -4,7 +4,7 @@ use crate::crypto::sloth;
 use crate::error::Result;
 use crate::hasher::pedersen::PedersenDomain;
 use crate::parameter_cache::ParameterSetIdentifier;
-use crate::vdf::Vdf;
+use crate::vdf::{Vdf, VdfPublicParams};
 
 /// VDF construction using sloth.
 #[derive(Debug, Clone)]
@@ -23,6 +23,16 @@ pub struct SetupParams {
 pub struct PublicParams {
     pub key: PedersenDomain,
     pub rounds: usize,
+}
+
+impl VdfPublicParams<PedersenDomain> for PublicParams {
+    fn key(&self) -> PedersenDomain {
+        self.key
+    }
+
+    fn rounds(&self) -> usize {
+        self.rounds
+    }
 }
 
 impl ParameterSetIdentifier for PublicParams {


### PR DESCRIPTION
- finish compound proof implementation of beacon_post
- switch to using beacon_post in the exported proofs api
- use no vdf effectively for now by setting `post_epochs=1`
- various fixes to make these things work out

Note: Before this can be merged params need to be regenerated, but waiting to do so until everything is finalized.

