### PR TITLE
perf(storage_proofs): Allocate outside the parents() call

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -94,3 +94,7 @@ harness = false
 [[bench]]
 name = "encode"
 harness = false
+
+[[bench]]
+name = "parents"
+harness = false

--- a/storage-proofs/benches/drgraph.rs
+++ b/storage-proofs/benches/drgraph.rs
@@ -16,7 +16,8 @@ fn drgraph(c: &mut Criterion) {
             "bucket/m=6",
             |b, (graph, i)| {
                 b.iter(|| {
-                    black_box(graph.parents(*i));
+                    let mut parents = vec![0; 6];
+                    black_box(graph.parents(*i, &mut parents));
                 })
             },
             params,

--- a/storage-proofs/benches/parents.rs
+++ b/storage-proofs/benches/parents.rs
@@ -1,0 +1,79 @@
+#[macro_use]
+extern crate criterion;
+#[cfg(feature = "cpu-profile")]
+extern crate gperftools;
+extern crate storage_proofs;
+
+use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use storage_proofs::drgraph::Graph;
+use storage_proofs::hasher::blake2s::Blake2sHasher;
+use storage_proofs::hasher::pedersen::PedersenHasher;
+use storage_proofs::hasher::sha256::Sha256Hasher;
+use storage_proofs::hasher::Hasher;
+use storage_proofs::zigzag_graph::{ZigZag, ZigZagBucketGraph};
+
+#[cfg(feature = "cpu-profile")]
+#[inline(always)]
+fn start_profile(stage: &str) {
+    gperftools::profiler::PROFILER
+        .lock()
+        .unwrap()
+        .start(format!("./{}.profile", stage))
+        .unwrap();
+}
+
+#[cfg(not(feature = "cpu-profile"))]
+#[inline(always)]
+fn start_profile(_stage: &str) {}
+
+#[cfg(feature = "cpu-profile")]
+#[inline(always)]
+fn stop_profile() {
+    gperftools::profiler::PROFILER
+        .lock()
+        .unwrap()
+        .stop()
+        .unwrap();
+}
+
+#[cfg(not(feature = "cpu-profile"))]
+#[inline(always)]
+fn stop_profile() {}
+
+fn pregenerate_graph<H: Hasher>(size: usize) -> ZigZagBucketGraph<H> {
+    let seed = [1, 2, 3, 4, 5, 6, 7];
+    ZigZagBucketGraph::<H>::new_zigzag(size, 5, 8, seed)
+}
+
+fn parents_loop<H: Hasher, G: Graph<H>>(graph: &G) -> Vec<Vec<usize>> {
+    (0..graph.size()).map(|node| graph.parents(node)).collect()
+}
+
+fn parents_loop_benchmark(cc: &mut Criterion) {
+    let sizes = vec![10, 50, 1000];
+
+    cc.bench(
+        "parents in a loop",
+        ParameterizedBenchmark::new(
+            "Blake2s",
+            |b, size| {
+                let graph = pregenerate_graph::<Blake2sHasher>(*size);
+                start_profile(&format!("parents-blake2s-{}", *size));
+                b.iter(|| black_box(parents_loop::<Blake2sHasher, _>(&graph)));
+                stop_profile();
+            },
+            sizes,
+        )
+        .with_function("Pedersen", |b, degree| {
+            let graph = pregenerate_graph::<PedersenHasher>(*degree);
+            b.iter(|| black_box(parents_loop::<PedersenHasher, _>(&graph)))
+        })
+        .with_function("Sha256", |b, degree| {
+            let graph = pregenerate_graph::<Sha256Hasher>(*degree);
+            b.iter(|| black_box(parents_loop::<Sha256Hasher, _>(&graph)))
+        }),
+    );
+}
+
+criterion_group!(benches, parents_loop_benchmark);
+criterion_main!(benches);

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -188,10 +188,11 @@ where
         let mut input = Vec::new();
         input.extend(packed_replica_id);
 
+        let mut parents = vec![0; pub_params.graph.degree()];
         for challenge in challenges {
             let mut por_nodes = vec![*challenge];
-            let parents = pub_params.graph.parents(*challenge);
-            por_nodes.extend(parents);
+            pub_params.graph.parents(*challenge, &mut parents);
+            por_nodes.extend_from_slice(&parents);
 
             for node in por_nodes {
                 let por_pub_inputs = merklepor::PublicInputs {

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -297,7 +297,8 @@ where
                 data,
             });
 
-            let parents = pub_params.graph.parents(challenge);
+            let mut parents = vec![0; pub_params.graph.degree()];
+            pub_params.graph.parents(challenge, &mut parents);
             let mut replica_parentsi = Vec::with_capacity(parents.len());
 
             for p in &parents {
@@ -363,7 +364,10 @@ where
                     return Ok(false);
                 }
 
-                let expected_parents = pub_params.graph.parents(pub_inputs.challenges[i]);
+                let mut expected_parents = vec![0; pub_params.graph.degree()];
+                pub_params
+                    .graph
+                    .parents(pub_inputs.challenges[i], &mut expected_parents);
                 if proof.replica_parents[i].len() != expected_parents.len() {
                     println!(
                         "proof parents were not the same length as in public parameters: {} != {}",

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -126,9 +126,8 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
             0 | 1 => {
                 // Use the degree of the curren graph (`m`), as parents.len() might be bigger
                 // than that (that's the case for ZigZag Graph)
-                #[allow(clippy::needless_range_loop)]
-                for k in 0..m {
-                    parents[k] = 0;
+                for parent in parents.iter_mut().take(m) {
+                    *parent = 0;
                 }
             }
             _ => {
@@ -138,8 +137,7 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
                 seed[7] = node as u32;
                 let mut rng = ChaChaRng::from_seed(&seed);
 
-                #[allow(clippy::needless_range_loop)]
-                for k in 0..m {
+                for (k, parent) in parents.iter_mut().take(m).enumerate() {
                     // iterate over m meta nodes of the ith real node
                     // simulate the edges that we would add from previous graph nodes
                     // if any edge is added from a meta node of jth real node then add edge (j,i)
@@ -151,10 +149,10 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
 
                     // remove self references and replace with reference to previous node
                     if out == node {
-                        parents[k] = node - 1;
+                        *parent = node - 1;
                     } else {
                         assert!(out <= node);
-                        parents[k] = out;
+                        *parent = out;
                     }
                 }
 

--- a/storage-proofs/src/vde.rs
+++ b/storage-proofs/src/vde.rs
@@ -25,6 +25,7 @@ where
     // The only subtlety is that a ZigZag graph may be reversed, so the direction
     // of the traversal must also be.
 
+    let mut parents = vec![0; graph.degree()];
     for n in 0..graph.size() {
         let node = if graph.forward() {
             n
@@ -33,8 +34,7 @@ where
             (graph.size() - n) - 1
         };
 
-        let parents = graph.parents(node);
-        assert_eq!(parents.len(), graph.degree(), "wrong number of parents");
+        graph.parents(node, &mut parents);
 
         let key = create_key::<H>(replica_id, node, &parents, data)?;
         let start = data_at_node_offset(node);
@@ -79,7 +79,8 @@ where
     H: Hasher,
     G: Graph<H>,
 {
-    let parents = graph.parents(v);
+    let mut parents = vec![0; graph.degree()];
+    graph.parents(v, &mut parents);
     let key = create_key::<H>(replica_id, v, &parents, &data)?;
     let node_data = H::Domain::try_from_bytes(&data_at_node(data, v)?)?;
 

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -142,30 +142,32 @@ impl<Z: ZigZag> Graph<Z::BaseHasher> for Z {
     }
 
     #[inline]
-    fn parents(&self, raw_node: usize) -> Vec<usize> {
+    fn parents(&self, raw_node: usize, parents: &mut [usize]) {
         // If graph is reversed, use real_index to convert index to reversed index.
         // So we convert a raw reversed node to an unreversed node, calculate its parents,
         // then convert the parents to reversed.
 
-        let drg_parents = self
-            .base_graph()
-            .parents(self.real_index(raw_node))
-            .iter()
-            .map(|i| self.real_index(*i))
-            .collect::<Vec<_>>();
+        self.base_graph()
+            .parents(self.real_index(raw_node), parents);
+        #[allow(clippy::needless_range_loop)]
+        for ii in 0..self.base_graph().degree() {
+            parents[ii] = self.real_index(parents[ii]);
+        }
 
-        let mut parents = drg_parents;
         // expanded_parents takes raw_node
         let expanded_parents = self.expanded_parents(raw_node);
 
-        parents.extend(expanded_parents.iter());
+        for (ii, value) in expanded_parents.iter().enumerate() {
+            parents[ii + self.base_graph().degree()] = *value
+        }
 
         // Pad so all nodes have correct degree.
-        for _ in 0..(self.degree() - parents.len()) {
+        let current_length = self.base_graph().degree() + expanded_parents.len();
+        for ii in 0..(self.degree() - current_length) {
             if self.reversed() {
-                parents.push(self.size() - 1);
+                parents[ii + current_length] = self.size() - 1
             } else {
-                parents.push(0);
+                parents[ii + current_length] = 0
             }
         }
         assert!(parents.len() == self.degree());
@@ -176,8 +178,6 @@ impl<Z: ZigZag> Graph<Z::BaseHasher> for Z {
         } else {
             *p >= raw_node
         }));
-
-        parents
     }
 
     fn seed(&self) -> [u32; 7] {
@@ -424,7 +424,9 @@ mod tests {
 
     fn assert_graph_ascending<H: Hasher, G: Graph<H>>(g: G) {
         for i in 0..g.size() {
-            for p in g.parents(i) {
+            let mut parents = vec![0; g.degree()];
+            g.parents(i, &mut parents);
+            for p in parents {
                 if i == 0 {
                     assert!(p == i);
                 } else {
@@ -436,7 +438,8 @@ mod tests {
 
     fn assert_graph_descending<H: Hasher, G: Graph<H>>(g: G) {
         for i in 0..g.size() {
-            let parents = g.parents(i);
+            let mut parents = vec![0; g.degree()];
+            g.parents(i, &mut parents);
             for p in parents {
                 if i == g.size() - 1 {
                     assert!(p == i);

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -149,9 +149,8 @@ impl<Z: ZigZag> Graph<Z::BaseHasher> for Z {
 
         self.base_graph()
             .parents(self.real_index(raw_node), parents);
-        #[allow(clippy::needless_range_loop)]
-        for ii in 0..self.base_graph().degree() {
-            parents[ii] = self.real_index(parents[ii]);
+        for parent in parents.iter_mut().take(self.base_graph().degree()) {
+            *parent = self.real_index(*parent);
         }
 
         // expanded_parents takes raw_node


### PR DESCRIPTION
In order to save some allocations, the vector for parents is
allocated outside the call. This is on optimisation for loops
where that vector can be re-used in several parents() calls.

It's not clear that it really improves the performance. When
running the benchmark for encoding a single node, there's no
significant difference when this change is applied:

```
group                             HEAD2                                  less-alloc2
-----                             -----                                  -----------
encode single node/Blake2s/10     1.00     13.1±0.63µs        ? B/sec    1.01     13.2±0.62µs        ? B/sec
encode single node/Blake2s/3      1.00     11.8±0.52µs        ? B/sec    1.07     12.7±0.59µs        ? B/sec
encode single node/Blake2s/5      1.00     12.3±0.92µs        ? B/sec    1.05     12.8±0.77µs        ? B/sec
encode single node/Pedersen/10    1.00     11.8±0.61µs        ? B/sec    1.00     11.8±0.59µs        ? B/sec
encode single node/Pedersen/3     1.02     11.5±0.69µs        ? B/sec    1.00     11.3±0.47µs        ? B/sec
encode single node/Pedersen/5     1.00     11.5±0.65µs        ? B/sec    1.00     11.5±0.93µs        ? B/sec
encode single node/Sha256/10      1.00     12.0±0.77µs        ? B/sec    1.02     12.2±1.22µs        ? B/sec
encode single node/Sha256/3       1.01     11.3±0.52µs        ? B/sec    1.00     11.2±0.55µs        ? B/sec
encode single node/Sha256/5       1.00     11.4±0.56µs        ? B/sec    1.00     11.4±0.63µs        ? B/sec
```

Closes #575.