### PR TITLE
Bugs/warnings after upgrade rust

### DIFF
--- a/ffi-toolkit/src/lib.rs
+++ b/ffi-toolkit/src/lib.rs
@@ -23,7 +23,6 @@ pub fn raw_ptr<T>(thing: T) -> *mut T {
 
 // transmutes a C string to a copy-on-write Rust string
 pub unsafe fn c_str_to_rust_str<'a>(x: *const libc::c_char) -> Cow<'a, str> {
-    use std::borrow::Cow;
     if x.is_null() {
         Cow::from("")
     } else {

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -31,6 +31,7 @@ mod sector_builder;
 
 /// Verifies the output of seal.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn verify_seal(
     sector_size: u64,
@@ -87,6 +88,7 @@ pub unsafe extern "C" fn verify_seal(
 
 /// Generates a proof-of-spacetime for the given replica commitments.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn generate_post(
     ptr: *mut SectorBuilder,
@@ -135,6 +137,7 @@ pub unsafe extern "C" fn generate_post(
 
 /// Verifies that a proof-of-spacetime is valid.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn verify_post(
     sector_size: u64,
@@ -188,6 +191,7 @@ pub unsafe extern "C" fn verify_post(
 
 /// Initializes and returns a SectorBuilder.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn init_sector_builder(
     sector_class: FFISectorClass,
@@ -227,6 +231,7 @@ pub unsafe extern "C" fn init_sector_builder(
 
 /// Destroys a SectorBuilder.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_sector_builder(ptr: *mut SectorBuilder) {
     let _ = Box::from_raw(ptr);
@@ -234,6 +239,7 @@ pub unsafe extern "C" fn destroy_sector_builder(ptr: *mut SectorBuilder) {
 
 /// Returns the number of user bytes that will fit into a staged sector.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn get_max_user_bytes_per_staged_sector(sector_size: u64) -> u64 {
     u64::from(UnpaddedBytesAmount::from(SectorSize(sector_size)))
@@ -242,6 +248,7 @@ pub unsafe extern "C" fn get_max_user_bytes_per_staged_sector(sector_size: u64) 
 /// Writes user piece-bytes to a staged sector and returns the id of the sector
 /// to which the bytes were written.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn add_piece(
     ptr: *mut SectorBuilder,
@@ -275,6 +282,7 @@ pub unsafe extern "C" fn add_piece(
 
 /// Unseals and returns the bytes associated with the provided piece key.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn read_piece_from_sealed_sector(
     ptr: *mut SectorBuilder,
@@ -303,6 +311,7 @@ pub unsafe extern "C" fn read_piece_from_sealed_sector(
 
 /// For demo purposes. Seals all staged sectors.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn seal_all_staged_sectors(
     ptr: *mut SectorBuilder,
@@ -326,6 +335,7 @@ pub unsafe extern "C" fn seal_all_staged_sectors(
 /// Returns sector sealing status for the provided sector id if it exists. If
 /// we don't know about the provided sector id, produce an error.
 ///
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn get_seal_status(
     ptr: *mut SectorBuilder,
@@ -386,6 +396,7 @@ pub unsafe extern "C" fn get_seal_status(
     raw_ptr(response)
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn get_sealed_sectors(
     ptr: *mut SectorBuilder,
@@ -444,6 +455,7 @@ pub unsafe extern "C" fn get_sealed_sectors(
     raw_ptr(response)
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn get_staged_sectors(
     ptr: *mut SectorBuilder,

--- a/filecoin-proofs/src/api/responses.rs
+++ b/filecoin-proofs/src/api/responses.rs
@@ -50,6 +50,7 @@ impl Default for VerifySealResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_verify_seal_response(ptr: *mut VerifySealResponse) {
     let _ = Box::from_raw(ptr);
@@ -85,6 +86,7 @@ impl Default for GeneratePoStResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_generate_post_response(ptr: *mut GeneratePoStResponse) {
     let _ = Box::from_raw(ptr);
@@ -112,6 +114,7 @@ impl Default for VerifyPoSTResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_verify_post_response(ptr: *mut VerifyPoSTResponse) {
     let _ = Box::from_raw(ptr);
@@ -167,6 +170,7 @@ impl Default for InitSectorBuilderResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_init_sector_builder_response(ptr: *mut InitSectorBuilderResponse) {
     let _ = Box::from_raw(ptr);
@@ -194,6 +198,7 @@ impl Default for AddPieceResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_add_piece_response(ptr: *mut AddPieceResponse) {
     let _ = Box::from_raw(ptr);
@@ -223,6 +228,7 @@ impl Default for ReadPieceFromSealedSectorResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_read_piece_from_sealed_sector_response(
     ptr: *mut ReadPieceFromSealedSectorResponse,
@@ -250,6 +256,7 @@ impl Default for SealAllStagedSectorsResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_seal_all_staged_sectors_response(
     ptr: *mut SealAllStagedSectorsResponse,
@@ -311,6 +318,7 @@ impl Default for GetSealStatusResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_get_seal_status_response(ptr: *mut GetSealStatusResponse) {
     let _ = Box::from_raw(ptr);
@@ -378,6 +386,7 @@ impl Default for GetSealedSectorsResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_get_sealed_sectors_response(ptr: *mut GetSealedSectorsResponse) {
     let _ = Box::from_raw(ptr);
@@ -408,6 +417,7 @@ impl Default for GetStagedSectorsResponse {
     }
 }
 
+#[allow(dead_code)]
 #[no_mangle]
 pub unsafe extern "C" fn destroy_get_staged_sectors_response(ptr: *mut GetStagedSectorsResponse) {
     let _ = Box::from_raw(ptr);


### PR DESCRIPTION
Fixes #643 

## What's in this PR?

- ignore (and fix) compiler warnings introduced when we upgraded rust-toolchain recently