### PR TITLE
accept and return proof partitions through FFI + eliminate FFI enums + add seal verification to FFI test 

### DIFF
--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -284,8 +284,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
         (piece_bytes, piece_key)
     };
 
-    // poll for sealed sector metadata through the FFI and then verify that the
-    // proof was valid
+    // poll for sealed sector metadata through the FFI
     {
         let (result_tx, result_rx) = mpsc::channel();
         let (kill_tx, kill_rx) = mpsc::channel();

--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -13,6 +13,7 @@ extern crate sector_base;
 
 include!(concat!(env!("OUT_DIR"), "/libfilecoin_proofs.rs"));
 
+use byteorder::{LittleEndian, WriteBytesExt};
 use ffi_toolkit::c_str_to_rust_str;
 use ffi_toolkit::free_c_str;
 use ffi_toolkit::rust_str_to_c_str;
@@ -33,6 +34,18 @@ use tempfile::TempDir;
 ///////////////////////////////////////////////////////////////////////////////
 // SectorBuilder lifecycle test
 ///////////////////////////////
+
+fn u64_to_fr_safe(sector_id: u64) -> [u8; 31] {
+    let mut byte_vector = vec![];
+    byte_vector.write_u64::<LittleEndian>(sector_id).unwrap();
+    byte_vector.resize(31, 0);
+
+    let mut byte_array = [0; 31];
+    let bytes = &byte_vector[..byte_array.len()]; // panics if not enough data
+    byte_array.copy_from_slice(bytes);
+
+    byte_array
+}
 
 fn make_piece(num_bytes_in_piece: usize) -> (String, Vec<u8>) {
     let mut rng = thread_rng();
@@ -128,9 +141,9 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
     let sizes = if use_live_store {
         ConfigurableSizes {
             sector_class: FFISectorClass {
-                sector_size: FFISectorSize_SSB_TwoHundredFiftySixMiB,
-                seal_proof_partitions: FFISealProofPartitions_SPP_Two,
-                post_proof_partitions: FFIPoStProofPartitions_PPP_One,
+                sector_size: 266338304,
+                porep_proof_partitions: 2,
+                post_proof_partitions: 1,
             },
             max_bytes: 266338304,
             first_piece_bytes: 26214400,
@@ -140,9 +153,9 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
     } else {
         ConfigurableSizes {
             sector_class: FFISectorClass {
-                sector_size: FFISectorSize_SSB_OneKiB,
-                seal_proof_partitions: FFISealProofPartitions_SPP_Two,
-                post_proof_partitions: FFIPoStProofPartitions_PPP_One,
+                sector_size: 1024,
+                porep_proof_partitions: 2,
+                post_proof_partitions: 1,
             },
             max_bytes: 1016,
             first_piece_bytes: 100,
@@ -155,7 +168,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
         &metadata_dir,
         &staging_dir,
         &sealed_dir,
-        [0; 31],
+        u64_to_fr_safe(0),
         123,
         sizes.sector_class,
     );
@@ -249,7 +262,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
         &metadata_dir,
         &staging_dir,
         &sealed_dir,
-        [0; 31],
+        u64_to_fr_safe(0),
         123,
         sizes.sector_class,
     );
@@ -271,7 +284,8 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
         (piece_bytes, piece_key)
     };
 
-    // poll for sealed sector metadata through the FFI
+    // poll for sealed sector metadata through the FFI and then verify that the
+    // proof was valid
     {
         let (result_tx, result_rx) = mpsc::channel();
         let (kill_tx, kill_rx) = mpsc::channel();
@@ -288,6 +302,8 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
                 };
 
                 let resp = get_seal_status(sector_builder, 126);
+                defer!(destroy_get_seal_status_response(resp));
+
                 if (*resp).status_code != 0 {
                     return;
                 }
@@ -295,7 +311,6 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
                 if (*resp).seal_status_code == FFISealStatus_Sealed {
                     let _ = result_tx.send((*resp).sector_id).unwrap();
                 }
-                defer!(destroy_get_seal_status_response(resp));
 
                 thread::sleep(Duration::from_millis(1000));
             }
@@ -313,6 +328,34 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
         };
 
         assert_eq!(now_sealed_sector_id, 126);
+    }
+
+    // get sealed sector and verify the PoRep proof
+    {
+        let resp = get_seal_status(sector_builder_b, 126);
+
+        {
+            let resp2 = verify_seal(
+                sizes.sector_class.sector_size,
+                sizes.sector_class.porep_proof_partitions,
+                &mut (*resp).comm_r,
+                &mut (*resp).comm_d,
+                &mut (*resp).comm_r_star,
+                &mut u64_to_fr_safe(0),
+                &mut u64_to_fr_safe(126),
+                (*resp).proof_ptr,
+                (*resp).proof_len,
+            );
+            defer!(destroy_verify_seal_response(resp2));
+
+            if (*resp2).status_code != 0 {
+                panic!("{}", c_str_to_rust_str((*resp2).error_msg))
+            }
+
+            assert!((*resp2).is_valid)
+        }
+
+        destroy_get_seal_status_response(resp);
     }
 
     // get sealed sectors - we should have just one
@@ -356,6 +399,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
 
         let resp = verify_post(
             sizes.sector_class.sector_size,
+            sizes.sector_class.post_proof_partitions,
             &sealed_sector_replica_commitment[0],
             32,
             &mut challenge_seed,
@@ -363,7 +407,6 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
             (*resp).flattened_proofs_len,
             (*resp).faults_ptr,
             (*resp).faults_len,
-            SINGLE_PARTITION_PROOF_LEN as usize,
         );
         defer!(destroy_verify_post_response(resp));
 

--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -19,6 +19,8 @@ use ffi_toolkit::free_c_str;
 use ffi_toolkit::rust_str_to_c_str;
 use filecoin_proofs::error::ExpectWithBacktrace;
 use rand::{thread_rng, Rng};
