### PR TITLE
piece packing

### DIFF
--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -133,6 +133,7 @@ struct ConfigurableSizes {
     second_piece_bytes: usize,
     sector_class: FFISectorClass,
     third_piece_bytes: usize,
+    fourth_piece_bytes: usize,
 }
 
 unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error>> {
@@ -147,10 +148,11 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
                 porep_proof_partitions: 2,
                 post_proof_partitions: 1,
             },
-            max_bytes: 266338304,
-            first_piece_bytes: 26214400,
-            second_piece_bytes: 131072000,
-            third_piece_bytes: 157286400,
+            max_bytes: 1016 * 1024 * 256,
+            first_piece_bytes: 100 * 1024 * 256,
+            second_piece_bytes: 110 * 1024 * 256,
+            third_piece_bytes: 600 * 1024 * 256,
+            fourth_piece_bytes: 508 * 1024 * 256,
         }
     } else {
         ConfigurableSizes {
@@ -161,8 +163,9 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
             },
             max_bytes: 1016,
             first_piece_bytes: 100,
-            second_piece_bytes: 500,
+            second_piece_bytes: 110,
             third_piece_bytes: 600,
+            fourth_piece_bytes: 508,
         }
     };
 
@@ -270,10 +273,10 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
     );
     defer!(destroy_sector_builder(sector_builder_b));
 
-    // add fourth piece, where size(piece) == max (will trigger sealing)
+    // add fourth piece that will trigger sealing in the first sector
     let (bytes_in, piece_key) = {
         let (piece_bytes, piece_key, resp) =
-            create_and_add_piece(sector_builder_b, sizes.max_bytes);
+            create_and_add_piece(sector_builder_b, sizes.fourth_piece_bytes);
         defer!(destroy_add_piece_response(resp));
 
         if (*resp).status_code != 0 {
@@ -281,7 +284,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
         }
 
         // sector id changed again (piece wouldn't fit)
-        assert_eq!(126, (*resp).sector_id);
+        assert_eq!(124, (*resp).sector_id);
 
         (piece_bytes, piece_key)
     };
@@ -302,7 +305,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
                     _ => (),
                 };
 
-                let resp = get_seal_status(sector_builder, 126);
+                let resp = get_seal_status(sector_builder, 124);
                 defer!(destroy_get_seal_status_response(resp));
 
                 if (*resp).status_code != 0 {
@@ -328,12 +331,12 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
             result_rx.recv_timeout(Duration::from_secs(300)).unwrap()
         };
 
-        assert_eq!(now_sealed_sector_id, 126);
+        assert_eq!(now_sealed_sector_id, 124);
     }
 
     // get sealed sector and verify the PoRep proof
     {
-        let resp = get_seal_status(sector_builder_b, 126);
+        let resp = get_seal_status(sector_builder_b, 124);
 
         {
             let resp2 = verify_seal(
@@ -342,7 +345,7 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
                 &mut (*resp).comm_d,
                 &mut (*resp).comm_r_star,
                 &mut u64_to_fr_safe(0),
-                &mut u64_to_fr_safe(126),
+                &mut u64_to_fr_safe(124),
                 (*resp).proof_ptr,
                 (*resp).proof_len,
             );

--- a/filecoin-proofs/examples/ffi/main.rs
+++ b/filecoin-proofs/examples/ffi/main.rs
@@ -149,10 +149,10 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
                 post_proof_partitions: 1,
             },
             max_bytes: 1016 * 1024 * 256,
-            first_piece_bytes: 100 * 1024 * 256,
-            second_piece_bytes: 110 * 1024 * 256,
-            third_piece_bytes: 600 * 1024 * 256,
-            fourth_piece_bytes: 508 * 1024 * 256,
+            first_piece_bytes: 400 * 1024 * 256,
+            second_piece_bytes: 200 * 1024 * 256,
+            third_piece_bytes: 500 * 1024 * 256,
+            fourth_piece_bytes: 200 * 1024 * 256,
         }
     } else {
         ConfigurableSizes {
@@ -162,10 +162,10 @@ unsafe fn sector_builder_lifecycle(use_live_store: bool) -> Result<(), Box<Error
                 post_proof_partitions: 1,
             },
             max_bytes: 1016,
-            first_piece_bytes: 100,
-            second_piece_bytes: 110,
-            third_piece_bytes: 600,
-            fourth_piece_bytes: 508,
+            first_piece_bytes: 400,
+            second_piece_bytes: 200,
+            third_piece_bytes: 500,
+            fourth_piece_bytes: 200,
         }
     };
 

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -15,7 +15,7 @@ use crate::api::post_adapter::*;
 use crate::error;
 use crate::error::ExpectWithBacktrace;
 use crate::FCP_LOG;
-use sector_base::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount, UnpaddedByteIndex};
+use sector_base::api::bytes_amount::{PaddedBytesAmount, UnpaddedByteIndex, UnpaddedBytesAmount};
 use sector_base::api::porep_config::PoRepConfig;
 use sector_base::api::porep_proof_partitions::PoRepProofPartitions;
 use sector_base::api::post_config::PoStConfig;
@@ -648,12 +648,7 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>>(
         &data,
     )?;
 
-    let written = write_unpadded(
-        &unsealed,
-        &mut buf_writer,
-        offset.into(),
-        num_bytes.into(),
-    )?;
+    let written = write_unpadded(&unsealed, &mut buf_writer, offset.into(), num_bytes.into())?;
 
     Ok(UnpaddedBytesAmount(written as u64))
 }

--- a/filecoin-proofs/src/api/internal.rs
+++ b/filecoin-proofs/src/api/internal.rs
@@ -15,7 +15,7 @@ use crate::api::post_adapter::*;
 use crate::error;
 use crate::error::ExpectWithBacktrace;
 use crate::FCP_LOG;
