### PR TITLE
zigzag benching

### DIFF
--- a/bench.config.toml
+++ b/bench.config.toml
@@ -1,4 +1,3 @@
-
 [merklepor]
 challenges = [ 1 ] #, 10, 50, 100, 200 ]
 size = [ "1 KiB" ] #, "64 MiB", "128 MiB", "256 MiB", "512 MiB", "1024 MiB"]
@@ -22,9 +21,13 @@ m = [ 6 ]
 
 [zigzag]
 challenges = [ 1 ]
-size = ["1 KiB"]
-hasher = ["pedersen"]
-command = "--groth"
+size = [ "1 KiB" ]
+hasher = [ "pedersen", "blake2s" ]
 sloth  = [ 0 ]
 m = [ 5 ]
-expansion = [ 6 ]
+command = "--groth"
+expansion = [ 8 ]
+layers = [ 10 ]
+partitions = [ 1 ]
+taper = [ 0.3333 ]
+taper_layers = [ 7 ]

--- a/src/bin/bencher.rs
+++ b/src/bin/bencher.rs
@@ -267,7 +267,7 @@ fn run(config_path: &str, print_table: bool) -> Result<()> {
                 }
             }
             Err(error) => {
-                println!("error: {}", error);
+                eprintln!("error: {}", error);
             }
         }
     }
@@ -609,7 +609,7 @@ fn run_benchmark(name: &str, config: &Case) -> Result<Vec<BenchmarkResult>> {
         match output.status.code() {
             Some(code) => {
                 if code != 0 {
-                    println!("{}", &String::from_utf8_lossy(&output.stderr));
+                    eprintln!("{}", &String::from_utf8_lossy(&output.stderr));
                     return Err(format_err!("benchmark exited with non-zero status"));
                 }
             }


### PR DESCRIPTION
fixes: https://github.com/filecoin-project/rust-fil-proofs/issues/536

allows additional parameters to be passed to the benchmarks, for now specifically zigzag
allows a benchmark to fail and continue to try to run the rest
allows non-json output to not break a benchmark