### PR TITLE
support variable-length proofs

### DIFF
--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -363,6 +363,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
             (*resp).flattened_proofs_len,
             (*resp).faults_ptr,
             (*resp).faults_len,
+            SINGLE_PARTITION_PROOF_LEN as usize,
         );
         defer!(destroy_verify_post_response(resp));
 

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -39,26 +39,13 @@ use storage_proofs::vdf_sloth::{self, Sloth};
 use storage_proofs::zigzag_drgporep::ZigZagDrgPoRep;
 use storage_proofs::zigzag_graph::ZigZagBucketGraph;
 
+const SINGLE_PARTITION_PROOF_LEN: usize = 192;
+
 pub type Commitment = Fr32Ary;
 pub type ChallengeSeed = Fr32Ary;
 
 /// FrSafe is an array of the largest whole number of bytes guaranteed not to overflow the field.
 type FrSafe = [u8; 31];
-
-/// How big, in bytes, is the SNARK proof exposed by the API?
-///
-/// Note: These values need to be kept in sync with what's in api/mod.rs.
-/// Due to limitations of cbindgen, we can't define a constant whose value is
-/// a non-primitive (e.g. an expression like 192 * 2 or internal::STUFF) and
-/// see the constant in the generated C-header file.
-const SNARK_BYTES: usize = 192;
-const POREP_PARTITIONS: usize = 2;
-const POREP_PROOF_BYTES: usize = SNARK_BYTES * POREP_PARTITIONS;
-
-const POST_PARTITIONS: usize = 1;
-const POST_PROOF_BYTES: usize = SNARK_BYTES * POST_PARTITIONS;
-
-type SnarkProof = [u8; POREP_PROOF_BYTES];
 
 lazy_static! {
     pub static ref ENGINE_PARAMS: JubjubBls12 = JubjubBls12::new();
@@ -375,17 +362,13 @@ pub fn generate_post_fixed_sectors_count(
     let proof = VDFPostCompound::prove(&pub_params, &pub_inputs, &priv_inputs, &groth_params)
         .expect("failed while proving");
 
-    let mut buf = Vec::with_capacity(POST_PROOF_BYTES);
+    let mut buf = Vec::with_capacity(
+        SINGLE_PARTITION_PROOF_LEN * usize::from(PoStProofPartitions::from(fixed.post_config)),
+    );
 
     proof.write(&mut buf)?;
 
-    let mut proof_bytes = [0; POST_PROOF_BYTES];
-    proof_bytes.copy_from_slice(&buf);
-
-    Ok(GeneratePoStFixedSectorsCountOutput {
-        proof: proof_bytes,
-        faults,
-    })
+    Ok(GeneratePoStFixedSectorsCountOutput { proof: buf, faults })
 }
 
 fn verify_post_fixed_sectors_count(
@@ -429,9 +412,12 @@ fn verify_post_fixed_sectors_count(
 
     let verifying_key = get_post_verifying_key(fixed.post_config)?;
 
+    let num_post_proof_bytes =
+        SINGLE_PARTITION_PROOF_LEN * usize::from(PoStProofPartitions::from(fixed.post_config));
+
     let proof = MultiProof::new_from_reader(
         Some(usize::from(PoStProofPartitions::from(fixed.post_config))),
-        &fixed.proof[0..192],
+        &fixed.proof[0..num_post_proof_bytes],
         &verifying_key,
     )?;
 
@@ -458,11 +444,12 @@ fn make_merkle_tree<T: Into<PathBuf> + AsRef<Path>>(
     public_params(bytes).graph.merkle_tree(&data)
 }
 
+#[derive(Clone, Debug)]
 pub struct SealOutput {
     pub comm_r: Commitment,
     pub comm_r_star: Commitment,
     pub comm_d: Commitment,
-    pub snark_proof: SnarkProof,
+    pub proof: Vec<u8>,
 }
 
 /// Minimal support for cleaning (deleting) a file unless it was successfully populated.
@@ -558,14 +545,11 @@ pub fn seal<T: Into<PathBuf> + AsRef<Path>>(
         &groth_params,
     )?;
 
-    // TODO: POREP_PROOF_BYTES needs to be a function of PoRepPartitions
-    let mut buf = Vec::with_capacity(POREP_PROOF_BYTES);
+    let mut buf = Vec::with_capacity(
+        SINGLE_PARTITION_PROOF_LEN * usize::from(PoRepProofPartitions::from(porep_config)),
+    );
 
     proof.write(&mut buf)?;
-
-    // TODO: POREP_PROOF_BYTES needs to be a function of PoRepPartitions
-    let mut proof_bytes = [0; POREP_PROOF_BYTES];
-    proof_bytes.copy_from_slice(&buf);
 
     let comm_r = commitment_from_fr::<Bls12>(public_tau.comm_r.into());
     let comm_d = commitment_from_fr::<Bls12>(public_tau.comm_d.into());
@@ -580,7 +564,7 @@ pub fn seal<T: Into<PathBuf> + AsRef<Path>>(
         comm_r_star,
         prover_id_in,
         sector_id_in,
-        &proof_bytes,
+        &buf,
     )
     .expect("post-seal verification sanity check failed");
 
@@ -588,7 +572,7 @@ pub fn seal<T: Into<PathBuf> + AsRef<Path>>(
         comm_r,
         comm_r_star,
         comm_d,
-        snark_proof: proof_bytes,
+        proof: buf,
     })
 }
 
@@ -650,7 +634,7 @@ pub fn verify_seal(
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: &setup_params(PaddedBytesAmount::from(porep_config)),
         engine_params: &(*ENGINE_PARAMS),
-        partitions: Some(POREP_PARTITIONS),
+        partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
     };
 
     let compound_public_params: compound_proof::PublicParams<
@@ -779,8 +763,8 @@ mod tests {
             comm_r,
             comm_d,
             comm_r_star,
-            snark_proof,
-        } = seal_output;
+            proof,
+        } = seal_output.clone();
 
         // valid commitments
         {
@@ -791,7 +775,7 @@ mod tests {
                 comm_r_star,
                 &prover_id,
                 &sector_id,
-                &snark_proof,
+                &proof,
             )
             .expect("failed to run verify_seal");
 
@@ -861,7 +845,7 @@ mod tests {
                 h.seal_output.comm_r,
                 &h.prover_id,
                 &h.sector_id,
-                &h.seal_output.snark_proof,
+                &h.seal_output.proof,
             )
             .expect("failed to run verify_seal");
 

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -22,7 +22,7 @@ pub struct VerifyPoStDynamicSectorsCountInput {
     pub post_config: PoStConfig,
     pub comm_rs: Vec<Commitment>,
     pub challenge_seed: ChallengeSeed,
-    pub proofs: Vec<[u8; 192]>,
+    pub proofs: Vec<Vec<u8>>,
     pub faults: Vec<u64>,
 }
 
@@ -30,17 +30,17 @@ pub struct VerifyPoStFixedSectorsCountInput {
     pub post_config: PoStConfig,
     pub comm_rs: [Commitment; POST_SECTORS_COUNT],
     pub challenge_seed: ChallengeSeed,
-    pub proof: [u8; 192],
+    pub proof: Vec<u8>,
     pub faults: Vec<u64>,
 }
 
 pub struct GeneratePoStDynamicSectorsCountOutput {
-    pub proofs: Vec<[u8; 192]>,
+    pub proofs: Vec<Vec<u8>>,
     pub faults: Vec<u64>,
 }
 
 pub struct GeneratePoStFixedSectorsCountOutput {
-    pub proof: [u8; 192],
+    pub proof: Vec<u8>,
     pub faults: Vec<u64>,
 }
 
@@ -155,7 +155,7 @@ pub fn verify_post_spread_input(
 ) -> error::Result<Vec<VerifyPoStFixedSectorsCountInput>> {
     let faults_len = dynamic.faults.len();
     let commrs_len = dynamic.comm_rs.len();
-    let proofs_len = dynamic.proofs.len();
+    let proofs_len = { dynamic.proofs.len() };
     let replicas_c = (commrs_len as f64 / POST_SECTORS_COUNT as f64).ceil() as usize;
     let faults_max = dynamic.faults.iter().max();
 
@@ -204,7 +204,7 @@ pub fn verify_post_spread_input(
             post_config: dynamic.post_config,
             comm_rs,
             challenge_seed: dynamic.challenge_seed,
-            proof: dynamic.proofs[i],
+            proof: dynamic.proofs[i].clone(),
             faults: Vec::new(),
         })
     }