-use sector_base::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount};
+use sector_base::api::bytes_amount::{PaddedBytesAmount, UnpaddedBytesAmount, UnpaddedByteIndex};
 use sector_base::api::porep_config::PoRepConfig;
 use sector_base::api::porep_proof_partitions::PoRepProofPartitions;
 use sector_base::api::post_config::PoStConfig;
@@ -624,7 +624,7 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>>(
     output_path: T,
     prover_id_in: &FrSafe,
     sector_id_in: &FrSafe,
-    offset: u64,
+    offset: UnpaddedByteIndex,
     num_bytes: UnpaddedBytesAmount,
 ) -> error::Result<(UnpaddedBytesAmount)> {
     let prover_id = pad_safe_fr(prover_id_in);
@@ -651,7 +651,7 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>>(
     let written = write_unpadded(
         &unsealed,
         &mut buf_writer,
-        offset as usize,
+        offset.into(),
         num_bytes.into(),
     )?;
 
@@ -860,7 +860,7 @@ mod tests {
                     &unseal_access,
                     &prover_id,
                     &sector_id,
-                    0,
+                    UnpaddedByteIndex(0),
                     cfg.max_unsealed_bytes_per_sector(),
                 )
                 .expect("failed to unseal")
@@ -1039,7 +1039,7 @@ mod tests {
                     &PathBuf::from(&h.unseal_access),
                     &h.prover_id,
                     &h.sector_id,
-                    offset,
+                    UnpaddedByteIndex(offset),
                     UnpaddedBytesAmount(range_length),
                 )
                 .expect("failed to unseal")
@@ -1090,7 +1090,7 @@ mod tests {
             &unseal_access,
             &h.prover_id,
             &h.sector_id,
-            0,
+            UnpaddedByteIndex(0),
             UnpaddedBytesAmount((contents_a.len() + contents_b.len()) as u64),
         )
         .expect("failed to unseal");

--- a/filecoin-proofs/src/api/sector_builder/helpers/add_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/add_piece.rs
@@ -91,8 +91,7 @@ fn compute_destination_sector_id(
         Ok(vector
             .iter()
             .find(move |staged_sector| {
-                let preceding_piece_bytes =
-                    sum_piece_bytes_with_alignment(staged_sector.pieces.iter());
+                let preceding_piece_bytes = sum_piece_bytes_with_alignment(&staged_sector.pieces);
                 let PieceAlignment {
                     left_bytes,
                     right_bytes,

--- a/filecoin-proofs/src/api/sector_builder/helpers/get_sectors_ready_for_sealing.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/get_sectors_ready_for_sealing.rs
@@ -19,7 +19,7 @@ pub fn get_sectors_ready_for_sealing(
             .values()
             .filter(|x| x.seal_status == SealStatus::Pending)
             .partition(|x| {
-                max_user_bytes_per_staged_sector <= sum_piece_bytes_with_alignment(x.pieces.iter())
+                max_user_bytes_per_staged_sector <= sum_piece_bytes_with_alignment(&x.pieces)
             });
 
     not_full.sort_unstable_by_key(|x| Reverse(x.sector_id));

--- a/filecoin-proofs/src/api/sector_builder/helpers/get_sectors_ready_for_sealing.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/get_sectors_ready_for_sealing.rs
@@ -1,4 +1,4 @@
-use crate::api::sector_builder::metadata::sum_piece_bytes;
+use crate::api::sector_builder::pieces::sum_piece_lengths;
 use crate::api::sector_builder::metadata::SealStatus;
 use crate::api::sector_builder::metadata::StagedSectorMetadata;
 use crate::api::sector_builder::state::StagedState;
@@ -18,7 +18,7 @@ pub fn get_sectors_ready_for_sealing(
             .sectors
             .values()
             .filter(|x| x.seal_status == SealStatus::Pending)
-            .partition(|x| max_user_bytes_per_staged_sector <= sum_piece_bytes(x));
+            .partition(|x| max_user_bytes_per_staged_sector <= sum_piece_lengths(x.pieces.iter()));
 
     not_full.sort_unstable_by_key(|x| Reverse(x.sector_id));
 

--- a/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
@@ -57,7 +57,6 @@ fn retrieve_piece_aux<'a>(
         );
         err_unrecov(msg)
     })?;
-    let start_offset = get_piece_start_byte(&sealed_sector.pieces, &piece);
 
     let num_bytes_unsealed = internal::get_unsealed_range(
         (*sector_store.inner).proofs_config().porep_config(),
@@ -65,7 +64,7 @@ fn retrieve_piece_aux<'a>(
         &PathBuf::from(staging_sector_access),
         prover_id,
         &sector_id_as_bytes(sealed_sector.sector_id)?,
-        start_offset,
+        get_piece_start_byte(&sealed_sector.pieces, &piece),
         piece.num_bytes,
     )?;
 

--- a/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
@@ -2,8 +2,8 @@ use crate::api::internal;
 use crate::api::sector_builder::errors::err_unrecov;
 use crate::api::sector_builder::metadata::sector_id_as_bytes;
 use crate::api::sector_builder::metadata::SealedSectorMetadata;
+use crate::api::sector_builder::pieces::{get_piece_by_key, get_piece_start_byte};
 use crate::api::sector_builder::WrappedSectorStore;
-use crate::api::sector_builder::pieces::{get_piece_start, get_piece_by_key};
 use crate::error;
 use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use std::path::PathBuf;
@@ -57,7 +57,7 @@ fn retrieve_piece_aux<'a>(
         );
         err_unrecov(msg)
     })?;
-    let start_offset = get_piece_start(&sealed_sector.pieces, piece);
+    let start_offset = get_piece_start_byte(&sealed_sector.pieces, piece);
 
     let num_bytes_unsealed = internal::get_unsealed_range(
         (*sector_store.inner).proofs_config().porep_config(),

--- a/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
@@ -3,6 +3,7 @@ use crate::api::sector_builder::errors::err_unrecov;
 use crate::api::sector_builder::metadata::sector_id_as_bytes;
 use crate::api::sector_builder::metadata::SealedSectorMetadata;
 use crate::api::sector_builder::WrappedSectorStore;
+use crate::api::sector_builder::pieces::{get_piece_start, get_piece_by_key};
 use crate::error;
 use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use std::path::PathBuf;
@@ -49,13 +50,14 @@ fn retrieve_piece_aux<'a>(
     piece_key: &'a str,
     staging_sector_access: &'a str,
 ) -> error::Result<(UnpaddedBytesAmount, Vec<u8>)> {
-    let (start_offset, num_bytes) = piece_pos(&sealed_sector, piece_key).ok_or_else(|| {
+    let piece = get_piece_by_key(&sealed_sector.pieces, piece_key).ok_or_else(|| {
         let msg = format!(
             "piece {} not found in sector {}",
             piece_key, &sealed_sector.sector_id
         );
         err_unrecov(msg)
     })?;
+    let start_offset = get_piece_start(&sealed_sector.pieces, piece);
 
     let num_bytes_unsealed = internal::get_unsealed_range(
         (*sector_store.inner).proofs_config().porep_config(),
@@ -64,13 +66,13 @@ fn retrieve_piece_aux<'a>(
         prover_id,
         &sector_id_as_bytes(sealed_sector.sector_id)?,
         start_offset,
-        num_bytes,
+        piece.num_bytes,
     )?;
 
-    if num_bytes_unsealed != num_bytes {
+    if num_bytes_unsealed != piece.num_bytes {
         let s = format!(
             "expected to unseal {} bytes, but unsealed {} bytes",
-            u64::from(num_bytes),
+            u64::from(piece.num_bytes),
             u64::from(num_bytes_unsealed)
         );
 
@@ -84,75 +86,4 @@ fn retrieve_piece_aux<'a>(
     )?;
 
     Ok((num_bytes_unsealed, piece_bytes))
-}
-
-// Returns a tuple of piece bytes-offset and number-of-bytes in piece if the
-// provided sealed sector contains a matching piece.
-fn piece_pos(
-    sealed_sector: &SealedSectorMetadata,
-    piece_key: &str,
-) -> Option<(u64, UnpaddedBytesAmount)> {
-    let (found_piece, start_offset, num_bytes) = sealed_sector.pieces.iter().fold(
-        (false, 0, UnpaddedBytesAmount(0)),
-        |(eject, start_offset, num_bytes), item| {
-            if eject {
-                (eject, start_offset, num_bytes)
-            } else if item.piece_key == piece_key {
-                (true, start_offset, item.num_bytes)
-            } else {
-                (
-                    false,
-                    start_offset + u64::from(item.num_bytes),
-                    item.num_bytes,
-                )
-            }
-        },
-    );
-
-    if found_piece {
-        Some((start_offset, num_bytes))
-    } else {
-        None
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::api::sector_builder::metadata::PieceMetadata;
-
-    #[test]
-    fn test_alpha() {
-        let mut sealed_sector: SealedSectorMetadata = Default::default();
-
-        sealed_sector.pieces.push(PieceMetadata {
-            piece_key: String::from("x"),
-            num_bytes: UnpaddedBytesAmount(5),
-        });
-
-        sealed_sector.pieces.push(PieceMetadata {
-            piece_key: String::from("y"),
-            num_bytes: UnpaddedBytesAmount(30),
-        });
-
-        sealed_sector.pieces.push(PieceMetadata {
-            piece_key: String::from("z"),
-            num_bytes: UnpaddedBytesAmount(100),
-        });
-
-        match piece_pos(&sealed_sector, "x") {
-            Some(pair) => assert_eq!(pair, (0, UnpaddedBytesAmount(5))),
-            None => panic!(),
-        }
-
-        match piece_pos(&sealed_sector, "y") {
-            Some(pair) => assert_eq!(pair, (5, UnpaddedBytesAmount(30))),
-            None => panic!(),
-        }
-
-        match piece_pos(&sealed_sector, "z") {
-            Some(pair) => assert_eq!(pair, (35, UnpaddedBytesAmount(100))),
-            None => panic!(),
-        }
-    }
 }

--- a/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
+++ b/filecoin-proofs/src/api/sector_builder/helpers/retrieve_piece.rs
@@ -57,7 +57,7 @@ fn retrieve_piece_aux<'a>(
         );
         err_unrecov(msg)
     })?;
-    let start_offset = get_piece_start_byte(&sealed_sector.pieces, piece);
+    let start_offset = get_piece_start_byte(&sealed_sector.pieces, &piece);
 
     let num_bytes_unsealed = internal::get_unsealed_range(
         (*sector_store.inner).proofs_config().porep_config(),

--- a/filecoin-proofs/src/api/sector_builder/metadata.rs
+++ b/filecoin-proofs/src/api/sector_builder/metadata.rs
@@ -82,12 +82,6 @@ impl Default for SealedSectorMetadata {
     }
 }
 
-pub fn sum_piece_bytes(s: &StagedSectorMetadata) -> UnpaddedBytesAmount {
-    s.pieces
-        .iter()
-        .fold(UnpaddedBytesAmount(0), |acc, x| acc + x.num_bytes)
-}
-
 pub fn sector_id_as_bytes(sector_id: SectorId) -> error::Result<[u8; 31]> {
     // Transmute a u64 sector id to a zero-padded byte array.
     let mut sector_id_as_bytes = [0u8; 31];

--- a/filecoin-proofs/src/api/sector_builder/mod.rs
+++ b/filecoin-proofs/src/api/sector_builder/mod.rs
@@ -19,6 +19,7 @@ pub mod errors;
 mod helpers;
 mod kv_store;
 pub mod metadata;
+pub mod pieces;
 mod scheduler;
 mod sealer;
 mod state;

--- a/filecoin-proofs/src/api/sector_builder/pieces.rs
+++ b/filecoin-proofs/src/api/sector_builder/pieces.rs
@@ -1,9 +1,9 @@
 use crate::api::sector_builder::metadata::PieceMetadata;
 use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use std::cmp::max;
+use std::io::Cursor;
 use std::io::Read;
 use std::iter::Iterator;
-use std::io::Cursor;
 
 pub struct PieceAlignment {
     pub left_bytes: UnpaddedBytesAmount,
@@ -68,10 +68,7 @@ pub fn get_piece_alignment(
     }
 }
 
-pub fn with_alignment(
-    source: impl Read,
-    piece_alignment: PieceAlignment,
-) -> impl Read {
+pub fn with_alignment(source: impl Read, piece_alignment: PieceAlignment) -> impl Read {
     let PieceAlignment {
         left_bytes,
         right_bytes,
@@ -90,7 +87,8 @@ pub fn get_aligned_source(
 ) -> (UnpaddedBytesAmount, impl Read) {
     let written_bytes = sum_piece_bytes_with_alignment(pieces.iter());
     let piece_alignment = get_piece_alignment(written_bytes, piece_bytes);
-    let expected_num_bytes_written = piece_alignment.left_bytes + piece_bytes + piece_alignment.right_bytes;
+    let expected_num_bytes_written =
+        piece_alignment.left_bytes + piece_bytes + piece_alignment.right_bytes;
 
     (
         expected_num_bytes_written,

--- a/filecoin-proofs/src/api/sector_builder/pieces.rs
+++ b/filecoin-proofs/src/api/sector_builder/pieces.rs
@@ -21,11 +21,8 @@ pub fn sum_piece_bytes_with_alignment(pieces: &[PieceMetadata]) -> UnpaddedBytes
     })
 }
 
-pub fn get_piece_by_key<'a>(
-    pieces: &'a [PieceMetadata],
-    piece_key: &str,
-) -> Option<&'a PieceMetadata> {
-    pieces.iter().find(|p| p.piece_key == piece_key)
+pub fn get_piece_by_key(pieces: &[PieceMetadata], piece_key: &str) -> Option<PieceMetadata> {
+    pieces.iter().find(|p| p.piece_key == piece_key).map(|p| p.clone())
 }
 
 pub fn get_piece_start_byte(pieces: &[PieceMetadata], piece: &PieceMetadata) -> u64 {

--- a/filecoin-proofs/src/api/sector_builder/pieces.rs
+++ b/filecoin-proofs/src/api/sector_builder/pieces.rs
@@ -2,12 +2,21 @@ use crate::api::sector_builder::metadata::PieceMetadata;
 use sector_base::api::bytes_amount::UnpaddedBytesAmount;
 use std::cmp::max;
 
-pub type PiecePadding = (UnpaddedBytesAmount, UnpaddedBytesAmount);
+pub struct PieceAlignment {
+    pub left_bytes: UnpaddedBytesAmount,
+    pub right_bytes: UnpaddedBytesAmount,
+}
 
-pub fn sum_piece_lengths<'a, T: Iterator<Item = &'a PieceMetadata>>(pieces: T) -> UnpaddedBytesAmount {
+pub fn sum_piece_bytes_with_alignment<'a, T: Iterator<Item = &'a PieceMetadata>>(
+    pieces: T,
+) -> UnpaddedBytesAmount {
     pieces.fold(UnpaddedBytesAmount(0), |acc, p| {
-        let (l, r) = get_piece_padding(acc, p.num_bytes);
-        acc + l + p.num_bytes + r
+        let PieceAlignment {
+            left_bytes,
+            right_bytes,
+        } = get_piece_alignment(acc, p.num_bytes);
+
+        acc + left_bytes + p.num_bytes + right_bytes
     })
 }
 
@@ -18,21 +27,26 @@ pub fn get_piece_by_key<'a>(
     pieces.iter().find(|p| p.piece_key == piece_key)
 }
 
-pub fn get_piece_start(pieces: &[PieceMetadata], piece: &PieceMetadata) -> u64 {
-    let last_byte = sum_piece_lengths(pieces.iter().take_while(|p| p.piece_key != piece.piece_key));
-    let (left_padding, _) = get_piece_padding(last_byte, piece.num_bytes);
+pub fn get_piece_start_byte(pieces: &[PieceMetadata], piece: &PieceMetadata) -> u64 {
+    let last_byte = sum_piece_bytes_with_alignment(
+        pieces.iter().take_while(|p| p.piece_key != piece.piece_key),
+    );
+    let alignment = get_piece_alignment(last_byte, piece.num_bytes);
 
-    u64::from(last_byte + left_padding)
+    u64::from(last_byte + alignment.left_bytes)
 }
 
-pub fn get_piece_padding(written_bytes: UnpaddedBytesAmount, piece_bytes: UnpaddedBytesAmount) -> PiecePadding {
+pub fn get_piece_alignment(
+    written_bytes: UnpaddedBytesAmount,
+    piece_bytes: UnpaddedBytesAmount,
+) -> PieceAlignment {
     let minimum_piece_bytes = (4 * 32) - 1;
     let adjusted_piece_bytes = max(minimum_piece_bytes, u64::from(piece_bytes));
 
     let mut piece_bytes_needed = minimum_piece_bytes;
 
     while piece_bytes_needed < adjusted_piece_bytes {
-      piece_bytes_needed *= 2;
+        piece_bytes_needed *= 2;
     }
 
     let encroaching = u64::from(written_bytes) % piece_bytes_needed;
@@ -45,7 +59,10 @@ pub fn get_piece_padding(written_bytes: UnpaddedBytesAmount, piece_bytes: Unpadd
 
     let right_bytes = piece_bytes_needed - u64::from(piece_bytes);
 
-    (UnpaddedBytesAmount(left_bytes), UnpaddedBytesAmount(right_bytes))
+    PieceAlignment {
+        left_bytes: UnpaddedBytesAmount(left_bytes),
+        right_bytes: UnpaddedBytesAmount(right_bytes),
+    }
 }
 
 #[cfg(test)]
@@ -53,158 +70,55 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_foo() {
+    fn test_get_piece_alignment() {
         let table = vec![
-            (  0,    0, (  0, 127)),
-            (  0,  127, (  0,   0)),
-            (  0,  254, (  0,   0)),
-            (  0,  508, (  0,   0)),
-            (  0, 1016, (  0,   0)),
-            (127,  127, (  0,   0)),
-            (127,  254, (127,   0)),
-            (127,  508, (381,   0)),
-
-            (100,  100, ( 27,  27)),
-            (200,  200, ( 54,  54)),
-            (300,  300, (208, 208)),
-
+            (0, 0, (0, 127)),
+            (0, 127, (0, 0)),
+            (0, 254, (0, 0)),
+            (0, 508, (0, 0)),
+            (0, 1016, (0, 0)),
+            (127, 127, (0, 0)),
+            (127, 254, (127, 0)),
+            (127, 508, (381, 0)),
+            (100, 100, (27, 27)),
+            (200, 200, (54, 54)),
+            (300, 300, (208, 208)),
         ];
 
         for (x, y, (a, b)) in table.clone() {
-            let (UnpaddedBytesAmount(c), UnpaddedBytesAmount(d)) = get_piece_padding(UnpaddedBytesAmount(x), UnpaddedBytesAmount(y));
-            println!("f({}, {}) -> ({}, {}) (expected: {}, {})", x, y, c, d, a, b);
+            let PieceAlignment {
+                left_bytes: UnpaddedBytesAmount(c),
+                right_bytes: UnpaddedBytesAmount(d),
+            } = get_piece_alignment(UnpaddedBytesAmount(x), UnpaddedBytesAmount(y));
             assert_eq!((c, d), (a, b));
         }
     }
 
-    fn leaves(n: u64) -> UnpaddedBytesAmount {
-        UnpaddedBytesAmount(n * 32)
-    }
-
     #[test]
-    fn test_get_piece_info() {
-        // minimally sized piece in clean sector
-        assert_eq!(
-            get_piece_padding(leaves(0), leaves(4)),
-            (leaves(0), leaves(0))
-        );
-
-        // smaller than minimum piece in clean sector
-        assert_eq!(
-            get_piece_padding(leaves(0), leaves(3)),
-            (leaves(0), leaves(1))
-        );
-
-        // slightly bigger piece in clean sector
-        assert_eq!(
-            get_piece_padding(leaves(0), leaves(5)),
-            (leaves(0), leaves(3))
-        );
-
-        // minimal piece in populated sector
-        assert_eq!(
-            get_piece_padding(leaves(4), leaves(4)),
-            (leaves(0), leaves(0))
-        );
-
-        // big piece in populated sector
-        assert_eq!(
-            get_piece_padding(leaves(4), leaves(5)),
-            (leaves(4), leaves(3))
-        );
-
-        // bigger piece in populated sector
-        assert_eq!(
-            get_piece_padding(leaves(4), leaves(8)),
-            (leaves(4), leaves(0))
-        );
-
-        // even bigger piece in populated sector
-        assert_eq!(
-            get_piece_padding(leaves(4), leaves(15)),
-            (leaves(12), leaves(1))
-        );
-
-        // piece in misaligned sector
-        assert_eq!(
-            get_piece_padding(leaves(5), leaves(5)),
-            (leaves(3), leaves(3))
-        );
-    }
-
-    #[test]
-    fn test_get_piece_start_foo() {
+    fn test_get_piece_start_byte() {
         let mut pieces: Vec<PieceMetadata> = Default::default();
 
-        pieces.push(PieceMetadata {
-            piece_key: String::from("x"),
+        let piece_a = PieceMetadata {
+            piece_key: String::from("a"),
             num_bytes: UnpaddedBytesAmount(31),
-            // comm_p: None,
-        });
+        };
 
-        pieces.push(PieceMetadata {
-            piece_key: String::from("y"),
+        let piece_b = PieceMetadata {
+            piece_key: String::from("b"),
             num_bytes: UnpaddedBytesAmount(32),
-            // comm_p: None,
-        });
+        };
 
-        pieces.push(PieceMetadata {
-            piece_key: String::from("z"),
+        let piece_c = PieceMetadata {
+            piece_key: String::from("c"),
             num_bytes: UnpaddedBytesAmount(33),
-            // comm_p: None,
-        });
+        };
 
-        match get_piece_start(&pieces, "x") {
-            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 0),
-            None => panic!(),
-        }
+        pieces.push(piece_a);
+        pieces.push(piece_b);
+        pieces.push(piece_c);
 
-        match get_piece_start(&pieces, "y") {
-            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 128),
-            None => panic!(),
-        }
-
-        match get_piece_start(&pieces, "z") {
-            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 256),
-            None => panic!(),
-        }
-    }
-
-    #[test]
-    fn test_get_piece_start() {
-        let mut pieces: Vec<PieceMetadata> = Default::default();
-
-        pieces.push(PieceMetadata {
-            piece_key: String::from("x"),
-            num_bytes: UnpaddedBytesAmount(5),
-            // comm_p: None,
-        });
-
-        pieces.push(PieceMetadata {
-            piece_key: String::from("y"),
-            num_bytes: UnpaddedBytesAmount(300),
-            // comm_p: None,
-        });
-
-        pieces.push(PieceMetadata {
-            piece_key: String::from("z"),
-            num_bytes: UnpaddedBytesAmount(100),
-            // comm_p: None,
-        });
-
-        match get_piece_start(&pieces, "x") {
-            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 0),
-            None => panic!(),
-        }
-
-        match get_piece_start(&pieces, "y") {
-            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 512),
-            None => panic!(),
-        }
-
-        match get_piece_start(&pieces, "z") {
-            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 1024),
-            None => panic!(),
-        }
+        assert_eq!(get_piece_start_byte(&pieces, &pieces[0]), 0);
+        assert_eq!(get_piece_start_byte(&pieces, &pieces[1]), 127);
+        assert_eq!(get_piece_start_byte(&pieces, &pieces[2]), 254);
     }
 }

--- a/filecoin-proofs/src/api/sector_builder/pieces.rs
+++ b/filecoin-proofs/src/api/sector_builder/pieces.rs
@@ -1,5 +1,5 @@
 use crate::api::sector_builder::metadata::PieceMetadata;
-use sector_base::api::bytes_amount::{UnpaddedBytesAmount, UnpaddedByteIndex};
+use sector_base::api::bytes_amount::{UnpaddedByteIndex, UnpaddedBytesAmount};
 use std::cmp::max;
 use std::io::Cursor;
 use std::io::Read;
@@ -22,7 +22,10 @@ pub fn sum_piece_bytes_with_alignment(pieces: &[PieceMetadata]) -> UnpaddedBytes
 }
 
 pub fn get_piece_by_key(pieces: &[PieceMetadata], piece_key: &str) -> Option<PieceMetadata> {
-    pieces.iter().find(|p| p.piece_key == piece_key).map(|p| p.clone())
+    pieces
+        .iter()
+        .find(|p| p.piece_key == piece_key)
+        .map(|p| p.clone())
 }
 
 pub fn get_piece_start_byte(pieces: &[PieceMetadata], piece: &PieceMetadata) -> UnpaddedByteIndex {
@@ -114,12 +117,20 @@ mod tests {
             (300, 300, (208, 208)),
         ];
 
-        for (x, y, (a, b)) in table.clone() {
+        for (bytes_in_sector, bytes_in_piece, (expected_left_align, expected_right_align)) in
+            table.clone()
+        {
             let PieceAlignment {
-                left_bytes: UnpaddedBytesAmount(c),
-                right_bytes: UnpaddedBytesAmount(d),
-            } = get_piece_alignment(UnpaddedBytesAmount(x), UnpaddedBytesAmount(y));
-            assert_eq!((c, d), (a, b));
+                left_bytes: UnpaddedBytesAmount(actual_left_align),
+                right_bytes: UnpaddedBytesAmount(actual_right_align),
+            } = get_piece_alignment(
+                UnpaddedBytesAmount(bytes_in_sector),
+                UnpaddedBytesAmount(bytes_in_piece),
+            );
+            assert_eq!(
+                (expected_left_align, expected_right_align),
+                (actual_left_align, actual_right_align)
+            );
         }
     }
 
@@ -146,8 +157,17 @@ mod tests {
         pieces.push(piece_b);
         pieces.push(piece_c);
 
-        assert_eq!(get_piece_start_byte(&pieces, &pieces[0]), UnpaddedByteIndex(0));
-        assert_eq!(get_piece_start_byte(&pieces, &pieces[1]), UnpaddedByteIndex(127));
-        assert_eq!(get_piece_start_byte(&pieces, &pieces[2]), UnpaddedByteIndex(254));
+        assert_eq!(
+            get_piece_start_byte(&pieces, &pieces[0]),
+            UnpaddedByteIndex(0)
+        );
+        assert_eq!(
+            get_piece_start_byte(&pieces, &pieces[1]),
+            UnpaddedByteIndex(127)
+        );
+        assert_eq!(
+            get_piece_start_byte(&pieces, &pieces[2]),
+            UnpaddedByteIndex(254)
+        );
     }
 }

--- a/filecoin-proofs/src/api/sector_builder/pieces.rs
+++ b/filecoin-proofs/src/api/sector_builder/pieces.rs
@@ -1,0 +1,210 @@
+use crate::api::sector_builder::metadata::PieceMetadata;
+use sector_base::api::bytes_amount::UnpaddedBytesAmount;
+use std::cmp::max;
+
+pub type PiecePadding = (UnpaddedBytesAmount, UnpaddedBytesAmount);
+
+pub fn sum_piece_lengths<'a, T: Iterator<Item = &'a PieceMetadata>>(pieces: T) -> UnpaddedBytesAmount {
+    pieces.fold(UnpaddedBytesAmount(0), |acc, p| {
+        let (l, r) = get_piece_padding(acc, p.num_bytes);
+        acc + l + p.num_bytes + r
+    })
+}
+
+pub fn get_piece_by_key<'a>(
+    pieces: &'a [PieceMetadata],
+    piece_key: &str,
+) -> Option<&'a PieceMetadata> {
+    pieces.iter().find(|p| p.piece_key == piece_key)
+}
+
+pub fn get_piece_start(pieces: &[PieceMetadata], piece: &PieceMetadata) -> u64 {
+    let last_byte = sum_piece_lengths(pieces.iter().take_while(|p| p.piece_key != piece.piece_key));
+    let (left_padding, _) = get_piece_padding(last_byte, piece.num_bytes);
+
+    u64::from(last_byte + left_padding)
+}
+
+pub fn get_piece_padding(written_bytes: UnpaddedBytesAmount, piece_bytes: UnpaddedBytesAmount) -> PiecePadding {
+    let minimum_piece_bytes = (4 * 32) - 1;
+    let adjusted_piece_bytes = max(minimum_piece_bytes, u64::from(piece_bytes));
+
+    let mut piece_bytes_needed = minimum_piece_bytes;
+
+    while piece_bytes_needed < adjusted_piece_bytes {
+      piece_bytes_needed *= 2;
+    }
+
+    let encroaching = u64::from(written_bytes) % piece_bytes_needed;
+
+    let left_bytes = if encroaching > 0 {
+        piece_bytes_needed - encroaching
+    } else {
+        0
+    };
+
+    let right_bytes = piece_bytes_needed - u64::from(piece_bytes);
+
+    (UnpaddedBytesAmount(left_bytes), UnpaddedBytesAmount(right_bytes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_foo() {
+        let table = vec![
+            (  0,    0, (  0, 127)),
+            (  0,  127, (  0,   0)),
+            (  0,  254, (  0,   0)),
+            (  0,  508, (  0,   0)),
+            (  0, 1016, (  0,   0)),
+            (127,  127, (  0,   0)),
+            (127,  254, (127,   0)),
+            (127,  508, (381,   0)),
+
+            (100,  100, ( 27,  27)),
+            (200,  200, ( 54,  54)),
+            (300,  300, (208, 208)),
+
+        ];
+
+        for (x, y, (a, b)) in table.clone() {
+            let (UnpaddedBytesAmount(c), UnpaddedBytesAmount(d)) = get_piece_padding(UnpaddedBytesAmount(x), UnpaddedBytesAmount(y));
+            println!("f({}, {}) -> ({}, {}) (expected: {}, {})", x, y, c, d, a, b);
+            assert_eq!((c, d), (a, b));
+        }
+    }
+
+    fn leaves(n: u64) -> UnpaddedBytesAmount {
+        UnpaddedBytesAmount(n * 32)
+    }
+
+    #[test]
+    fn test_get_piece_info() {
+        // minimally sized piece in clean sector
+        assert_eq!(
+            get_piece_padding(leaves(0), leaves(4)),
+            (leaves(0), leaves(0))
+        );
+
+        // smaller than minimum piece in clean sector
+        assert_eq!(
+            get_piece_padding(leaves(0), leaves(3)),
+            (leaves(0), leaves(1))
+        );
+
+        // slightly bigger piece in clean sector
+        assert_eq!(
+            get_piece_padding(leaves(0), leaves(5)),
+            (leaves(0), leaves(3))
+        );
+
+        // minimal piece in populated sector
+        assert_eq!(
+            get_piece_padding(leaves(4), leaves(4)),
+            (leaves(0), leaves(0))
+        );
+
+        // big piece in populated sector
+        assert_eq!(
+            get_piece_padding(leaves(4), leaves(5)),
+            (leaves(4), leaves(3))
+        );
+
+        // bigger piece in populated sector
+        assert_eq!(
+            get_piece_padding(leaves(4), leaves(8)),
+            (leaves(4), leaves(0))
+        );
+
+        // even bigger piece in populated sector
+        assert_eq!(
+            get_piece_padding(leaves(4), leaves(15)),
+            (leaves(12), leaves(1))
+        );
+
+        // piece in misaligned sector
+        assert_eq!(
+            get_piece_padding(leaves(5), leaves(5)),
+            (leaves(3), leaves(3))
+        );
+    }
+
+    #[test]
+    fn test_get_piece_start_foo() {
+        let mut pieces: Vec<PieceMetadata> = Default::default();
+
+        pieces.push(PieceMetadata {
+            piece_key: String::from("x"),
+            num_bytes: UnpaddedBytesAmount(31),
+            // comm_p: None,
+        });
+
+        pieces.push(PieceMetadata {
+            piece_key: String::from("y"),
+            num_bytes: UnpaddedBytesAmount(32),
+            // comm_p: None,
+        });
+
+        pieces.push(PieceMetadata {
+            piece_key: String::from("z"),
+            num_bytes: UnpaddedBytesAmount(33),
+            // comm_p: None,
+        });
+
+        match get_piece_start(&pieces, "x") {
+            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 0),
+            None => panic!(),
+        }
+
+        match get_piece_start(&pieces, "y") {
+            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 128),
+            None => panic!(),
+        }
+
+        match get_piece_start(&pieces, "z") {
+            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 256),
+            None => panic!(),
+        }
+    }
+
+    #[test]
+    fn test_get_piece_start() {
+        let mut pieces: Vec<PieceMetadata> = Default::default();
+
+        pieces.push(PieceMetadata {
+            piece_key: String::from("x"),
+            num_bytes: UnpaddedBytesAmount(5),
+            // comm_p: None,
+        });
+
+        pieces.push(PieceMetadata {
+            piece_key: String::from("y"),
+            num_bytes: UnpaddedBytesAmount(300),
+            // comm_p: None,
+        });
+
+        pieces.push(PieceMetadata {
+            piece_key: String::from("z"),
+            num_bytes: UnpaddedBytesAmount(100),
+            // comm_p: None,
+        });
+
+        match get_piece_start(&pieces, "x") {
+            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 0),
+            None => panic!(),
+        }
+
+        match get_piece_start(&pieces, "y") {
+            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 512),
+            None => panic!(),
+        }
+
+        match get_piece_start(&pieces, "z") {
+            Some(UnpaddedBytesAmount(start)) => assert_eq!(start, 1024),
+            None => panic!(),
+        }
+    }
+}

