### PR TITLE
link CoreFoundation framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,7 +233,7 @@ jobs:
             - cargo-v9-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Build (release)
-          command: cargo +$(cat rust-toolchain) build --release --verbose --frozen --all
+          command: RUSTFLAGS="--print native-static-libs" cargo +$(cat rust-toolchain) build --release --verbose --frozen --all
       - run:
           name: Install jq
           command: apt-get install jq -yqq
@@ -263,7 +263,7 @@ jobs:
       - run: cargo fetch
       - run:
           name: Build (release)
-          command: cargo +$(cat rust-toolchain) build --release --verbose --frozen --all
+          command: RUSTFLAGS="--print native-static-libs" cargo +$(cat rust-toolchain) build --release --verbose --frozen --all
       - run:
           name: Install jq
           command: |

--- a/filecoin-proofs/build.rs
+++ b/filecoin-proofs/build.rs
@@ -63,7 +63,7 @@ fn main() {
     let libs = if cfg!(target_os = "linux") {
         "-lutil -lutil -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -lutil"
     } else if cfg!(target_os = "macos") {
-        "-framework Security -framework CoreFoundation -lSystem -lresolv -lc -lm"
+        "-framework Security -framework CoreFoundation -framework Security -lSystem -lresolv -lc -lm"
     } else {
         ""
     };

--- a/filecoin-proofs/build.rs
+++ b/filecoin-proofs/build.rs
@@ -63,7 +63,7 @@ fn main() {
     let libs = if cfg!(target_os = "linux") {
         "-lutil -lutil -ldl -lrt -lpthread -lgcc_s -lc -lm -lrt -lpthread -lutil -lutil"
     } else if cfg!(target_os = "macos") {
-        "-framework Security -lSystem -lresolv -lc -lm"
+        "-framework Security -framework CoreFoundation -lSystem -lresolv -lc -lm"
     } else {
         ""
     };


### PR DESCRIPTION
## Why is this PR needed?

A recent change to the rust-fil-proofs codebase introduced a link-time dependency on CoreFoundation for OSX builds. 

## What's in this PR?

This PR adds that dependency to the pkg-config file which our build generates. This PR also updates the CircleCI config to output (to stdout) the linker command required to link libfilecoin_proofs.a in OSX and in Linux environments (for debugging).