### PR TITLE
Piece Inclusion Proof (PIP)

### DIFF
--- a/storage-proofs/src/error.rs
+++ b/storage-proofs/src/error.rs
@@ -7,6 +7,10 @@ pub type Result<T> = ::std::result::Result<T, Error>;
 pub enum Error {
     #[fail(display = "Bytes could not be converted to Fr")]
     BadFrBytes,
+    #[fail(
+        display = "Could not create PieceInclusionProof (probably bad piece commitment: comm_p)"
+    )]
+    BadPieceCommitment,
     #[fail(display = "Out of bounds access {} > {}", _0, _1)]
     OutOfBounds(usize, usize),
     #[fail(
@@ -22,10 +26,14 @@ pub enum Error {
     InvalidCommitment,
     #[fail(display = "malformed input")]
     MalformedInput,
+    #[fail(display = "malformed merkle tree")]
+    MalformedMerkleTree,
     #[fail(display = "invalid input size")]
     InvalidInputSize,
     #[fail(display = "merkle tree generation error: {}", _0)]
     MerkleTreeGenerationError(String),
+    #[fail(display = "Cannot (yet) generate inclusion proof for unaligned piece.")]
+    UnalignedPiece,
 }
 
 impl From<SynthesisError> for Error {

--- a/storage-proofs/src/piece_inclusion_proof.rs
+++ b/storage-proofs/src/piece_inclusion_proof.rs
@@ -1,255 +1,486 @@
-use std::marker::PhantomData;
-
+use itertools::Itertools;
 use merkle_light::hash::Algorithm;
-use merkle_light::proof::Proof;
+use merkle_light::merkle::{self, next_pow2, VecStore};
 
 use crate::error::*;
+use crate::fr32::Fr32Vec;
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::MerkleTree;
 
-type InclusionProof<T> = Proof<T>;
-
-/// A FileInclusionProof contains a merkle inclusion proof for the first and last node
-/// of a piece. This ensures all 'edge' hashes necessary to generate a complete merkle
-/// tree are available.
-///
-/// Depending on the position of the nodes, not every hash provided will actually be needed.
-/// As a space optimization, and at the cost of greater complexity in the encoding, 'interior' nodes
-/// of either path may be omitted.
+/// Based on the alignment information (and sector size, provided during verification),
+/// the algorithm deterministically consumes the elements.
+#[derive(Clone, Debug)]
 pub struct PieceInclusionProof<H: Hasher> {
-    first_node_proof: InclusionProof<H::Domain>,
-    last_node_proof: InclusionProof<H::Domain>,
-    _h: PhantomData<H>,
+    position: usize,
+    piece_leaves: usize,
+    proof_elements: Vec<H::Domain>,
 }
 
-/// file_inclusion_proofs takes a merkle tree and a slice of piece lengths, and returns
-/// a vector of file inclusion proofs corresponding to the pieces. This assumes that the first
-/// piece begins at offset 0, and that each piece begins directly after the previous piece ends.
-/// For this method to work, the piece data used to validate pieces will need to be padded as necessary,
-/// and pieces will need to be aligned (to 128-byte chunks for Fr32 bit-padding) when written.
-pub fn file_inclusion_proofs<H: Hasher>(
+/// `position`, `length` are in H::Domain units
+#[derive(Clone, Debug)]
+pub struct PieceSpec<'a> {
+    comm_p: &'a Fr32Vec,
+    position: usize,
+    length: usize,
+}
+
+impl<'a> PieceSpec<'a> {
+    /// `compute_packing` returns a packing list and a proof size.
+    /// A packing list is a pair of (start, length) pairs, relative to the beginning of the piece,
+    /// in leaf units.
+    /// Proof size is a number of elements (size same as one leaf) provided in the variable part of a PieceInclusionProof.
+    pub fn compute_packing(&self, tree_len: usize) -> Result<(Vec<(usize, usize)>, usize)> {
+        if !self.is_aligned(tree_len) {
+            Err(Error::UnalignedPiece)
+        } else {
+            let packing_list = vec![(0, self.length)];
+            Ok((packing_list, self.proof_length(tree_len)))
+        }
+    }
+
+    pub fn is_aligned(&self, tree_len: usize) -> bool {
+        piece_is_aligned(self.position, self.length, tree_len)
+    }
+
+    fn height(&self) -> usize {
+        height_for_length(self.length)
+    }
+
+    // `proof_length` is length of proof that comm_p is in the containing root, excluding comm_p and root, which aren't needed for the proof itself.
+    fn proof_length(&self, tree_len: usize) -> usize {
+        height_for_length(tree_len) - self.height()
+    }
+}
+
+#[allow(dead_code)]
+fn create_piece_tree<H: Hasher>(
+    data: &[H::Domain],
+) -> merkle::MerkleTree<H::Domain, H::Function, VecStore<H::Domain>> {
+    let data_size = data.len();
+    // We need to compute comm_p as a merkle root over power-of-two-sized data.
+    let tree_size = next_pow2(data_size);
+
+    // If actual data is less than tree size, pad it with zeroes.
+    //if data_size < tree_size {
+    // NOTE: this assumes that `H::Domain::default()` corresponds to zeroed input.
+    // This matters because padding may have been applied at the byte level, using zero bytes.
+    merkle::MerkleTree::<H::Domain, H::Function, VecStore<H::Domain>>::new(
+        data.iter()
+            .cloned()
+            .pad_using(tree_size, |_| H::Domain::default()),
+    )
+}
+
+#[allow(dead_code)]
+/// Compute `comm_p` from a slice of Domain elements.
+/// `comm_p` is the merkle root of a piece, zero-padded to fill a complete binary sub-tree.
+fn compute_piece_commitment<H: Hasher>(data: &[H::Domain]) -> H::Domain {
+    create_piece_tree::<H>(data).root()
+}
+
+#[allow(dead_code)]
+/// Generate `comm_p` from bytes
+fn generate_piece_commitment<H: Hasher>(data: &[u8]) -> Result<H::Domain> {
+    let mut domain_data = Vec::new();
+    for d in data.chunks(32) {
+        domain_data.push(<H::Domain as Domain>::try_from_bytes(d)?)
+    }
+
+    Ok(compute_piece_commitment::<H>(&domain_data))
+}
+
+#[allow(dead_code)]
+/// Generate `comm_p` from bytes and return it as bytes.
+fn generate_piece_commitment_bytes<H: Hasher>(data: &[u8]) -> Result<Fr32Vec> {
+    let comm_p = generate_piece_commitment::<H>(data)?;
+
+    Ok(H::Domain::into_bytes(&comm_p))
+}
+
+pub fn piece_inclusion_proofs<H: Hasher>(
+    piece_specs: &[PieceSpec],
     tree: &MerkleTree<H::Domain, H::Function>,
-    piece_lengths: &[usize],
-) -> Vec<PieceInclusionProof<H>> {
-    bounds(piece_lengths)
+) -> Result<Vec<PieceInclusionProof<H>>> {
+    piece_specs
         .iter()
-        .map(|(start, end)| file_inclusion_proof(tree, *start, end - 1))
+        .map(|piece_spec| PieceInclusionProof::new(piece_spec.clone(), tree))
         .collect()
 }
 
-// Given a set of lengths, return corresponding (start, end) pairs for successive pieces.
-fn bounds(lengths: &[usize]) -> Vec<(usize, usize)> {
-    let mut start = 0;
-    let mut bounds = Vec::with_capacity(lengths.len());
-    for length in lengths {
-        let end = start + length;
-        bounds.push((start, end));
-        start = end;
-    }
-    bounds
-}
-
-/// file_inclusion_proof takes a merkle tree and the index positions of the first and last nodes
-/// of the piece whose inclusion should be proved. It returns a corresponding file_inclusion_proof.
-/// For the resulting proof to be valid, first_node must be <= last_node.
-pub fn file_inclusion_proof<H: Hasher>(
-    tree: &MerkleTree<H::Domain, H::Function>,
-    first_node: usize,
-    last_node: usize,
-) -> PieceInclusionProof<H> {
-    PieceInclusionProof {
-        first_node_proof: tree.gen_proof(first_node),
-        last_node_proof: tree.gen_proof(last_node),
-        _h: PhantomData,
-    }
-}
-
 impl<H: Hasher> PieceInclusionProof<H> {
+    pub fn new(
+        piece_spec: PieceSpec,
+        tree: &MerkleTree<H::Domain, H::Function>,
+    ) -> Result<PieceInclusionProof<H>> {
+        let PieceSpec {
+            comm_p,
+            position: first_leaf,
+            length: leaf_count,
+        } = piece_spec;
+
+        let last_leaf = first_leaf + (leaf_count - 1);
+
+        // For now, we only handled aligned pieces.
+        if !piece_spec.is_aligned(tree.len()) {
+            return Err(Error::UnalignedPiece);
+        }
+
+        let first_proof = tree.gen_proof(first_leaf);
+        let last_proof = tree.gen_proof(last_leaf);
+
+        // Including first leaf (item).
+        let proof_length = piece_spec.height() + 1;
+
+        // Find the first common hash (at same position) in first and last proof,
+        // then discard all previous hashes and path bits, and create a new proof containing
+        // only the common part.
+        //
+        // For an aligned piece, there is guaranteed to be a common element.
+        // That is, the merkle root of the piece must be a node of the tree (and therefore in the paths
+        // of all leaves of the piece (including the first and last).
+        for (i, (a, b)) in first_proof
+            .lemma()
+            .iter()
+            .zip(last_proof.lemma().iter())
+            .enumerate()
+        {
+            if (a == b) && (i == proof_length) {
+                let proof_elements = first_proof.lemma()[i..first_proof.lemma().len() - 1].to_vec();
+
+                let piece_inclusion_proof = PieceInclusionProof {
+                    proof_elements,
+                    position: first_leaf,
+                    piece_leaves: leaf_count,
+                };
+
+                if piece_inclusion_proof.verify(
+                    &tree.root(),
+                    &H::Domain::try_from_bytes(comm_p)?,
+                    leaf_count,
+                    tree.leafs(),
+                ) {
+                    return Ok(piece_inclusion_proof);
+                } else {
+                    return Err(Error::BadPieceCommitment);
+                }
+            }
+        }
+
+        // There must be a common root, if only the root of the entire tree.
+        Err(Error::MalformedMerkleTree)
+    }
+
+    fn leaf_path(leaf: usize, tree_height: usize) -> Vec<bool> {
+        let mut height = tree_height;
+        let mut rising_leaf = leaf;
+        let mut path = Vec::new();
+
+        while height > 0 {
+            // If this leaf's least significant bit is set, then it is a right branch, so `is_right` is true.
+            path.push(rising_leaf & 1 == 1);
+            rising_leaf >>= 1;
+            height -= 1;
+        }
+        path
+    }
+
     /// verify takes a merkle root and (pre-processed) piece data.
-    /// Iff it returns true, then FileInclusionProof indeed proves that piece's
+    /// Iff it returns true, then PieceInclusionProof indeed proves that piece's
     /// bytes were included in the merkle tree corresponding to root -- and at the
     /// position encoded in the proof.
-    fn verify(&self, root: &H::Domain, piece: &[u8]) -> bool {
-        // These checks are superfluous but inexpensive and clarifying.
-        if !(self.first_node_proof.validate::<H::Function>()
-            && self.last_node_proof.validate::<H::Function>())
-        {
+    /// `piece_leaves` and `sector_leaves` are in units of `Domain` (i.e. `NODE_SIZE` = 32 bytes).
+
+    fn verify(
+        &self,
+        root: &H::Domain,
+        comm_p: &H::Domain,
+        piece_leaves: usize,
+        sector_leaves: usize,
+    ) -> bool {
+        let sector_height = height_for_length(sector_leaves);
+        let piece_height = height_for_length(piece_leaves);
+        let proof_length = sector_height - piece_height;
+
+        let proof_path = &Self::leaf_path(self.position, sector_height)[piece_height..];
+
+        // This is an important check. Without it, a fake proof could have a longer path and prove less data.
+        // In the most extreme case, this would mean storing `comm_p` itself as a leaf node.
+        // This check ensures `comm_p` appears at the right height in the tree.
+        if (proof_path.len() != proof_length) || self.proof_elements.len() != proof_length {
             return false;
         }
-        // If the computed root is equal to the provided root, then the piece was provably
-        // present in the data from which the merkle tree was constructed.
-        match compute_root::<H>(&self.first_node_proof, &self.last_node_proof, piece) {
-            Ok(computed_root) => *root == computed_root,
-            Err(_) => false,
+
+        if piece_leaves != self.piece_leaves {
+            return false;
         }
-    }
-}
 
-/// Compute the root which results when hashing the supplied piece_data, supplemented by the hashes
-/// in the left (first) and right (last) inclusion proofs from the FileInclusionProof.
-fn compute_root<H: Hasher>(
-    left_proof: &InclusionProof<H::Domain>,
-    right_proof: &InclusionProof<H::Domain>,
-    piece_data: &[u8],
-) -> Result<H::Domain> {
-    // Zip the left and right proof_vecs into one.
-    let proof_vecs = proof_vec(left_proof).zip(proof_vec(right_proof));
-
-    let mut hasher = H::Function::default();
-
-    let mut last_row = Vec::new();
-
-    for chunk in piece_data.chunks(32) {
-        last_row.push(H::Domain::try_from_bytes(chunk)?);
+        Self::validate_inclusion(
+            *root,
+            *comm_p,
+            &self.proof_elements,
+            proof_path,
+            piece_height,
+        )
     }
 
-    for (height, ((l_hash, l_is_left), (r_hash, r_is_left))) in proof_vecs.enumerate() {
-        let mut row = Vec::new();
-        if !*l_is_left {
-            row.push(*l_hash);
-        };
-        row.extend(last_row);
-        if *r_is_left {
-            row.push(*r_hash);
-        }
-        last_row = hash_pairs::<H>(&mut hasher, row.as_slice(), height)?;
-    }
-    assert_eq!(last_row.len(), 1);
-    Ok(last_row[0])
-}
+    /// Validates the MerkleProof and that it corresponds to the supplied node.
+    /// Node height must be supplied, since `validate_inclusion` can prove inclusion
+    /// of nodes which are not leaves. `node_height` is 0 for a leaf node.
+    fn validate_inclusion(
+        root: H::Domain,
+        node: H::Domain,
+        elements: &[H::Domain],
+        path: &[bool],
+        node_height: usize,
+    ) -> bool {
+        let mut a = H::Function::default();
 
-/// For each successive pair of input hashes in row, construct a new hash according to the method used by `hasher.node`,
-/// returning a vector of the constructed hashes, in order.
-/// The result will be an error (resulting in a failed proof) if row does not contain an even number of hashes.
-fn hash_pairs<H: Hasher>(
-    hasher: &mut H::Function,
-    row: &[H::Domain],
-    height: usize,
-) -> Result<Vec<H::Domain>> {
-    let hashed: Result<Vec<_>> = row
-        .chunks(2)
-        .map(|pair| {
-            if pair.len() != 2 {
-                // If input is malformed, return an Err, which will fail the proof.
-                return Err(Error::MalformedInput);
-            }
-            hasher.reset();
-            Ok(hasher.node(pair[0], pair[1], height))
+        root == (0..path.len()).fold(node, |h, i| {
+            a.reset();
+            let is_right = path[i];
+
+            let (left, right) = if is_right {
+                (elements[i], h)
+            } else {
+                (h, elements[i])
+            };
+
+            a.node(left, right, i + node_height)
         })
-        .collect();
+    }
 
-    hashed
+    /// verify_piece_inclusion_proofs returns true iff each provided piece is proved with respect to root
+    /// by the corresponding (by index) proof.
+    pub fn verify_all(
+        root: &[u8],
+        proofs: &[PieceInclusionProof<H>],
+        comm_ps: &[Vec<u8>],
+        piece_sizes: &[usize],
+        sector_size: usize,
+    ) -> Result<bool> {
+        let root_domain = H::Domain::try_from_bytes(root)?;
+
+        Ok(proofs.iter().zip(comm_ps.iter().zip(piece_sizes)).all(
+            |(proof, (comm_p, piece_size))| {
+                proof.verify(
+                    &root_domain,
+                    &H::Domain::try_from_bytes(comm_p).unwrap(),
+                    *piece_size,
+                    sector_size,
+                )
+            },
+        ))
+    }
 }
 
-/// Return a vector of (hash, bool) pairs, where the bool indicates whether the paired hash
-/// will be the left child of the next node hashed. In order to accomplish this, we skip
-/// the first hash provided (in proof.lemma()). This is an implementation detail of how a
-/// merkle_light::proof::Proof is structured.
-fn proof_vec<T: Domain>(proof: &Proof<T>) -> impl Iterator<Item = (&T, &bool)> {
-    proof.lemma().iter().skip(1).zip(proof.path().iter())
+////////////////////////////////////////////////////////////////////////////////
+// Utility
+
+pub fn piece_is_aligned(position: usize, length: usize, tree_len: usize) -> bool {
+    let capacity_at_pos = subtree_capacity(position, tree_len);
+
+    is_pow2(capacity_at_pos) && capacity_at_pos >= length
 }
 
-/// verify_file_inclusion_proofs returns true iff each provided piece is proved with respect to root
-/// by the corresponding (by index) proof.
-pub fn verify_file_inclusion_proofs<H: Hasher>(
-    root: &H::Domain,
-    proofs: &[PieceInclusionProof<H>],
-    pieces: &[&[u8]],
-) -> bool {
-    proofs
-        .iter()
-        .zip(pieces)
-        .all(|(proof, piece)| proof.verify(root, piece))
+fn height_for_length(n: usize) -> usize {
+    (n as f64).log2().ceil() as usize
 }
+
+fn is_pow2(n: usize) -> bool {
+    n.count_ones() == 1
+}
+
+fn subtree_capacity(pos: usize, total: usize) -> usize {
+    assert!(pos < total, "position must be less than tree capacity");
+
+    let mut capacity = 1;
+    // If tree is not 'full', then pos 0 will have subtree_capacity greater than size of tree.
+    let mut cursor = pos + next_pow2(total);
+
+    while cursor & 1 == 0 {
+        capacity *= 2;
+        cursor >>= 1;
+    }
+    capacity
+}
+////////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::drgraph::{new_seed, BucketGraph, Graph};
     use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
-
-    const NODE_BYTES: usize = 32;
+    use crate::util::NODE_SIZE;
 
     #[test]
-    fn compute_bounds() {
-        assert_eq!(bounds(&[3, 5, 7, 9]), [(0, 3), (3, 8), (8, 15), (15, 24)]);
+    fn piece_inclusion_proof_pedersen() {
+        test_piece_inclusion_proof::<PedersenHasher>();
     }
 
     #[test]
-    fn file_inclusion_proof_pedersen() {
-        test_file_inclusion_proof::<PedersenHasher>();
+    fn piece_inclusion_proof_sha256() {
+        test_piece_inclusion_proof::<Sha256Hasher>();
     }
 
     #[test]
-    fn file_inclusion_proof_sha256() {
-        test_file_inclusion_proof::<Sha256Hasher>();
+    fn piece_inclusion_proof_blake2s() {
+        test_piece_inclusion_proof::<Blake2sHasher>();
     }
 
-    #[test]
-    fn file_inclusion_proof_blake2s() {
-        test_file_inclusion_proof::<Blake2sHasher>();
-    }
+    fn test_piece_inclusion_proof<H: Hasher>() {
+        let mut size = 32;
 
-    fn test_file_inclusion_proof<H: Hasher>() {
-        let nodes = 5;
-        for i in 1..nodes {
-            for j in 1..(nodes - i) {
-                file_inclusion_proof_aux::<H>(nodes, &[i, j]);
+        test_piece_inclusion_proof_aux::<H>(32, &[32], &[0], false);
+
+        //        // Aligned proofs
+        while size > 2 {
+            for i in 2..size {
+                test_piece_inclusion_proof_aux::<H>(size, &[i], &[0], false);
             }
+
+            size >>= 1;
         }
 
-        file_inclusion_proof_aux::<H>(32, &[32usize]);
-        file_inclusion_proof_aux::<H>(32, &[10usize, 15, 7]);
-        file_inclusion_proof_aux::<H>(32, &[3usize, 9, 20]);
-        file_inclusion_proof_aux::<H>(32, &[4usize, 6, 14]);
+        //        // Unaligned proof (should fail)
+        test_piece_inclusion_proof_aux::<H>(32, &[16usize], &[8usize], true);
+
+        //        // Mixed aligned and unaligned
+        for i in 0..16 {
+            test_piece_inclusion_proof_aux::<H>(32, &[8usize], &[i], i % 8 != 0);
+        }
+
+        // TODO: when unaligned proofs are supported, test more exhaustively.
     }
 
-    fn file_inclusion_proof_aux<H: Hasher>(nodes: usize, node_lengths: &[usize]) {
-        let size = nodes * NODE_BYTES;
+    fn test_piece_inclusion_proof_aux<H: Hasher>(
+        nodes: usize,
+        node_lengths: &[usize],
+        start_positions: &[usize],
+        expect_alignment_error: bool,
+    ) {
+        assert_eq!(node_lengths.len(), 1); // For now.
+        let size = nodes * NODE_SIZE;
         let g = BucketGraph::<H>::new(nodes, 0, 0, new_seed());
-        let mut data = Vec::<u8>::with_capacity(nodes);
+        let mut data = vec![0u8; size]; //Vec::<u8>::with_capacity(nodes);
 
-        for i in 0..size {
-            data.push(
-                (((i / NODE_BYTES) + i)
+        let data_size = node_lengths[0] * NODE_SIZE;
+
+        for i in 0..data_size {
+            data[i] = (((i / NODE_SIZE) + i)
                 // Mask out two most significant bits so we will always be Fr32,
-                & 63) as u8,
-            )
+                & 63) as u8;
         }
 
         let tree = g.merkle_tree(&data).unwrap();
-        let lengths: Vec<usize> = node_lengths.iter().map(|x| x * 32).collect();
 
-        let proofs = file_inclusion_proofs::<H>(&tree, &node_lengths);
-        let bounds = bounds(lengths.as_slice());
         let mut pieces = Vec::new();
-        for (start, end) in &bounds {
-            pieces.push(&data[*start..*end])
+        let mut comm_ps = Vec::new();
+
+        let sections: Vec<_> = start_positions
+            .iter()
+            .zip(node_lengths)
+            .map(|(pos, length)| (*pos, *length))
+            .collect();
+
+        for (start, length) in &sections {
+            let piece = &data[*start * NODE_SIZE..(*start + *length) * NODE_SIZE];
+            pieces.push(piece);
+            let comm_p = generate_piece_commitment_bytes::<H>(piece);
+            comm_ps.push(comm_p.unwrap());
         }
 
-        assert_eq!(
-            true,
-            verify_file_inclusion_proofs(&tree.root(), &proofs, &pieces),
+        let piece_tree = create_piece_tree::<H>(
+            &data
+                .chunks(32)
+                .map(|x| H::Domain::try_from_bytes(x).unwrap())
+                .collect::<Vec<_>>(),
         );
+        assert_eq!(tree.leafs(), piece_tree.leafs());
 
-        let mut wrong_data = Vec::<u8>::with_capacity(size);
-        let mut wrong_pieces = Vec::new();
+        let mut piece_specs = Vec::new();
+        for (comm_p, (position, length)) in comm_ps.iter().zip(sections.clone()) {
+            piece_specs.push(PieceSpec {
+                comm_p: &comm_p,
+                position,
+                length,
+            })
+        }
 
-        for i in 0..size {
-            wrong_data.push(
-                ((i / NODE_BYTES) + (2 * i)
-                // Mask out two most significant bits so we will always be Fr32,
-                & 63) as u8,
+        let proofs = piece_inclusion_proofs::<H>(&piece_specs, &tree);
+
+        if expect_alignment_error {
+            assert!(proofs.is_err());
+        } else {
+            let proofs = proofs.unwrap();
+            for (proof, piece_spec) in proofs.iter().zip(piece_specs.clone()) {
+                let (_, proof_length) = piece_spec.compute_packing(nodes).unwrap();
+                assert_eq!(proof.proof_elements.len(), proof_length);
+            }
+
+            assert_eq!(
+                true,
+                PieceInclusionProof::verify_all(
+                    &tree.root().into_bytes(),
+                    proofs.as_slice(),
+                    &comm_ps,
+                    &node_lengths,
+                    nodes,
+                )
+                .unwrap()
+            );
+        }
+
+        if !expect_alignment_error {
+            let proofs = piece_inclusion_proofs::<H>(&piece_specs, &tree);
+
+            let mut wrong_data = Vec::<u8>::with_capacity(size);
+            let mut wrong_pieces = Vec::new();
+            let mut wrong_comm_ps = Vec::new();
+            for i in 0..size {
+                wrong_data.push(
+                    ((i / NODE_SIZE) + (2 * i)
+                        // Mask out two most significant bits so we will always be Fr32,
+                        & 63) as u8,
+                )
+            }
+
+            for (start, length) in &sections {
+                let wrong_piece = &wrong_data[*start * NODE_SIZE..(*start + *length) * NODE_SIZE];
+                wrong_pieces.push(wrong_piece);
+                wrong_comm_ps.push(generate_piece_commitment_bytes::<H>(wrong_piece).unwrap());
+            }
+
+            assert_eq!(
+                false,
+                PieceInclusionProof::verify_all(
+                    &tree.root().into_bytes(),
+                    &proofs.unwrap(),
+                    &wrong_comm_ps,
+                    &node_lengths,
+                    nodes
+                )
+                .unwrap(),
             )
         }
+    }
 
-        for (start, end) in &bounds {
-            wrong_pieces.push(&wrong_data[*start..*end])
-        }
-
-        assert_eq!(
-            false,
-            verify_file_inclusion_proofs(&tree.root(), &proofs, &wrong_pieces),
-        )
+    #[test]
+    fn test_subtree_capacity() {
+        assert_eq!(subtree_capacity(0, 16), 16);
+        assert_eq!(subtree_capacity(1, 16), 1);
+        assert_eq!(subtree_capacity(2, 16), 2);
+        assert_eq!(subtree_capacity(3, 16), 1);
+        assert_eq!(subtree_capacity(4, 16), 4);
+        assert_eq!(subtree_capacity(5, 16), 1);
+        assert_eq!(subtree_capacity(6, 16), 2);
+        assert_eq!(subtree_capacity(7, 16), 1);
+        assert_eq!(subtree_capacity(8, 16), 8);
+        assert_eq!(subtree_capacity(9, 16), 1);
+        assert_eq!(subtree_capacity(10, 16), 2);
+        assert_eq!(subtree_capacity(11, 16), 1);
+        assert_eq!(subtree_capacity(12, 16), 4);
+        assert_eq!(subtree_capacity(13, 16), 1);
+        assert_eq!(subtree_capacity(14, 16), 2);
+        assert_eq!(subtree_capacity(15, 16), 1);
     }
 }


### PR DESCRIPTION
Implements first part of #592.

Probably needs some interface tweaks for integration.

For now, only aligned proofs are supported. However, my goal was to provide an interface compatible with later addition of unaligned proofs.

In particular,
  - Before packing, call `PieceSpec::compute_packing` to receive a packing list and proof size.
    - Packing list provides the ordering in which arbitrary piece segments should be added to the sector.
    - Proof size allows for comparison of alternate alignments to evaluate the cost (in proof size) of padding decisions.
  - Proofs always contain size and position of the piece. (This can be two 64-bit numbers. If we want to optimize for proof size of the aligned case, we can add some kind of type tag. If we want to compress somehow, we can.) With size and position, we have all the information needed to deterministically calculate a packing order and therefore a proof shape.
  - Proofs have a variable-size component (returned by `analyze`). The variable-size component is a sequence of `H::Domain` elements, which the verifier must be able to interpret.

### NOTE (cc: @dig)
 - verification requires both sector size and piece size. Otherwise a miner could just store `CommP` in a leaf and produce a valid proof that it is contained in the sector. (cc: @sidke)

**[UPDATE: I reworked a lot since writing the below. It might be possible to reintroduce the merkle-tree personalization without too much problem now. However, if it's awkward, I still think we can do without it.]**
 - ~I removed the 'personalization', which makes merkle-tree hashes depend on height in the tree. I did this so we can use normal merkle-proof verification to verify inclusion of CommP in CommD. Otherwise, we will need a modified proof verification which takes height as a parameter.~

   ~The most general form of PIP involves roots of sub-trees, proof that these are included in piece trees, and proofs of piece trees within sectors. We can most easily use the general merkle-tree apparatus if we don't also try to encode height in the hashing (though we do need to account for length of proof paths).~

   ~I don't think we lose anything by removing the hash 'personalization' or that we ever really needed it.~