--- a/filecoin-proofs/src/api/sector_builder/pieces.rs
+++ b/filecoin-proofs/src/api/sector_builder/pieces.rs
@@ -1,5 +1,5 @@
 use crate::api::sector_builder::metadata::PieceMetadata;
-use sector_base::api::bytes_amount::UnpaddedBytesAmount;
+use sector_base::api::bytes_amount::{UnpaddedBytesAmount, UnpaddedByteIndex};
 use std::cmp::max;
 use std::io::Cursor;
 use std::io::Read;
@@ -25,7 +25,7 @@ pub fn get_piece_by_key(pieces: &[PieceMetadata], piece_key: &str) -> Option<Pie
     pieces.iter().find(|p| p.piece_key == piece_key).map(|p| p.clone())
 }
 
-pub fn get_piece_start_byte(pieces: &[PieceMetadata], piece: &PieceMetadata) -> u64 {
+pub fn get_piece_start_byte(pieces: &[PieceMetadata], piece: &PieceMetadata) -> UnpaddedByteIndex {
     let pieces: Vec<PieceMetadata> = pieces
         .into_iter()
         .take_while(|p| p.piece_key != piece.piece_key)
@@ -34,7 +34,7 @@ pub fn get_piece_start_byte(pieces: &[PieceMetadata], piece: &PieceMetadata) -> 
     let last_byte = sum_piece_bytes_with_alignment(&pieces);
     let alignment = get_piece_alignment(last_byte, piece.num_bytes);
 
-    u64::from(last_byte + alignment.left_bytes)
+    UnpaddedByteIndex::from(last_byte + alignment.left_bytes)
 }
 
 pub fn get_piece_alignment(
@@ -146,8 +146,8 @@ mod tests {
         pieces.push(piece_b);
         pieces.push(piece_c);
 
-        assert_eq!(get_piece_start_byte(&pieces, &pieces[0]), 0);
-        assert_eq!(get_piece_start_byte(&pieces, &pieces[1]), 127);
-        assert_eq!(get_piece_start_byte(&pieces, &pieces[2]), 254);
+        assert_eq!(get_piece_start_byte(&pieces, &pieces[0]), UnpaddedByteIndex(0));
+        assert_eq!(get_piece_start_byte(&pieces, &pieces[1]), UnpaddedByteIndex(127));
+        assert_eq!(get_piece_start_byte(&pieces, &pieces[2]), UnpaddedByteIndex(254));
     }
 }

--- a/filecoin-proofs/src/api/sector_builder/pieces.rs
+++ b/filecoin-proofs/src/api/sector_builder/pieces.rs
@@ -66,7 +66,7 @@ pub fn get_piece_alignment(
     }
 }
 
