### PR TITLE
make NUM_PROVING_THREADS configurable

### DIFF
--- a/storage-proofs/src/compound_proof.rs
+++ b/storage-proofs/src/compound_proof.rs
@@ -1,6 +1,7 @@
 use rayon::prelude::*;
 
 use crate::circuit::multi_proof::MultiProof;
+use crate::config::must_get_num_proving_threads;
 use crate::error::Result;
 use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
 use crate::partitions;
@@ -8,8 +9,6 @@ use crate::proof::ProofScheme;
 use bellman::{groth16, Circuit};
 use rand::OsRng;
 use sapling_crypto::jubjub::JubjubEngine;
-
-const NUM_PROVING_THREADS: usize = 4;
 
 pub struct SetupParams<'a, 'b: 'a, E: JubjubEngine, S: ProofScheme<'a>>
 where
@@ -93,7 +92,7 @@ where
 
         // Use a custom pool for this, so we can control the number of threads being used.
         let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(NUM_PROVING_THREADS)
+            .num_threads(must_get_num_proving_threads())
             .build()
             .expect("failed to build thread pool");
 

--- a/storage-proofs/src/config.rs
+++ b/storage-proofs/src/config.rs
@@ -15,6 +15,7 @@ type Config = HashMap<String, String>;
 const DEFAULT_CONFIG: &[(&str, &str)] = &[
     ("MAXIMIZE_CACHING", "false"),
     ("MERKLE_TREE_PATH", "/tmp/merkle-trees"),
+    ("NUM_PROVING_THREADS", "4"),
 ];
 
 lazy_static! {
@@ -86,6 +87,10 @@ pub fn get_config_bool(key: &str) -> Result<bool> {
         "0" | "false" | "off" | "no" | "" => Ok(false),
         _ => Err(err_msg("cannot cast as bool")),
     }
+}
+
+pub fn must_get_num_proving_threads() -> usize {
+    get_config("NUM_PROVING_THREADS").unwrap().parse().unwrap()
 }
 
 pub fn debug_config() {


### PR DESCRIPTION
This should fix https://github.com/filecoin-project/rust-fil-proofs/issues/585. But this is just a temporary solution, as people may be surprised the fact that `NUM_PROVING_THREADS` specified in the toml file should be a string. To make the config work for value other than string, we may have to change the config to a struct. Should I implement that or any other ideas?