### PR TITLE
Change argument to get_max_user_bytes_per_staged_sector

### DIFF
--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -105,14 +105,9 @@ unsafe fn create_sector_builder(
         panic!("{}", c_str_to_rust_str((*resp).error_msg))
     }
 
-    let resp_2 = get_max_user_bytes_per_staged_sector((*resp).sector_builder);
-    defer!(destroy_get_max_user_bytes_per_staged_sector_response(
-        resp_2
-    ));
-
     (
         (*resp).sector_builder,
-        (*resp_2).max_staged_bytes_per_sector as usize,
+        get_max_user_bytes_per_staged_sector(&sector_store_config) as usize,
     )
 }
 

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -279,6 +279,19 @@ pub unsafe extern "C" fn destroy_sector_builder(ptr: *mut SectorBuilder) {
     let _ = Box::from_raw(ptr);
 }
 
+/// Returns the SectorSize.
+///
+#[no_mangle]
+pub unsafe extern "C" fn sector_size(cfg_ptr: *const ConfiguredStore) -> u64 {
+    if let Some(cfg) = cfg_ptr.as_ref() {
+        let cfg = new_sector_config(cfg);
+        return u64::from(cfg.max_unsealed_bytes_per_sector())
+    } else {
+        error!(FCP_LOG, "sector_size: unsupported configuration: {:?}", cfg_ptr; "target" => "FFI");
+        return 0
+    }
+}
+
 /// Writes user piece-bytes to a staged sector and returns the id of the sector
 /// to which the bytes were written.
 ///

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -279,16 +279,18 @@ pub unsafe extern "C" fn destroy_sector_builder(ptr: *mut SectorBuilder) {
     let _ = Box::from_raw(ptr);
 }
 
-/// Returns the SectorSize.
+/// Returns the number of user bytes that will fit into a staged sector.
 ///
 #[no_mangle]
-pub unsafe extern "C" fn sector_size(cfg_ptr: *const ConfiguredStore) -> u64 {
+pub unsafe extern "C" fn get_max_user_bytes_per_staged_sector(
+    cfg_ptr: *const ConfiguredStore,
+) -> u64 {
     if let Some(cfg) = cfg_ptr.as_ref() {
         let cfg = new_sector_config(cfg);
-        return u64::from(cfg.max_unsealed_bytes_per_sector())
+        return u64::from(cfg.max_unsealed_bytes_per_sector());
     } else {
-        error!(FCP_LOG, "sector_size: unsupported configuration: {:?}", cfg_ptr; "target" => "FFI");
-        return 0
+        error!(FCP_LOG, "get_max_user_bytes_per_staged_sector: unsupported configuration: {:?}", cfg_ptr; "target" => "FFI");
+        return 0;
     }
 }
 
@@ -372,20 +374,6 @@ pub unsafe extern "C" fn seal_all_staged_sectors(
             response.error_msg = ptr;
         }
     }
-
-    raw_ptr(response)
-}
-
-/// Returns the number of user bytes that will fit into a staged sector.
-///
-#[no_mangle]
-pub unsafe extern "C" fn get_max_user_bytes_per_staged_sector(
-    ptr: *mut SectorBuilder,
-) -> *mut responses::GetMaxStagedBytesPerSector {
-    let mut response: responses::GetMaxStagedBytesPerSector = Default::default();
-
-    response.status_code = FCPResponseStatus::FCPNoError;
-    response.max_staged_bytes_per_sector = (*ptr).get_max_user_bytes_per_staged_sector().into();
 
     raw_ptr(response)
 }

--- a/filecoin-proofs/src/api/responses.rs
+++ b/filecoin-proofs/src/api/responses.rs
@@ -257,35 +257,6 @@ pub unsafe extern "C" fn destroy_seal_all_staged_sectors_response(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-/// GetMaxStagedBytesPerSector
-//////////////////////////////
-
-#[repr(C)]
-#[derive(DropStructMacro)]
-pub struct GetMaxStagedBytesPerSector {
-    pub status_code: FCPResponseStatus,
-    pub error_msg: *const libc::c_char,
-    pub max_staged_bytes_per_sector: u64,
-}
-
-impl Default for GetMaxStagedBytesPerSector {
-    fn default() -> GetMaxStagedBytesPerSector {
-        GetMaxStagedBytesPerSector {
-            status_code: FCPResponseStatus::FCPNoError,
-            error_msg: ptr::null(),
-            max_staged_bytes_per_sector: 0,
-        }
-    }
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn destroy_get_max_user_bytes_per_staged_sector_response(
-    ptr: *mut GetMaxStagedBytesPerSector,
-) {
-    let _ = Box::from_raw(ptr);
-}
-
-///////////////////////////////////////////////////////////////////////////////
 /// GetSealStatusResponse
 /////////////////////////
 

--- a/filecoin-proofs/src/api/sector_builder/mod.rs
+++ b/filecoin-proofs/src/api/sector_builder/mod.rs
@@ -12,7 +12,6 @@ use crate::api::sector_builder::sealer::*;
 use crate::error::ExpectWithBacktrace;
 use crate::error::Result;
 use crate::FCP_LOG;
-use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use sector_base::api::disk_backed_storage::new_sector_store;
 use sector_base::api::disk_backed_storage::ConfiguredStore;
 use sector_base::api::sector_store::SectorStore;
@@ -107,12 +106,6 @@ impl SectorBuilder {
             sealers_tx: seal_tx,
             sealers: seal_workers,
         })
-    }
-
-    // Returns the number of user-provided bytes that will fit into a staged
-    // sector.
-    pub fn get_max_user_bytes_per_staged_sector(&self) -> UnpaddedBytesAmount {
-        self.run_blocking(Request::GetMaxUserBytesPerStagedSector)
     }
 
     // Stages user piece-bytes for sealing. Note that add_piece calls are

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -52,7 +52,6 @@ pub enum Request {
     ),
     RetrievePiece(String, mpsc::SyncSender<Result<Vec<u8>>>),
     SealAllStagedSectors(mpsc::SyncSender<Result<()>>),
-    GetMaxUserBytesPerStagedSector(mpsc::SyncSender<UnpaddedBytesAmount>),
     HandleSealResult(SectorId, Box<Result<SealedSectorMetadata>>),
     Shutdown,
 }
@@ -118,9 +117,6 @@ impl Scheduler {
                     }
                     Request::GetStagedSectors(tx) => {
                         tx.send(m.get_staged_sectors()).expect(FATAL_NOSEND);
-                    }
-                    Request::GetMaxUserBytesPerStagedSector(tx) => {
-                        tx.send(m.max_user_bytes()).expects(FATAL_NOSEND);
                     }
                     Request::SealAllStagedSectors(tx) => {
                         tx.send(m.seal_all_staged_sectors()).expects(FATAL_NOSEND);
@@ -272,12 +268,6 @@ impl SectorMetadataManager {
     // SectorBuilder knows about.
     pub fn get_staged_sectors(&self) -> Result<Vec<StagedSectorMetadata>> {
         Ok(self.state.staged.sectors.values().cloned().collect())
-    }
-
-    // Returns the number of user-provided bytes that will fit into a staged
-    // sector.
-    pub fn max_user_bytes(&self) -> UnpaddedBytesAmount {
-        self.max_user_bytes_per_staged_sector
     }
 
     // Update metadata to reflect the sealing results.


### PR DESCRIPTION
We change the argument of `get_max_user_bytes_per_staged_sector` from a `SectorBuilder` to a `ConfiguredStore`, since we need to use this function in a place that has access to the `ConfiguredStore`, but not the `SectorBuilder`.