-pub fn with_alignment(source: impl Read, piece_alignment: PieceAlignment) -> impl Read {
+fn with_alignment(source: impl Read, piece_alignment: PieceAlignment) -> impl Read {
     let PieceAlignment {
         left_bytes,
         right_bytes,

--- a/filecoin-proofs/src/api/sector_builder/pieces.rs
+++ b/filecoin-proofs/src/api/sector_builder/pieces.rs
@@ -1,6 +1,5 @@
 use crate::api::sector_builder::metadata::PieceMetadata;
 use sector_base::api::bytes_amount::{UnpaddedByteIndex, UnpaddedBytesAmount};
-use std::cmp::max;
 use std::io::Cursor;
 use std::io::Read;
 use std::iter::Iterator;
@@ -65,15 +64,13 @@ pub fn get_piece_alignment(
     // Bit padding causes bytes to only be aligned at every 127 bytes (for 31.75 bytes).
     // @TODO change this away from magic numbers.
     let minimum_piece_bytes = (4 * 32) - 1;
-    // Ensure the piece will be at the calculated minimum.
-    let adjusted_piece_bytes = max(minimum_piece_bytes, u64::from(piece_bytes));
 
     let mut piece_bytes_needed = minimum_piece_bytes;
 
     // Calculate the next power of two multiple that will fully contain the piece's data.
     // This is required to ensure a clean piece merkle root, without being affected by
     // preceding or following pieces.
-    while piece_bytes_needed < adjusted_piece_bytes {
+    while piece_bytes_needed < u64::from(piece_bytes) {
         piece_bytes_needed *= 2;
     }
 
@@ -96,7 +93,7 @@ pub fn get_piece_alignment(
 }
 
 /**
- * Wraps a Readable source with zero bytes on either end according to a provided PieceAlignment.
+ * Wraps a Readable source with null bytes on either end according to a provided PieceAlignment.
  */
 fn with_alignment(source: impl Read, piece_alignment: PieceAlignment) -> impl Read {
     let PieceAlignment {

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -204,12 +204,6 @@ impl<T: KeyValueStore> SectorMetadataManager<T> {
         piece_key: String,
         return_channel: mpsc::SyncSender<Result<Vec<u8>>>,
     ) {
-        println!("=== FOOBAR ===");
-        println!("=== FOOBAR ===");
-        println!("=== FOOBAR ===");
-        println!("=== FOOBAR ===");
-        println!("{:?}", self.state.staged.sectors);
-        println!("{:?}", self.state.sealed.sectors);
         let opt_sealed_sector = self.state.sealed.sectors.values().find(|sector| {
             sector
                 .pieces

--- a/filecoin-proofs/src/api/sector_builder/scheduler.rs
+++ b/filecoin-proofs/src/api/sector_builder/scheduler.rs
@@ -204,6 +204,12 @@ impl<T: KeyValueStore> SectorMetadataManager<T> {
         piece_key: String,
         return_channel: mpsc::SyncSender<Result<Vec<u8>>>,
     ) {
+        println!("=== FOOBAR ===");
+        println!("=== FOOBAR ===");
+        println!("=== FOOBAR ===");
+        println!("=== FOOBAR ===");
+        println!("{:?}", self.state.staged.sectors);
+        println!("{:?}", self.state.sealed.sectors);
         let opt_sealed_sector = self.state.sealed.sectors.values().find(|sector| {
             sector
                 .pieces

--- a/sector-base/src/api/bytes_amount.rs
+++ b/sector-base/src/api/bytes_amount.rs
@@ -8,6 +8,9 @@ pub struct PoStProofBytesAmount(pub usize);
 pub struct PoRepProofBytesAmount(pub usize);
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct UnpaddedByteIndex(pub u64);
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
 pub struct UnpaddedBytesAmount(pub u64);
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Serialize, Deserialize)]
@@ -46,6 +49,24 @@ impl From<PaddedBytesAmount> for usize {
 impl From<PaddedBytesAmount> for UnpaddedBytesAmount {
     fn from(n: PaddedBytesAmount) -> Self {
         UnpaddedBytesAmount(unpadded_bytes(n.0))
+    }
+}
+
+impl From<UnpaddedBytesAmount> for UnpaddedByteIndex {
+    fn from(n: UnpaddedBytesAmount) -> Self {
+        UnpaddedByteIndex(n.0)
+    }
+}
+
+impl From<UnpaddedByteIndex> for u64 {
+    fn from(n: UnpaddedByteIndex) -> Self {
+        n.0
+    }
+}
+
+impl From<UnpaddedByteIndex> for usize {
+    fn from(n: UnpaddedByteIndex) -> Self {
+        n.0 as usize
     }
 }
 


### PR DESCRIPTION
## What's in this PR?
- fixes `compute_destination_sector_id` to be deterministic by ordering sectors before selecting
- `add_piece` now packs pieces naively into sectors, zeroing their data in from the left and out to the right to ensure the existence of a yet to be calculated `comm_p` in the merkle tree of the sector
- `retrieve_piece` also accounts for this new padding  