### PR TITLE
Add CompoundProof Requirements + ChallengeRequirements

### DIFF
--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -42,7 +42,7 @@ use storage_proofs::drgraph::*;
 use storage_proofs::example_helper::prettyb;
 use storage_proofs::fr32::fr_into_bytes;
 use storage_proofs::hasher::{Blake2sHasher, Hasher, PedersenHasher, Sha256Hasher};
-use storage_proofs::layered_drgporep::{self, LayerChallenges};
+use storage_proofs::layered_drgporep::{self, ChallengeRequirements, LayerChallenges};
 use storage_proofs::porep::PoRep;
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::zigzag_drgporep::*;
@@ -371,8 +371,15 @@ fn do_the_work<H: 'static>(
                 for _ in 0..samples {
                     let start = Instant::now();
                     let cur_result = result;
-                    ZigZagCompound::verify(&compound_public_params, &pub_inputs, &multi_proof)
-                        .unwrap();
+                    ZigZagCompound::verify(
+                        &compound_public_params,
+                        &pub_inputs,
+                        &multi_proof,
+                        &ChallengeRequirements {
+                            minimum_challenges: 1,
+                        },
+                    )
+                    .unwrap();
                     // If one verification fails, result becomes permanently false.
                     result = result && cur_result;
                     total_groth_verifying += start.elapsed();

--- a/storage-proofs/src/batchpost.rs
+++ b/storage-proofs/src/batchpost.rs
@@ -11,7 +11,7 @@ use crate::error::Result;
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::MerkleTree;
 use crate::merklepor;
-use crate::proof::ProofScheme;
+use crate::proof::{NoRequirements, ProofScheme};
 use crate::util::data_at_node;
 
 #[derive(Clone, Debug)]
@@ -71,6 +71,7 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for BatchPoST<H> {
     type PublicInputs = PublicInputs<'a, H::Domain>;
     type PrivateInputs = PrivateInputs<'a, H>;
     type Proof = Proof<H>;
+    type Requirements = NoRequirements;
 
     fn setup(_sp: &Self::SetupParams) -> Result<Self::PublicParams> {
         // merklepor does not have a setup currently

--- a/storage-proofs/src/beacon_post.rs
+++ b/storage-proofs/src/beacon_post.rs
@@ -9,7 +9,7 @@ use crate::error::{Error, Result};
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::MerkleTree;
 use crate::parameter_cache::ParameterSetIdentifier;
-use crate::proof::ProofScheme;
+use crate::proof::{NoRequirements, ProofScheme};
 use crate::vdf::Vdf;
 use crate::vdf_post;
 
@@ -118,6 +118,7 @@ where
     type PublicInputs = PublicInputs<H::Domain>;
     type PrivateInputs = PrivateInputs<'a, H>;
     type Proof = Proof<'a, H, V>;
+    type Requirements = NoRequirements;
 
     fn setup(sp: &SetupParams<H::Domain, V>) -> Result<PublicParams<H::Domain, V>> {
         Ok(PublicParams {

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -536,7 +536,7 @@ mod tests {
     use crate::fr32::{bytes_into_fr, fr_into_bytes};
     use crate::hasher::{Blake2sHasher, Hasher, PedersenHasher};
     use crate::porep::PoRep;
-    use crate::proof::ProofScheme;
+    use crate::proof::{NoRequirements, ProofScheme};
     use crate::util::data_at_node;
 
     use ff::Field;
@@ -833,8 +833,13 @@ mod tests {
             )
             .expect("failed while proving");
 
-            let verified = DrgPoRepCompound::<H, _>::verify(&public_params, &public_inputs, &proof)
-                .expect("failed while verifying");
+            let verified = DrgPoRepCompound::<H, _>::verify(
+                &public_params,
+                &public_inputs,
+                &proof,
+                &NoRequirements,
+            )
+            .expect("failed while verifying");
 
             assert!(verified);
         }

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -245,6 +245,7 @@ impl<'a, E: JubjubEngine, H: Hasher> PoRCircuit<'a, E, H> {
 mod tests {
     use super::*;
 
+    use crate::proof::NoRequirements;
     use ff::Field;
     use rand::{Rng, SeedableRng, XorShiftRng};
     use sapling_crypto::circuit::multipack;
@@ -309,9 +310,13 @@ mod tests {
             )
             .expect("failed while proving");
 
-            let verified =
-                PoRCompound::<PedersenHasher>::verify(&public_params, &public_inputs, &proof)
-                    .expect("failed while verifying");
+            let verified = PoRCompound::<PedersenHasher>::verify(
+                &public_params,
+                &public_inputs,
+                &proof,
+                &NoRequirements,
+            )
+            .expect("failed while verifying");
             assert!(verified);
 
             let (circuit, inputs) = PoRCompound::<PedersenHasher>::circuit_for_test(
@@ -507,8 +512,9 @@ mod tests {
                 assert!(cs.verify(&inputs));
             }
 
-            let verified = PoRCompound::<H>::verify(&public_params, &public_inputs, &proof)
-                .expect("failed while verifying");
+            let verified =
+                PoRCompound::<H>::verify(&public_params, &public_inputs, &proof, &NoRequirements)
+                    .expect("failed while verifying");
             assert!(verified);
         }
     }

--- a/storage-proofs/src/circuit/porc.rs
+++ b/storage-proofs/src/circuit/porc.rs
@@ -293,7 +293,7 @@ mod tests {
     use crate::fr32::fr_into_bytes;
     use crate::hasher::pedersen::*;
     use crate::porc::{self, PoRC};
-    use crate::proof::ProofScheme;
+    use crate::proof::{NoRequirements, ProofScheme};
 
     #[test]
     fn test_porc_circuit_with_bls12_381() {
@@ -445,8 +445,13 @@ mod tests {
         assert!(cs.is_satisfied());
         assert!(cs.verify(&inputs));
 
-        let verified = PoRCCompound::<PedersenHasher>::verify(&pub_params, &pub_inputs, &proof)
-            .expect("failed while verifying");
+        let verified = PoRCCompound::<PedersenHasher>::verify(
+            &pub_params,
+            &pub_inputs,
+            &proof,
+            &NoRequirements,
+        )
+        .expect("failed while verifying");
 
         assert!(verified);
     }

--- a/storage-proofs/src/circuit/vdf_post.rs
+++ b/storage-proofs/src/circuit/vdf_post.rs
@@ -383,7 +383,7 @@ mod tests {
     use crate::drgraph::{new_seed, BucketGraph, Graph};
     use crate::fr32::fr_into_bytes;
     use crate::hasher::pedersen::*;
-    use crate::proof::ProofScheme;
+    use crate::proof::{NoRequirements, ProofScheme};
     use crate::vdf_post;
     use crate::vdf_sloth;
 
@@ -632,7 +632,7 @@ mod tests {
         //     }
         // }
 
-        let verified = VDFPostCompound::verify(&pub_params, &pub_inputs, &proof)
+        let verified = VDFPostCompound::verify(&pub_params, &pub_inputs, &proof, &NoRequirements)
             .expect("failed while verifying");
 
         assert!(verified);

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -378,7 +378,7 @@ mod tests {
     use crate::drgraph::new_seed;
     use crate::fr32::fr_into_bytes;
     use crate::hasher::{Blake2sHasher, Hasher, PedersenHasher};
-    use crate::layered_drgporep::{self, LayerChallenges};
+    use crate::layered_drgporep::{self, ChallengeRequirements, LayerChallenges};
     use crate::porep::PoRep;
     use crate::proof::ProofScheme;
 
@@ -698,8 +698,15 @@ mod tests {
         )
         .expect("failed while proving");
 
-        let verified = ZigZagCompound::verify(&public_params, &public_inputs, &proof)
-            .expect("failed while verifying");
+        let verified = ZigZagCompound::verify(
+            &public_params,
+            &public_inputs,
+            &proof,
+            &ChallengeRequirements {
+                minimum_challenges: 1,
+            },
+        )
+        .expect("failed while verifying");
 
         assert!(verified);
     }

--- a/storage-proofs/src/compound_proof.rs
+++ b/storage-proofs/src/compound_proof.rs
@@ -119,10 +119,19 @@ where
         public_params: &PublicParams<'a, E, S>,
         public_inputs: &S::PublicInputs,
         multi_proof: &MultiProof<E>,
+        requirements: &S::Requirements,
     ) -> Result<bool> {
         let vanilla_public_params = &public_params.vanilla_params;
         let pvk = groth16::prepare_verifying_key(&multi_proof.verifying_key);
         if multi_proof.circuit_proofs.len() != Self::partition_count(public_params) {
+            return Ok(false);
+        }
+
+        if !<S as ProofScheme>::satisfies_requirements(
+            &public_params.vanilla_params,
+            requirements,
+            multi_proof.circuit_proofs.len(),
+        ) {
             return Ok(false);
         }
 

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -12,7 +12,7 @@ use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::porep::{self, PoRep};
-use crate::proof::ProofScheme;
+use crate::proof::{NoRequirements, ProofScheme};
 use crate::vde::{self, decode_block, decode_domain_block};
 
 #[derive(Debug, Clone)]
@@ -248,6 +248,7 @@ where
     type PublicInputs = PublicInputs<H::Domain>;
     type PrivateInputs = PrivateInputs<'a, H>;
     type Proof = Proof<H>;
+    type Requirements = NoRequirements;
 
     fn setup(sp: &Self::SetupParams) -> Result<Self::PublicParams> {
         let graph = G::new(

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -124,6 +124,11 @@ pub struct Tau<T: Domain> {
     pub comm_r_star: T,
 }
 
+#[derive(Default)]
+pub struct ChallengeRequirements {
+    pub minimum_challenges: usize,
+}
+
 impl<T: Domain> Tau<T> {
     /// Return a single porep::Tau with the initial data and final replica commitments of layer_taus.
     pub fn simplify(&self) -> porep::Tau<T> {
@@ -486,6 +491,7 @@ impl<'a, L: Layers> ProofScheme<'a> for L {
     type PublicInputs = PublicInputs<<L::Hasher as Hasher>::Domain>;
     type PrivateInputs = PrivateInputs<L::Hasher>;
     type Proof = Proof<L::Hasher>;
+    type Requirements = ChallengeRequirements;
 
     fn setup(sp: &Self::SetupParams) -> Result<Self::PublicParams> {
         let graph = L::Graph::new(
@@ -626,6 +632,16 @@ impl<'a, L: Layers> ProofScheme<'a> for L {
             comm_r_star: pub_in.comm_r_star,
             k,
         }
+    }
+
+    fn satisfies_requirements(
+        public_params: &PublicParams<L::Hasher, L::Graph>,
+        requirements: &ChallengeRequirements,
+        partitions: usize,
+    ) -> bool {
+        let partition_challenges = public_params.layer_challenges.total_challenges();
+
+        partition_challenges * partitions >= requirements.minimum_challenges
     }
 }
 

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -6,7 +6,7 @@ use crate::error::*;
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
 use crate::parameter_cache::ParameterSetIdentifier;
-use crate::proof::ProofScheme;
+use crate::proof::{NoRequirements, ProofScheme};
 
 /// The parameters shared between the prover and verifier.
 #[derive(Clone, Debug)]
@@ -75,6 +75,7 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for MerklePoR<H> {
     type PublicInputs = PublicInputs<H::Domain>;
     type PrivateInputs = PrivateInputs<'a, H>;
     type Proof = Proof<H>;
+    type Requirements = NoRequirements;
 
     fn setup(sp: &SetupParams) -> Result<PublicParams> {
         Ok(PublicParams {

--- a/storage-proofs/src/porc.rs
+++ b/storage-proofs/src/porc.rs
@@ -10,7 +10,7 @@ use crate::error::{Error, Result};
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
 use crate::parameter_cache::ParameterSetIdentifier;
-use crate::proof::ProofScheme;
+use crate::proof::{NoRequirements, ProofScheme};
 
 #[derive(Debug, Clone)]
 pub struct SetupParams {
@@ -93,6 +93,7 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for PoRC<'a, H> {
     type PublicInputs = PublicInputs<'a, H::Domain>;
     type PrivateInputs = PrivateInputs<'a, H>;
     type Proof = Proof<H>;
+    type Requirements = NoRequirements;
 
     fn setup(sp: &Self::SetupParams) -> Result<Self::PublicParams> {
         Ok(PublicParams {

--- a/storage-proofs/src/proof.rs
+++ b/storage-proofs/src/proof.rs
@@ -13,6 +13,7 @@ pub trait ProofScheme<'a> {
     type PublicInputs: Clone;
     type PrivateInputs;
     type Proof: Clone + Serialize + DeserializeOwned;
+    type Requirements: Default;
 
     /// setup is used to generate public parameters from setup parameters in order to specialize
     /// a ProofScheme to the specific parameters required by a consumer.
@@ -88,4 +89,15 @@ pub trait ProofScheme<'a> {
     fn with_partition(pub_in: Self::PublicInputs, _k: Option<usize>) -> Self::PublicInputs {
         pub_in
     }
+
+    fn satisfies_requirements(
+        _pub_params: &Self::PublicParams,
+        _requirements: &Self::Requirements,
+        _partitions: usize,
+    ) -> bool {
+        true
+    }
 }
+
+#[derive(Default)]
+pub struct NoRequirements;

--- a/storage-proofs/src/vdf_post.rs
+++ b/storage-proofs/src/vdf_post.rs
@@ -16,7 +16,7 @@ use crate::hasher::{Domain, HashFunction, Hasher};
 use crate::merkle::MerkleTree;
 use crate::parameter_cache::ParameterSetIdentifier;
 use crate::porc::{self, PoRC};
-use crate::proof::ProofScheme;
+use crate::proof::{NoRequirements, ProofScheme};
 use crate::vdf::Vdf;
 
 #[derive(Clone, Debug)]
@@ -131,6 +131,7 @@ impl<'a, H: Hasher + 'a, V: Vdf<H::Domain>> ProofScheme<'a> for VDFPoSt<H, V> {
     type PublicInputs = PublicInputs<H::Domain>;
     type PrivateInputs = PrivateInputs<'a, H>;
     type Proof = Proof<'a, H, V>;
+    type Requirements = NoRequirements;
 
     fn setup(sp: &Self::SetupParams) -> Result<Self::PublicParams> {
         // Sector sizes which are powers of two have the form 100000 (i.e. leading one and all zeroes after).


### PR DESCRIPTION
This lays the groundwork for ensuring proofs meets some minimum challenge requirement, regardless of how many partitions are used. Previously we had no way of enforcing aggregate requirements. This corrects that.

It adds a general mechanism allowing `Requirements` to be specified to any `ProofScheme`. These requirements are passed as a parameter to a new `satisifies_requirements` trait method. This method also receives public parameters and number of partitions. This allows it to determine whether the proof's public parameters meet requirements when divided into a given number of partitions.

Also included is a simple `ChallengeRequirements` impelementation for layered proofs. This ensures that the total number of challenges across all partitions is at least some minimum. For now, I set the minimum for all PoReps created from the API at 1. So this should never fail. Eventually, this should prevent us from creating configurations (or somehow accidentally attempting to verify proofs) which don't meet challenge security.

Testing this will be a bit annoying, so I leave that for later when we have something meaningful to test.