### PR TITLE
add libstdc++ to deps list to accommodate rocksdb

### DIFF
--- a/filecoin-proofs/build.rs
+++ b/filecoin-proofs/build.rs
@@ -61,9 +61,9 @@ fn main() {
     let git_hash = String::from_utf8(git_output.stdout).unwrap();
 
     let libs = if cfg!(target_os = "linux") {
-        "-lutil -lutil -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -lutil"
+        "-lstdc++ -lutil -lutil -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -lutil"
     } else if cfg!(target_os = "macos") {
-        "-framework Security -lSystem -lresolv -lc -lm"
+        "-lstdc++ -framework Security -lSystem -lresolv -lc -lm"
     } else {
         ""
     };


### PR DESCRIPTION
Fixes #617 

## Why does this PR exist?

- we added rocksdb dependency recently, which means that the staticlib that we produce needs to be linked along with the C++ stdlib
- our packaging scripts don't build the pkg-config `Libs` list dynamically; this list needs to be updated every time the dependencies change

## What's in this PR?

- add `libstdc++` to hard-coded list of deps

## Next steps

We should [really be constructing that dependency list by consuming Rust compiler output](https://app.zenhub.com/workspaces/filecoin-5ab0036a12f8e82ae4ed60f0/issues/filecoin-project/rust-fil-proofs/616).