### PR TITLE
add libcurl to lib list

### DIFF
--- a/filecoin-proofs/build.rs
+++ b/filecoin-proofs/build.rs
@@ -61,9 +61,9 @@ fn main() {
     let git_hash = String::from_utf8(git_output.stdout).unwrap();
 
     let libs = if cfg!(target_os = "linux") {
-        "-lstdc++ -lutil -lutil -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -lutil"
+        "-lcurl -lstdc++ -lutil -lutil -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -lutil"
     } else if cfg!(target_os = "macos") {
-        "-lstdc++ -framework Security -lSystem -lresolv -lc -lm"
+        "-lcurl -lstdc++ -framework Security -lSystem -lresolv -lc -lm"
     } else {
         ""
     };


### PR DESCRIPTION
## Why does this PR exist?

A [recently merged PR](https://github.com/filecoin-project/rust-fil-proofs/pull/628) relies on libcurl, which for whatever reason isn't statically linked into the `libfilecoin_proofs.a` archive. This means that consumers of that archive can't link unless they provide `libcurl`. We don't find this out until we actually try to link the archive when building go-filecoin.

## What's in this PR?

- add `libcurl` to deps list

## Next steps

[We should really be constructing that dependency list by consuming Rust compiler output.](https://app.zenhub.com/workspaces/filecoin-5ab0036a12f8e82ae4ed60f0/issues/filecoin-project/rust-fil-proofs/616)