### PR TITLE
Revert "Add progress bar during parameter download"

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = "1.2"
 memmap = "0.7"
 clap = "2"
 colored = "1.6"
-pbr = "1.0.1"
+pbr = "1.0"
 tempfile = "3"
 byteorder = "1"
 itertools = "0.8"
@@ -35,7 +35,6 @@ regex = "1"
 drop_struct_macro_derive = { path = "../drop-struct-macro-derive" }
 ff = "0.4.0"
 blake2b_simd = "0.4.1"
-curl = "0.4.21"
 
 [dependencies.sapling-crypto]
 git = "https://github.com/filecoin-project/sapling-crypto"

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -94,7 +94,10 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
                 &parameter_map,
                 &parameter_id,
             ) {
-                Ok(_) => println!("ok!"),
+                Ok(mut child) => match child.wait() {
+                    Ok(_) => println!("ok\n"),
+                    Err(err) => println!("error: {}\n", err),
+                },
                 Err(err) => println!("error: {}\n", err),
             }
         }


### PR DESCRIPTION
Reverts filecoin-project/rust-fil-proofs#628

## Why does this PR exist?

The aforementioned PR adds a linker dependency on libcurl and this results in libcurl symbols appearing in our `libfilecoin_proofs.a` archive file. Developers who want to build e.g. go-filecoin against `libfilecoin_proofs.a` will need to have libcurl on their linker path.

```
$ nm -gC target/release/libfilecoin_proofs.a  | grep url | head -n 10

00000000000123b0 T _$LT$curl..easy..handler..Easy2$LT$H$GT$$GT$::get_mut::hd75faf5c99248079
0000000000020420 T _$LT$curl..easy..handler..Easy2$LT$H$GT$$u20$as$u20$core..ops..drop..Drop$GT$::drop::h1e6caa5a03813683
                 U _curl_easy_cleanup
                 U _$LT$curl..error..Error$u20$as$u20$core..fmt..Debug$GT$::fmt::h129f9d43596a4671
                 U _$LT$curl..easy..list..List$u20$as$u20$core..ops..drop..Drop$GT$::drop::h02023abf58e11e43
00000000000141e0 T curl::easy::handle::Easy::write_function::h71d85a34a71a113e
00000000000142c0 T curl::easy::handle::Easy::progress_function::h925167188033a7d4
                 U _$LT$curl..error..Error$u20$as$u20$core..fmt..Debug$GT$::fmt::h129f9d43596a4671
                 U _$LT$curl..error..Error$u20$as$u20$core..fmt..Display$GT$::fmt::h0d8f28b3364f877f
                 U curl::easy::handle::Easy::low_speed_time::ha753881d33f703ab
```

This dependency is also visible in our Cargo build output (OSX):

```
   Compiling filecoin-proofs v0.1.0 (/Users/erinswenson-healey/dev/rust-proofs/filecoin-proofs)
   Compiling rocksdb v0.12.1
note: Link against the following native artifacts when linking against this static library. The order and any duplication can be significant on some platforms.

note: native-static-libs: -lcurl -lc++ -framework Security -lSystem -lresolv -lc -lm
```

Unfortunately, libcurl is not installed by default in the `circleci/golang:1.12.1` Docker image. I suspect that Ubuntu users will also not have libcurl installed. So far, this has only resulted in [downstream CI builds failing](https://circleci.com/gh/filecoin-project/go-filecoin/14682) because I have not deployed this changeset to go-filecoin.

## What's in this PR?

This PR reverts the work done by @mslipper which added the new (fancy looking!) progress bar. This changeset will need to stay out of rust-fil-proofs `master` until we either:

1) Coordinate updates to the go-filecoin CircleCI configuration and developer setup documentation
2) Eliminate the new dependency from paramfetch alltogether
3) Figure out how to prevent libcurl symbols from appearing in our libfilecoin_proofs.a archive file

## How can we prevent stuff like this from happening?

Unfortunately, these types of errors are typically caught when linking libfilecoin_proofs.a into go-filecoin. We may be able to write some C program which attempts to link libfilecoin_proofs.a as part of the rust-fil-proofs build process. This would (more or less) simulate what go-filecoin does.