+use sector_base::api::disk_backed_storage::LIVE_SECTOR_SIZE;
+use sector_base::api::disk_backed_storage::TEST_SECTOR_SIZE;
 use std::env;
 use std::error::Error;
 use std::io::Write;
@@ -141,7 +143,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
     let sizes = if use_live_store {
         ConfigurableSizes {
             sector_class: FFISectorClass {
-                sector_size: 266338304,
+                sector_size: LIVE_SECTOR_SIZE,
                 porep_proof_partitions: 2,
                 post_proof_partitions: 1,
             },
@@ -153,7 +155,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
     } else {
         ConfigurableSizes {
             sector_class: FFISectorClass {
-                sector_size: 1024,
+                sector_size: TEST_SECTOR_SIZE,
                 porep_proof_partitions: 2,
                 post_proof_partitions: 1,
             },

--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -338,7 +338,6 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
         {
             let resp2 = verify_seal(
                 sizes.sector_class.sector_size,
-                sizes.sector_class.porep_proof_partitions,
                 &mut (*resp).comm_r,
                 &mut (*resp).comm_d,
                 &mut (*resp).comm_r_star,

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -733,6 +733,7 @@ mod tests {
     use rand::{thread_rng, Rng};
     use sector_base::api::disk_backed_storage::new_sector_store;
     use sector_base::api::sector_class::SectorClass;
+    use sector_base::api::sector_size::SectorSize;
     use sector_base::api::sector_store::SectorStore;
     use std::fs::create_dir_all;
     use std::fs::File;
@@ -742,6 +743,12 @@ mod tests {
     use std::io::Write;
     use std::thread;
     use tempfile::NamedTempFile;
+
+    const TEST_CLASS: SectorClass = SectorClass(
+        SectorSize::OneKiB,
+        PoRepProofPartitions::Two,
+        PoStProofPartitions::One,
+    );
 
     struct Harness {
         prover_id: FrSafe,
@@ -1141,28 +1148,28 @@ mod tests {
     #[test]
     #[ignore] // Slow test – run only when compiled for release.
     fn seal_verify_test() {
-        seal_verify_aux(SectorClass::Test, BytesAmount::Max);
-        seal_verify_aux(SectorClass::Test, BytesAmount::Offset(5));
+        seal_verify_aux(TEST_CLASS, BytesAmount::Max);
+        seal_verify_aux(TEST_CLASS, BytesAmount::Offset(5));
     }
 
     #[test]
     #[ignore] // Slow test – run only when compiled for release.
     fn seal_unsealed_roundtrip_test() {
-        seal_unsealed_roundtrip_aux(SectorClass::Test, BytesAmount::Max);
-        seal_unsealed_roundtrip_aux(SectorClass::Test, BytesAmount::Offset(5));
+        seal_unsealed_roundtrip_aux(TEST_CLASS, BytesAmount::Max);
+        seal_unsealed_roundtrip_aux(TEST_CLASS, BytesAmount::Offset(5));
     }
 
     #[test]
     #[ignore] // Slow test – run only when compiled for release.
     fn seal_unsealed_range_roundtrip_test() {
-        seal_unsealed_range_roundtrip_aux(SectorClass::Test, BytesAmount::Max);
-        seal_unsealed_range_roundtrip_aux(SectorClass::Test, BytesAmount::Offset(5));
+        seal_unsealed_range_roundtrip_aux(TEST_CLASS, BytesAmount::Max);
+        seal_unsealed_range_roundtrip_aux(TEST_CLASS, BytesAmount::Offset(5));
     }
 
     #[test]
     #[ignore] // Slow test – run only when compiled for release.
     fn write_and_preprocess_overwrites_unaligned_last_bytes() {
-        write_and_preprocess_overwrites_unaligned_last_bytes_aux(SectorClass::Test);
+        write_and_preprocess_overwrites_unaligned_last_bytes_aux(TEST_CLASS);
     }
 
     #[test]
@@ -1172,9 +1179,7 @@ mod tests {
 
         let spawned = (0..threads)
             .map(|_| {
-                thread::spawn(|| {
-                    seal_unsealed_range_roundtrip_aux(SectorClass::Test, BytesAmount::Max)
-                })
+                thread::spawn(|| seal_unsealed_range_roundtrip_aux(TEST_CLASS, BytesAmount::Max))
             })
             .collect::<Vec<_>>();
 
@@ -1186,7 +1191,7 @@ mod tests {
     #[test]
     #[ignore]
     fn post_verify_test() {
-        post_verify_aux(SectorClass::Test, BytesAmount::Max);
+        post_verify_aux(TEST_CLASS, BytesAmount::Max);
     }
 
     #[test]

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -17,9 +17,10 @@ use crate::error::ExpectWithBacktrace;
 use crate::FCP_LOG;
 use sector_base::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount};
 use sector_base::api::porep_config::PoRepConfig;
-use sector_base::api::porep_config::PoRepProofPartitions;
+use sector_base::api::porep_proof_partitions::PoRepProofPartitions;
 use sector_base::api::post_config::PoStConfig;
-use sector_base::api::post_config::PoStProofPartitions;
+use sector_base::api::post_proof_partitions::PoStProofPartitions;
+use sector_base::api::SINGLE_PARTITION_PROOF_LEN;
 use sector_base::io::fr32::write_unpadded;
 use storage_proofs::circuit::multi_proof::MultiProof;
 use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
@@ -38,8 +39,6 @@ use storage_proofs::vdf_post::{self, VDFPoSt};
 use storage_proofs::vdf_sloth::{self, Sloth};
 use storage_proofs::zigzag_drgporep::ZigZagDrgPoRep;
 use storage_proofs::zigzag_graph::ZigZagBucketGraph;
-
-const SINGLE_PARTITION_PROOF_LEN: usize = 192;
 
 pub type Commitment = Fr32Ary;
 pub type ChallengeSeed = Fr32Ary;

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -23,7 +23,7 @@ use sector_base::api::post_config::PoStConfig;
 use sector_base::api::post_proof_partitions;
 use sector_base::api::post_proof_partitions::try_from_bytes;
 use sector_base::api::sector_class::SectorClass;
-use sector_base::api::sector_size::try_from_u64;
+use sector_base::api::sector_size;
 
 pub mod internal;
 pub mod post_adapter;
@@ -46,8 +46,8 @@ pub unsafe extern "C" fn verify_seal(
 ) -> *mut responses::VerifySealResponse {
     info!(FCP_LOG, "verify_seal: {}", "start"; "target" => "FFI");
 
-    let porep_config = try_from_u64(sector_size).and_then(|ss| {
-        porep_proof_partitions::try_from_u8(proof_partitions).map(|ppp| PoRepConfig::Live(ss, ppp))
+    let porep_config = sector_size::try_from_u64(sector_size).and_then(|ss| {
+        porep_proof_partitions::try_from_u8(proof_partitions).map(|ppp| PoRepConfig(ss, ppp))
     });
 
     let porep_bytes = try_into_porep_proof_bytes(proof_partitions, proof_ptr, proof_len);
@@ -155,8 +155,8 @@ pub unsafe extern "C" fn verify_post(
 ) -> *mut responses::VerifyPoSTResponse {
     info!(FCP_LOG, "verify_post: {}", "start"; "target" => "FFI");
 
-    let post_config = try_from_u64(sector_size).and_then(|ss| {
-        post_proof_partitions::try_from_u8(proof_partitions).map(|ppp| PoStConfig::Live(ss, ppp))
+    let post_config = sector_size::try_from_u64(sector_size).and_then(|ss| {
+        post_proof_partitions::try_from_u8(proof_partitions).map(|ppp| PoStConfig(ss, ppp))
     });
 
     let post_bytes =
@@ -245,7 +245,7 @@ pub unsafe extern "C" fn destroy_sector_builder(ptr: *mut SectorBuilder) {
 ///
 #[no_mangle]
 pub unsafe extern "C" fn get_max_user_bytes_per_staged_sector(sector_size: u64) -> u64 {
-    try_from_u64(sector_size)
+    sector_size::try_from_u64(sector_size)
         .map(UnpaddedBytesAmount::from)
         .map(u64::from)
         .unwrap_or(0)
@@ -603,12 +603,12 @@ pub fn try_from_ffi_sector_class(fsc: FFISectorClass) -> crate::error::Result<Se
             porep_proof_partitions,
             post_proof_partitions,
         } => {
-            let r_ss = try_from_u64(sector_size);
+            let r_ss = sector_size::try_from_u64(sector_size);
             let r_prep = porep_proof_partitions::try_from_u8(porep_proof_partitions);
             let r_post = post_proof_partitions::try_from_u8(post_proof_partitions);
 
             r_ss.and_then(|ss| {
-                r_prep.and_then(|prep| r_post.map(|post| SectorClass::Live(ss, prep, post)))
+                r_prep.and_then(|prep| r_post.map(|post| SectorClass(ss, prep, post)))
             })
         }
     }

--- a/filecoin-proofs/src/api/post_adapter.rs
+++ b/filecoin-proofs/src/api/post_adapter.rs
@@ -1,10 +1,11 @@
+use std::iter::repeat;
+use std::iter::repeat_with;
+
 use crate::api::internal::ChallengeSeed;
 use crate::api::internal::Commitment;
 use crate::api::internal::POST_SECTORS_COUNT;
 use crate::error;
 use sector_base::api::post_config::PoStConfig;
-use std::iter::repeat;
-use std::iter::repeat_with;
 
 pub struct GeneratePoStDynamicSectorsCountInput {
     pub post_config: PoStConfig,
@@ -318,6 +319,10 @@ pub fn verify_post_collect_output(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use sector_base::api::post_proof_partitions::PoStProofPartitions;
+    use sector_base::api::sector_size::SectorSize;
+
+    const TEST_CONFIG: PoStConfig = PoStConfig(SectorSize::OneKiB, PoStProofPartitions::One);
 
     fn sector_access_flattened(fixed: &[GeneratePoStFixedSectorsCountInput]) -> Vec<&String> {
         fixed
@@ -347,19 +352,19 @@ mod tests {
     #[test]
     fn test_generate_post_dynamic_to_fixed_input() {
         let dynamic_a = GeneratePoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             challenge_seed: [0; 32],
             input_parts: vec![],
         };
 
         let dynamic_b = GeneratePoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             challenge_seed: [0; 32],
             input_parts: vec![(Some("a".to_string()), [0; 32])],
         };
 
         let dynamic_c = GeneratePoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             challenge_seed: [0; 32],
             input_parts: vec![
                 (Some("a".to_string()), [0; 32]),
@@ -368,7 +373,7 @@ mod tests {
         };
 
         let dynamic_d = GeneratePoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             challenge_seed: [0; 32],
             input_parts: vec![
                 (Some("a".to_string()), [0; 32]),
@@ -412,7 +417,7 @@ mod tests {
         let comm_r_d = [3; 32];
 
         let dynamic_a = VerifyPoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             comm_rs: Vec::new(),
             challenge_seed: [0; 32],
             proofs: Vec::new(),
@@ -420,7 +425,7 @@ mod tests {
         };
 
         let dynamic_b = VerifyPoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             comm_rs: vec![comm_r_a.clone()],
             challenge_seed: [0; 32],
             proofs: vec![proof_a.clone()],
@@ -428,7 +433,7 @@ mod tests {
         };
 
         let dynamic_c = VerifyPoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             comm_rs: vec![comm_r_a.clone(), comm_r_b.clone()],
             challenge_seed: [0; 32],
             proofs: vec![proof_a.clone()],
@@ -436,7 +441,7 @@ mod tests {
         };
 
         let dynamic_d = VerifyPoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             comm_rs: vec![comm_r_a.clone(), comm_r_b.clone(), comm_r_c.clone()],
             challenge_seed: [0; 32],
             proofs: vec![proof_a.clone(), proof_b.clone()],
@@ -473,7 +478,7 @@ mod tests {
         assert_eq!(
             true,
             verify_post_spread_input(VerifyPoStDynamicSectorsCountInput {
-                post_config: PoStConfig::Test,
+                post_config: TEST_CONFIG,
                 comm_rs: vec![comm_r_a.clone()],
                 challenge_seed: [0; 32],
                 proofs: vec![proof_a.clone(), proof_b.clone()],
@@ -486,7 +491,7 @@ mod tests {
         assert_eq!(
             true,
             verify_post_spread_input(VerifyPoStDynamicSectorsCountInput {
-                post_config: PoStConfig::Test,
+                post_config: TEST_CONFIG,
                 comm_rs: vec![comm_r_a.clone()],
                 challenge_seed: [0; 32],
                 proofs: vec![],
@@ -499,7 +504,7 @@ mod tests {
         assert_eq!(
             true,
             verify_post_spread_input(VerifyPoStDynamicSectorsCountInput {
-                post_config: PoStConfig::Test,
+                post_config: TEST_CONFIG,
                 comm_rs: vec![comm_r_a.clone()],
                 challenge_seed: [0; 32],
                 proofs: vec![proof_a.clone()],
@@ -512,7 +517,7 @@ mod tests {
         assert_eq!(
             true,
             verify_post_spread_input(VerifyPoStDynamicSectorsCountInput {
-                post_config: PoStConfig::Test,
+                post_config: TEST_CONFIG,
                 comm_rs: vec![comm_r_a.clone()],
                 challenge_seed: [0; 32],
                 proofs: vec![proof_a.clone()],
@@ -523,7 +528,7 @@ mod tests {
 
         // map dynamic sectors count indices to fixed count fault indices
         let fixed_e = verify_post_spread_input(VerifyPoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             comm_rs: vec![
                 comm_r_a.clone(),
                 comm_r_b.clone(),
@@ -540,7 +545,7 @@ mod tests {
 
         // ensure fault-values map to appropriate, duplicated comm_r
         let fixed_f = verify_post_spread_input(VerifyPoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             comm_rs: vec![comm_r_a.clone()],
             challenge_seed: [0; 32],
             proofs: vec![proof_a.clone()],
@@ -555,7 +560,7 @@ mod tests {
         // explanation: faults=[3] corresponds to faults=[1] in the second fixed
         // count pair and faults=[] in the first
         let fixed_g = verify_post_spread_input(VerifyPoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             comm_rs: vec![
                 comm_r_a.clone(),
                 comm_r_b.clone(),
@@ -576,7 +581,7 @@ mod tests {
         // and faults[0, 1] in the second (because the third commitment was
         // duplicated
         let fixed_h = verify_post_spread_input(VerifyPoStDynamicSectorsCountInput {
-            post_config: PoStConfig::Test,
+            post_config: TEST_CONFIG,
             comm_rs: vec![comm_r_a.clone(), comm_r_b.clone(), comm_r_c.clone()],
             challenge_seed: [0; 32],
             proofs: vec![proof_a.clone(), proof_b.clone()],

--- a/filecoin-proofs/src/api/responses.rs
+++ b/filecoin-proofs/src/api/responses.rs
@@ -68,6 +68,7 @@ pub struct GeneratePoStResponse {
     pub faults_ptr: *const u64,
     pub flattened_proofs_len: libc::size_t,
     pub flattened_proofs_ptr: *const u8,
+    pub proof_partitions: u8,
 }
 
 impl Default for GeneratePoStResponse {
@@ -79,6 +80,7 @@ impl Default for GeneratePoStResponse {
             faults_ptr: ptr::null(),
             flattened_proofs_len: 0,
             flattened_proofs_ptr: ptr::null(),
+            proof_partitions: 0,
         }
     }
 }
@@ -276,8 +278,8 @@ pub struct GetSealStatusResponse {
     pub comm_r_star: [u8; 32],
     pub sector_access: *const libc::c_char,
     pub sector_id: u64,
-    pub proofs_len: libc::size_t,
-    pub proofs_ptr: *const u8,
+    pub proof_len: libc::size_t,
+    pub proof_ptr: *const u8,
     pub pieces_len: libc::size_t,
     pub pieces_ptr: *const FFIPieceMetadata,
 }
@@ -299,8 +301,8 @@ impl Default for GetSealStatusResponse {
             comm_r_star: Default::default(),
             pieces_len: 0,
             pieces_ptr: ptr::null(),
-            proofs_len: 0,
-            proofs_ptr: ptr::null(),
+            proof_len: 0,
+            proof_ptr: ptr::null(),
             seal_error_msg: ptr::null(),
             seal_status_code: FFISealStatus::Failed,
             sector_access: ptr::null(),

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -16,7 +16,6 @@ use sector_base::api::porep_proof_partitions::POREP_PROOF_PARTITION_CHOICES;
 use sector_base::api::post_config::PoStConfig;
 use sector_base::api::post_proof_partitions::PoStProofPartitions;
 use sector_base::api::sector_size::SectorSize;
-use sector_base::api::sector_size::SECTOR_SIZE_CHOICES;
 use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::CompoundProof;
@@ -86,14 +85,11 @@ pub fn main() {
     let test_only: bool = matches.is_present("test-only");
 
     cache_porep_params(PoRepConfig(SectorSize::OneKiB, PoRepProofPartitions::Two));
-
     cache_post_params(PoStConfig(SectorSize::OneKiB, PoStProofPartitions::One));
 
     if !test_only {
         for p in &POREP_PROOF_PARTITION_CHOICES {
-            for s in &SECTOR_SIZE_CHOICES {
-                cache_porep_params(PoRepConfig(*s, *p));
-            }
+            cache_porep_params(PoRepConfig(SectorSize::TwoHundredFiftySixMiB, *p));
         }
         cache_post_params(PoStConfig(
             SectorSize::TwoHundredFiftySixMiB,

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -3,11 +3,19 @@ extern crate rand;
 extern crate sector_base;
 extern crate storage_proofs;
 
+use clap::{App, Arg};
+use slog::*;
+
 use filecoin_proofs::api::internal;
 use filecoin_proofs::FCP_LOG;
 use pairing::bls12_381::Bls12;
 use sector_base::api::bytes_amount::PaddedBytesAmount;
-use sector_base::api::porep_config::POREP_PROOF_PARTITION_CHOICES;
+use sector_base::api::porep_config::PoRepConfig;
+use sector_base::api::porep_proof_partitions::PoRepProofPartitions;
+use sector_base::api::porep_proof_partitions::POREP_PROOF_PARTITION_CHOICES;
+use sector_base::api::post_config::PoStConfig;
+use sector_base::api::post_proof_partitions::PoStProofPartitions;
+use sector_base::api::sector_size::SectorSize;
 use sector_base::api::sector_size::SECTOR_SIZE_CHOICES;
 use storage_proofs::circuit::vdf_post::{VDFPoStCircuit, VDFPostCompound};
 use storage_proofs::circuit::zigzag::ZigZagCompound;
@@ -16,14 +24,6 @@ use storage_proofs::hasher::pedersen::PedersenHasher;
 use storage_proofs::parameter_cache::CacheableParameters;
 use storage_proofs::vdf_post::VDFPoSt;
 use storage_proofs::vdf_sloth::Sloth;
-
-use clap::{App, Arg};
-use sector_base::api::porep_config::PoRepConfig;
-use sector_base::api::porep_config::PoRepProofPartitions;
-use sector_base::api::post_config::PoStConfig;
-use sector_base::api::post_config::PoStProofPartitions;
-use sector_base::api::sector_size::SectorSize;
-use slog::*;
 
 fn cache_porep_params(porep_config: PoRepConfig) {
     let n = u64::from(PaddedBytesAmount::from(porep_config));

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -85,16 +85,17 @@ pub fn main() {
 
     let test_only: bool = matches.is_present("test-only");
 
-    cache_porep_params(PoRepConfig::Test);
-    cache_post_params(PoStConfig::Test);
+    cache_porep_params(PoRepConfig(SectorSize::OneKiB, PoRepProofPartitions::Two));
+
+    cache_post_params(PoStConfig(SectorSize::OneKiB, PoStProofPartitions::One));
 
     if !test_only {
         for p in &POREP_PROOF_PARTITION_CHOICES {
             for s in &SECTOR_SIZE_CHOICES {
-                cache_porep_params(PoRepConfig::Live(*s, *p));
+                cache_porep_params(PoRepConfig(*s, *p));
             }
         }
-        cache_post_params(PoStConfig::Live(
+        cache_post_params(PoStConfig(
             SectorSize::TwoHundredFiftySixMiB,
             PoStProofPartitions::One,
         ));

--- a/filecoin-proofs/src/bin/paramgen.rs
+++ b/filecoin-proofs/src/bin/paramgen.rs
@@ -10,7 +10,8 @@ use std::fs::File;
 
 use filecoin_proofs::api::internal;
 use sector_base::api::bytes_amount::PaddedBytesAmount;
-use sector_base::api::porep_config::{PoRepConfig, PoRepProofPartitions};
+use sector_base::api::porep_config::PoRepConfig;
+use sector_base::api::porep_proof_partitions::PoRepProofPartitions;
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::CompoundProof;
 

--- a/filecoin-proofs/src/bin/paramgen.rs
+++ b/filecoin-proofs/src/bin/paramgen.rs
@@ -10,8 +10,8 @@ use std::fs::File;
 
 use filecoin_proofs::api::internal;
 use sector_base::api::bytes_amount::PaddedBytesAmount;
-use sector_base::api::porep_config::PoRepConfig;
 use sector_base::api::porep_proof_partitions::PoRepProofPartitions;
+use sector_base::api::sector_size::SectorSize;
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::CompoundProof;
 
@@ -21,8 +21,8 @@ pub fn main() {
     let out_file = &args[1];
 
     let public_params = internal::public_params(
-        PaddedBytesAmount::from(PoRepConfig::Test),
-        usize::from(PoRepProofPartitions::from(PoRepConfig::Test)),
+        PaddedBytesAmount::from(SectorSize::OneKiB),
+        usize::from(PoRepProofPartitions::Two),
     );
 
     let circuit = ZigZagCompound::blank_circuit(&public_params, &internal::ENGINE_PARAMS);

--- a/sector-base/src/api/bytes_amount.rs
+++ b/sector-base/src/api/bytes_amount.rs
@@ -3,6 +3,10 @@ use crate::io::fr32::unpadded_bytes;
 use serde::{Deserialize, Serialize};
 use std::ops::{Add, Sub};
 
+pub struct PoStProofBytesAmount(pub usize);
+
+pub struct PoRepProofBytesAmount(pub usize);
+
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct UnpaddedBytesAmount(pub u64);
 
@@ -74,6 +78,18 @@ impl Sub for PaddedBytesAmount {
 
     fn sub(self, other: PaddedBytesAmount) -> PaddedBytesAmount {
         PaddedBytesAmount(self.0 - other.0)
+    }
+}
+
+impl From<PoStProofBytesAmount> for usize {
+    fn from(x: PoStProofBytesAmount) -> Self {
+        x.0
+    }
+}
+
+impl From<PoRepProofBytesAmount> for usize {
+    fn from(x: PoRepProofBytesAmount) -> Self {
+        x.0
     }
 }
 

--- a/sector-base/src/api/disk_backed_storage.rs
+++ b/sector-base/src/api/disk_backed_storage.rs
@@ -222,8 +222,8 @@ impl From<SectorClass> for Config {
 pub mod tests {
     use super::*;
 
-    use crate::api::porep_config::PoRepProofPartitions;
-    use crate::api::post_config::PoStProofPartitions;
+    use crate::api::porep_proof_partitions::PoRepProofPartitions;
+    use crate::api::post_proof_partitions::PoStProofPartitions;
     use crate::api::sector_size::SectorSize;
     use crate::io::fr32::FR32_PADDING_MAP;
     use std::fs::create_dir_all;

--- a/sector-base/src/api/disk_backed_storage.rs
+++ b/sector-base/src/api/disk_backed_storage.rs
@@ -206,13 +206,9 @@ impl ProofsConfig for Config {
 impl From<SectorClass> for Config {
     fn from(x: SectorClass) -> Self {
         match x {
-            SectorClass::Test => Config {
-                porep_config: PoRepConfig::Test,
-                post_config: PoStConfig::Test,
-            },
-            SectorClass::Live(size, porep_p, post_p) => Config {
-                porep_config: PoRepConfig::Live(size, porep_p),
-                post_config: PoStConfig::Live(size, post_p),
+            SectorClass(size, porep_p, post_p) => Config {
+                porep_config: PoRepConfig(size, porep_p),
+                post_config: PoStConfig(size, post_p),
             },
         }
     }
@@ -259,14 +255,21 @@ pub mod tests {
     fn max_unsealed_bytes_per_sector_checks() {
         let xs = vec![
             (
-                SectorClass::Live(
+                SectorClass(
                     SectorSize::TwoHundredFiftySixMiB,
                     PoRepProofPartitions::Two,
                     PoStProofPartitions::One,
                 ),
                 266338304,
             ),
-            (SectorClass::Test, 1016),
+            (
+                SectorClass(
+                    SectorSize::OneKiB,
+                    PoRepProofPartitions::Two,
+                    PoStProofPartitions::One,
+                ),
+                1016,
+            ),
         ];
 
         for (sector_class, num_bytes) in xs {
@@ -278,7 +281,11 @@ pub mod tests {
 
     #[test]
     fn unsealed_sector_write_and_truncate() {
-        let storage: Box<SectorStore> = create_sector_store(SectorClass::Test);
+        let storage: Box<SectorStore> = create_sector_store(SectorClass(
+            SectorSize::OneKiB,
+            PoRepProofPartitions::Two,
+            PoStProofPartitions::One,
+        ));
         let mgr = storage.manager();
 
         let access = mgr
@@ -369,7 +376,11 @@ pub mod tests {
 
     #[test]
     fn deletes_staging_access() {
-        let store = create_sector_store(SectorClass::Test);
+        let store = create_sector_store(SectorClass(
+            SectorSize::OneKiB,
+            PoRepProofPartitions::Two,
+            PoStProofPartitions::One,
+        ));
         let access = store.manager().new_staging_sector_access().unwrap();
 
         assert!(store

--- a/sector-base/src/api/mod.rs
+++ b/sector-base/src/api/mod.rs
@@ -2,8 +2,12 @@ pub mod bytes_amount;
 pub mod disk_backed_storage;
 pub mod errors;
 pub mod porep_config;
+pub mod porep_proof_partitions;
 pub mod post_config;
+pub mod post_proof_partitions;
 pub mod sector_class;
 pub mod sector_size;
 pub mod sector_store;
 pub mod util;
+
+pub const SINGLE_PARTITION_PROOF_LEN: usize = 192;

--- a/sector-base/src/api/porep_config.rs
+++ b/sector-base/src/api/porep_config.rs
@@ -1,26 +1,21 @@
 use crate::api::bytes_amount::PaddedBytesAmount;
 use crate::api::bytes_amount::UnpaddedBytesAmount;
-use crate::api::disk_backed_storage::TEST_SECTOR_SIZE;
 use crate::api::porep_proof_partitions::PoRepProofPartitions;
 use crate::api::sector_size::SectorSize;
 
 #[derive(Clone, Copy, Debug)]
-pub enum PoRepConfig {
-    Live(SectorSize, PoRepProofPartitions),
-    Test,
-}
+pub struct PoRepConfig(pub SectorSize, pub PoRepProofPartitions);
 
 impl Default for PoRepConfig {
     fn default() -> Self {
-        PoRepConfig::Live(SectorSize::TwoHundredFiftySixMiB, PoRepProofPartitions::Two)
+        PoRepConfig(SectorSize::TwoHundredFiftySixMiB, PoRepProofPartitions::Two)
     }
 }
 
 impl From<PoRepConfig> for PaddedBytesAmount {
     fn from(x: PoRepConfig) -> Self {
         match x {
-            PoRepConfig::Test => PaddedBytesAmount(TEST_SECTOR_SIZE),
-            PoRepConfig::Live(s, _) => PaddedBytesAmount::from(s),
+            PoRepConfig(s, _) => PaddedBytesAmount::from(s),
         }
     }
 }
@@ -28,8 +23,7 @@ impl From<PoRepConfig> for PaddedBytesAmount {
 impl From<PoRepConfig> for UnpaddedBytesAmount {
     fn from(x: PoRepConfig) -> Self {
         match x {
-            PoRepConfig::Test => PaddedBytesAmount(TEST_SECTOR_SIZE).into(),
-            PoRepConfig::Live(s, _) => PaddedBytesAmount::from(s).into(),
+            PoRepConfig(s, _) => PaddedBytesAmount::from(s).into(),
         }
     }
 }
@@ -37,8 +31,7 @@ impl From<PoRepConfig> for UnpaddedBytesAmount {
 impl From<PoRepConfig> for PoRepProofPartitions {
     fn from(x: PoRepConfig) -> Self {
         match x {
-            PoRepConfig::Test => PoRepProofPartitions::Two,
-            PoRepConfig::Live(_, p) => p,
+            PoRepConfig(_, p) => p,
         }
     }
 }

--- a/sector-base/src/api/porep_config.rs
+++ b/sector-base/src/api/porep_config.rs
@@ -1,6 +1,7 @@
 use crate::api::bytes_amount::PaddedBytesAmount;
 use crate::api::bytes_amount::UnpaddedBytesAmount;
 use crate::api::disk_backed_storage::TEST_SECTOR_SIZE;
+use crate::api::porep_proof_partitions::PoRepProofPartitions;
 use crate::api::sector_size::SectorSize;
 
 #[derive(Clone, Copy, Debug)]
@@ -8,14 +9,6 @@ pub enum PoRepConfig {
     Live(SectorSize, PoRepProofPartitions),
     Test,
 }
-
-// When modifying, update internal::tests::partition_layer_challenges_test to reflect supported PoRepProofPartitions.
-#[derive(Clone, Copy, Debug)]
-pub enum PoRepProofPartitions {
-    Two,
-}
-
-pub const POREP_PROOF_PARTITION_CHOICES: [PoRepProofPartitions; 1] = [PoRepProofPartitions::Two];
 
 impl Default for PoRepConfig {
     fn default() -> Self {
@@ -46,14 +39,6 @@ impl From<PoRepConfig> for PoRepProofPartitions {
         match x {
             PoRepConfig::Test => PoRepProofPartitions::Two,
             PoRepConfig::Live(_, p) => p,
-        }
-    }
-}
-
-impl From<PoRepProofPartitions> for usize {
-    fn from(x: PoRepProofPartitions) -> Self {
-        match x {
-            PoRepProofPartitions::Two => 2,
         }
     }
 }

--- a/sector-base/src/api/porep_proof_partitions.rs
+++ b/sector-base/src/api/porep_proof_partitions.rs
@@ -1,0 +1,31 @@
+use crate::api::bytes_amount::PoRepProofBytesAmount;
+use crate::api::SINGLE_PARTITION_PROOF_LEN;
+
+// When modifying, update internal::tests::partition_layer_challenges_test to reflect supported PoRepProofPartitions.
+#[derive(Clone, Copy, Debug)]
+pub enum PoRepProofPartitions {
+    Two,
+}
+
+pub const POREP_PROOF_PARTITION_CHOICES: [PoRepProofPartitions; 1] = [PoRepProofPartitions::Two];
+
+impl From<PoRepProofPartitions> for usize {
+    fn from(x: PoRepProofPartitions) -> Self {
+        match x {
+            PoRepProofPartitions::Two => 2,
+        }
+    }
+}
+
+impl From<PoRepProofPartitions> for PoRepProofBytesAmount {
+    fn from(x: PoRepProofPartitions) -> Self {
+        PoRepProofBytesAmount(SINGLE_PARTITION_PROOF_LEN * usize::from(x))
+    }
+}
+
+pub fn try_from_u8(n: u8) -> ::std::result::Result<PoRepProofPartitions, failure::Error> {
+    match n {
+        2 => Ok(PoRepProofPartitions::Two),
+        n => Err(format_err!("no PoRepProofPartitions mapping for {}", n)),
+    }
+}

--- a/sector-base/src/api/post_config.rs
+++ b/sector-base/src/api/post_config.rs
@@ -1,26 +1,21 @@
 use crate::api::bytes_amount::PaddedBytesAmount;
 use crate::api::bytes_amount::UnpaddedBytesAmount;
-use crate::api::disk_backed_storage::TEST_SECTOR_SIZE;
 use crate::api::post_proof_partitions::PoStProofPartitions;
 use crate::api::sector_size::SectorSize;
 
 #[derive(Clone, Copy, Debug)]
-pub enum PoStConfig {
-    Live(SectorSize, PoStProofPartitions),
-    Test,
-}
+pub struct PoStConfig(pub SectorSize, pub PoStProofPartitions);
 
 impl Default for PoStConfig {
     fn default() -> Self {
-        PoStConfig::Live(SectorSize::TwoHundredFiftySixMiB, PoStProofPartitions::One)
+        PoStConfig(SectorSize::TwoHundredFiftySixMiB, PoStProofPartitions::One)
     }
 }
 
 impl From<PoStConfig> for PaddedBytesAmount {
     fn from(x: PoStConfig) -> Self {
         match x {
-            PoStConfig::Test => PaddedBytesAmount(TEST_SECTOR_SIZE),
-            PoStConfig::Live(s, _) => PaddedBytesAmount::from(s),
+            PoStConfig(s, _) => PaddedBytesAmount::from(s),
         }
     }
 }
@@ -28,8 +23,7 @@ impl From<PoStConfig> for PaddedBytesAmount {
 impl From<PoStConfig> for UnpaddedBytesAmount {
     fn from(x: PoStConfig) -> Self {
         match x {
-            PoStConfig::Test => PaddedBytesAmount(TEST_SECTOR_SIZE).into(),
-            PoStConfig::Live(s, _) => PaddedBytesAmount::from(s).into(),
+            PoStConfig(s, _) => PaddedBytesAmount::from(s).into(),
         }
     }
 }
@@ -37,8 +31,7 @@ impl From<PoStConfig> for UnpaddedBytesAmount {
 impl From<PoStConfig> for PoStProofPartitions {
     fn from(x: PoStConfig) -> Self {
         match x {
-            PoStConfig::Test => PoStProofPartitions::One,
-            PoStConfig::Live(_, p) => p,
+            PoStConfig(_, p) => p,
         }
     }
 }

--- a/sector-base/src/api/post_config.rs
+++ b/sector-base/src/api/post_config.rs
@@ -1,17 +1,13 @@
 use crate::api::bytes_amount::PaddedBytesAmount;
 use crate::api::bytes_amount::UnpaddedBytesAmount;
 use crate::api::disk_backed_storage::TEST_SECTOR_SIZE;
+use crate::api::post_proof_partitions::PoStProofPartitions;
 use crate::api::sector_size::SectorSize;
 
 #[derive(Clone, Copy, Debug)]
 pub enum PoStConfig {
     Live(SectorSize, PoStProofPartitions),
     Test,
-}
-
-#[derive(Clone, Copy, Debug)]
-pub enum PoStProofPartitions {
-    One,
 }
 
 impl Default for PoStConfig {
@@ -43,14 +39,6 @@ impl From<PoStConfig> for PoStProofPartitions {
         match x {
             PoStConfig::Test => PoStProofPartitions::One,
             PoStConfig::Live(_, p) => p,
-        }
-    }
-}
-
-impl From<PoStProofPartitions> for usize {
-    fn from(x: PoStProofPartitions) -> Self {
-        match x {
-            PoStProofPartitions::One => 1,
         }
     }
 }

--- a/sector-base/src/api/post_proof_partitions.rs
+++ b/sector-base/src/api/post_proof_partitions.rs
@@ -1,0 +1,48 @@
+use crate::api::bytes_amount::PoStProofBytesAmount;
+use crate::api::SINGLE_PARTITION_PROOF_LEN;
+
+#[derive(Clone, Copy, Debug)]
+pub enum PoStProofPartitions {
+    One,
+}
+
+impl From<PoStProofPartitions> for PoStProofBytesAmount {
+    fn from(x: PoStProofPartitions) -> Self {
+        PoStProofBytesAmount(SINGLE_PARTITION_PROOF_LEN * usize::from(x))
+    }
+}
+
+impl From<PoStProofPartitions> for usize {
+    fn from(x: PoStProofPartitions) -> Self {
+        match x {
+            PoStProofPartitions::One => 1,
+        }
+    }
+}
+
+pub fn try_from_u8(n: u8) -> ::std::result::Result<PoStProofPartitions, failure::Error> {
+    match n {
+        1 => Ok(PoStProofPartitions::One),
+        n => Err(format_err!("no PoStProofPartitions mapping for {}", n)),
+    }
+}
+
+pub fn try_from_bytes(bytes: &[u8]) -> ::std::result::Result<PoStProofPartitions, failure::Error> {
+    let n = bytes.len();
+
+    let mkerr = || {
+        Err(format_err!(
+            "no PoStProofPartitions mapping for {:x?}",
+            bytes
+        ))
+    };
+
+    if n % SINGLE_PARTITION_PROOF_LEN == 0 {
+        match n / SINGLE_PARTITION_PROOF_LEN {
+            1 => Ok(PoStProofPartitions::One),
+            _ => mkerr(),
+        }
+    } else {
+        mkerr()
+    }
+}

--- a/sector-base/src/api/sector_class.rs
+++ b/sector-base/src/api/sector_class.rs
@@ -1,7 +1,7 @@
 use crate::api::porep_config::PoRepConfig;
-use crate::api::porep_config::PoRepProofPartitions;
+use crate::api::porep_proof_partitions::PoRepProofPartitions;
 use crate::api::post_config::PoStConfig;
-use crate::api::post_config::PoStProofPartitions;
+use crate::api::post_proof_partitions::PoStProofPartitions;
 use crate::api::sector_size::SectorSize;
 
 #[derive(Clone, Copy, Debug)]

--- a/sector-base/src/api/sector_class.rs
+++ b/sector-base/src/api/sector_class.rs
@@ -5,16 +5,16 @@ use crate::api::post_proof_partitions::PoStProofPartitions;
 use crate::api::sector_size::SectorSize;
 
 #[derive(Clone, Copy, Debug)]
-pub enum SectorClass {
-    Live(SectorSize, PoRepProofPartitions, PoStProofPartitions),
-    Test,
-}
+pub struct SectorClass(
+    pub SectorSize,
+    pub PoRepProofPartitions,
+    pub PoStProofPartitions,
+);
 
 impl From<SectorClass> for PoStConfig {
     fn from(x: SectorClass) -> Self {
         match x {
-            SectorClass::Test => PoStConfig::Test,
-            SectorClass::Live(ss, _, ppp) => PoStConfig::Live(ss, ppp),
+            SectorClass(ss, _, ppp) => PoStConfig(ss, ppp),
         }
     }
 }
@@ -22,8 +22,7 @@ impl From<SectorClass> for PoStConfig {
 impl From<SectorClass> for PoRepConfig {
     fn from(x: SectorClass) -> Self {
         match x {
-            SectorClass::Test => PoRepConfig::Test,
-            SectorClass::Live(ss, ppp, _) => PoRepConfig::Live(ss, ppp),
+            SectorClass(ss, ppp, _) => PoRepConfig(ss, ppp),
         }
     }
 }

--- a/sector-base/src/api/sector_size.rs
+++ b/sector-base/src/api/sector_size.rs
@@ -32,3 +32,11 @@ impl From<SectorSize> for PaddedBytesAmount {
         }
     }
 }
+
+pub fn try_from_u64(n: u64) -> ::std::result::Result<SectorSize, failure::Error> {
+    match n {
+        1024 => Ok(SectorSize::OneKiB),
+        266338304 => Ok(SectorSize::TwoHundredFiftySixMiB),
+        n => Err(format_err!("no SectorSize mapping for {}", n)),
+    }
+}

--- a/sector-base/src/api/sector_size.rs
+++ b/sector-base/src/api/sector_size.rs
@@ -35,8 +35,8 @@ impl From<SectorSize> for PaddedBytesAmount {
 
 pub fn try_from_u64(n: u64) -> ::std::result::Result<SectorSize, failure::Error> {
     match n {
-        1024 => Ok(SectorSize::OneKiB),
-        266338304 => Ok(SectorSize::TwoHundredFiftySixMiB),
+        TEST_SECTOR_SIZE => Ok(SectorSize::OneKiB),
+        LIVE_SECTOR_SIZE => Ok(SectorSize::TwoHundredFiftySixMiB),
         n => Err(format_err!("no SectorSize mapping for {}", n)),
     }
 }


### PR DESCRIPTION
Supports go-filecoin issue `#2591`.

## Why does this PR exist?

- FFI consumers need to know how to chunk the proofs returned from `generate_post`
- FFI consumers need to tell us how to chunk the proofs provided to `verify_post`
- FFI test was not exercising `verify_seal` FFI function

## What's in this PR?

- Replace most of the `FFI*` enums, as they weren't providing any value (hat tip @porcuquine)
- Remove notion of `Live` versus `Test` `SectorClass`
- Remove notion of `Live` versus `Test` (`PoStConfig` and `PoRepConfig`)
- FFI functions which need number of proof partitions receive number of proof partitions
- FFI functions whose callers need to know number of proof partitions (for chunking) now receive number of proof partitions