@@ -231,7 +231,7 @@ pub fn verify_post_spread_input(
             post_config: dynamic.post_config,
             comm_rs,
             challenge_seed: dynamic.challenge_seed,
-            proof: dynamic.proofs[proofs_len - 1],
+            proof: dynamic.proofs[proofs_len - 1].to_vec(),
             faults: Vec::new(),
         })
     }
@@ -403,8 +403,8 @@ mod tests {
 
     #[test]
     fn test_verify_post_dynamic_to_fixed_input() {
-        let proof_a = [0; 192];
-        let proof_b = [1; 192];
+        let proof_a = [0; 192].to_vec();
+        let proof_b = [1; 192].to_vec();
 
         let comm_r_a = [0; 32];
         let comm_r_b = [1; 32];
@@ -593,23 +593,23 @@ mod tests {
     #[test]
     fn test_generate_post_fixed_to_dynamic_output() {
         let fixed_a = GeneratePoStFixedSectorsCountOutput {
-            proof: [0; 192],
+            proof: [0; 192].to_vec(),
             faults: vec![0, 1],
         };
         let fixed_b = GeneratePoStFixedSectorsCountOutput {
-            proof: [0; 192],
+            proof: [0; 192].to_vec(),
             faults: vec![0, 1],
         };
         let fixed_c = GeneratePoStFixedSectorsCountOutput {
-            proof: [1; 192],
+            proof: [1; 192].to_vec(),
             faults: vec![],
         };
         let fixed_d = GeneratePoStFixedSectorsCountOutput {
-            proof: [2; 192],
+            proof: [2; 192].to_vec(),
             faults: vec![1],
         };
         let fixed_e = GeneratePoStFixedSectorsCountOutput {
-            proof: [2; 192],
+            proof: [2; 192].to_vec(),
             faults: vec![0, 1],
         };
 

--- a/filecoin-proofs/src/api/responses.rs
+++ b/filecoin-proofs/src/api/responses.rs
@@ -1,6 +1,5 @@
 use crate::api::sector_builder::errors::SectorBuilderErr;
 use crate::api::sector_builder::SectorBuilder;
-use crate::api::API_POREP_PROOF_BYTES;
 use drop_struct_macro_derive::DropStructMacro;
 use failure::Error;
 use ffi_toolkit::free_c_str;
@@ -277,7 +276,8 @@ pub struct GetSealStatusResponse {
     pub comm_r_star: [u8; 32],
     pub sector_access: *const libc::c_char,
     pub sector_id: u64,
-    pub snark_proof: [u8; API_POREP_PROOF_BYTES],
+    pub proofs_len: libc::size_t,
+    pub proofs_ptr: *const u8,
     pub pieces_len: libc::size_t,
     pub pieces_ptr: *const FFIPieceMetadata,
 }
@@ -294,19 +294,17 @@ impl Default for GetSealStatusResponse {
         GetSealStatusResponse {
             status_code: FCPResponseStatus::FCPNoError,
             error_msg: ptr::null(),
-
-            seal_status_code: FFISealStatus::Failed,
-
-            seal_error_msg: ptr::null(),
-
             comm_d: Default::default(),
             comm_r: Default::default(),
             comm_r_star: Default::default(),
             pieces_len: 0,
             pieces_ptr: ptr::null(),
+            proofs_len: 0,
+            proofs_ptr: ptr::null(),
+            seal_error_msg: ptr::null(),
+            seal_status_code: FFISealStatus::Failed,
             sector_access: ptr::null(),
             sector_id: 0,
-            snark_proof: [0; 384],
         }
     }
 }
@@ -345,11 +343,12 @@ pub struct FFISealedSectorMetadata {
     pub comm_d: [u8; 32],
     pub comm_r: [u8; 32],
     pub comm_r_star: [u8; 32],
-    pub sector_access: *const libc::c_char,
-    pub sector_id: u64,
-    pub snark_proof: [u8; API_POREP_PROOF_BYTES],
     pub pieces_len: libc::size_t,
     pub pieces_ptr: *const FFIPieceMetadata,
+    pub proofs_len: libc::size_t,
+    pub proofs_ptr: *const u8,
+    pub sector_access: *const libc::c_char,
+    pub sector_id: u64,
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/filecoin-proofs/src/api/sector_builder/helpers/seal.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/seal.rs
@@ -27,7 +27,7 @@ pub fn seal(
         comm_r,
         comm_d,
         comm_r_star,
-        snark_proof,
+        proof,
     } = seal_internal(
         (*sector_store.inner).proofs_config().porep_config(),
         &PathBuf::from(staged_sector.sector_access.clone()),
@@ -43,7 +43,7 @@ pub fn seal(
         comm_r_star,
         comm_r,
         comm_d,
-        snark_proof,
+        proof,
     };
 
     Ok(newly_sealed_sector)

--- a/filecoin-proofs/src/api/sector_builder/metadata.rs
+++ b/filecoin-proofs/src/api/sector_builder/metadata.rs
@@ -1,6 +1,5 @@
 use crate::api::sector_builder::SectorId;
 use crate::error;
-use crate::serde_big_array::BigArray;
 use byteorder::LittleEndian;
 use byteorder::WriteBytesExt;
 use sector_base::api::bytes_amount::UnpaddedBytesAmount;
@@ -23,9 +22,7 @@ pub struct SealedSectorMetadata {
     pub comm_r_star: [u8; 32],
     pub comm_r: [u8; 32],
     pub comm_d: [u8; 32],
-
-    #[serde(with = "BigArray")]
-    pub snark_proof: [u8; 384],
+    pub proof: Vec<u8>,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]
@@ -50,7 +47,7 @@ impl PartialEq for SealedSectorMetadata {
             && self.comm_r_star == other.comm_r_star
             && self.comm_r == other.comm_r
             && self.comm_d == other.comm_d
-            && self.snark_proof.iter().eq(other.snark_proof.iter())
+            && self.proof.iter().eq(other.proof.iter())
     }
 }
 
@@ -80,7 +77,7 @@ impl Default for SealedSectorMetadata {
             comm_r_star: Default::default(),
             comm_r: Default::default(),
             comm_d: Default::default(),
-            snark_proof: [0; 384],
+            proof: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Makes incremental progress towards multiple sector size epic.

## What's in this PR?

- modify FFI-exposed verification functions' types to accept proofs of different sizes
- write some functions to infer proof partitions from number of bytes in proof

## Hedging

I put this changeset together as quickly as I could in order to unblock @porcuquine. It's not of the highest quality (see over usage of `Vec<u8>`), but it can be improved upon in subsequent PRs.

## What's next?

- We should replace all the `Vec<u8>` stuff with a `PoStProof` enum with members for each proof length. Mixing up the length of these byte vectors is going to bite (byte?) us later.