### PR TITLE
refactor(storage-proofs): remove panic-able unwraps

### DIFF
--- a/storage-proofs/src/batchpost.rs
+++ b/storage-proofs/src/batchpost.rs
@@ -246,21 +246,23 @@ mod tests {
 
         let priv_inputs = PrivateInputs::<H>::new(data.as_slice(), &tree);
 
-        let proof = BatchPoST::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+        let proof = BatchPoST::<H>::prove(&pub_params, &pub_inputs, &priv_inputs)
+            .expect("failed to create proof");
 
-        assert!(
-            BatchPoST::<H>::verify(&pub_params, &pub_inputs, &proof).unwrap(),
-            "failed to verify"
-        );
+        let proof_is_valid = BatchPoST::<H>::verify(&pub_params, &pub_inputs, &proof)
+            .expect("failed to verify proof");
+
+        assert!(proof_is_valid, "failed to verify");
 
         // mess with a single part of the proof
         {
             let mut proof = proof;
             proof.challenges[0] = proof.challenges[0] + 1;
-            assert!(
-                !BatchPoST::<H>::verify(&pub_params, &pub_inputs, &proof).unwrap(),
-                "verified invalid proof"
-            );
+
+            let proof_is_valid = BatchPoST::<H>::verify(&pub_params, &pub_inputs, &proof)
+                .expect("failed to verify proof");
+
+            assert!(!proof_is_valid, "verified invalid proof");
         }
     }
 

--- a/storage-proofs/src/beacon_post.rs
+++ b/storage-proofs/src/beacon_post.rs
@@ -236,7 +236,8 @@ mod tests {
             post_periods_count: 3,
         };
 
-        let pub_params = BeaconPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&sp).unwrap();
+        let pub_params =
+            BeaconPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&sp).expect("setup failed");
 
         let data0: Vec<u8> = (0..1024)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
@@ -260,8 +261,12 @@ mod tests {
             _h: PhantomData,
         };
 
-        let proof = BeaconPoSt::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+        let proof = BeaconPoSt::prove(&pub_params, &pub_inputs, &priv_inputs)
+            .expect("failed to create proof");
 
-        assert!(BeaconPoSt::verify(&pub_params, &pub_inputs, &proof).unwrap());
+        let proof_is_valid =
+            BeaconPoSt::verify(&pub_params, &pub_inputs, &proof).expect("failed to verify proof");
+
+        assert!(proof_is_valid);
     }
 }

--- a/storage-proofs/src/challenge_derivation.rs
+++ b/storage-proofs/src/challenge_derivation.rs
@@ -21,6 +21,7 @@ pub fn derive_challenges<D: Domain>(
             let j = ((n * k as usize) + i) as u32;
             bytes.extend(commitment.into_bytes());
             bytes.push(layer);
+            // Unwraping here is safe, all hash domains are larger than 4 bytes (the size of a `u32`).
             bytes.write_u32::<LittleEndian>(j).unwrap();
 
             let hash = blake2s(bytes.as_slice());
@@ -28,7 +29,10 @@ pub fn derive_challenges<D: Domain>(
 
             // For now, we cannot try to prove the first or last node, so make sure the challenge can never be 0 or leaves - 1.
             let big_mod_challenge = big_challenge % (leaves - 2);
-            big_mod_challenge.to_usize().unwrap() + 1
+            let big_mod_challenge = big_mod_challenge
+                .to_usize()
+                .expect("`big_mod_challenge` exceeds size of `usize`");
+            big_mod_challenge + 1
         })
         .collect()
 }

--- a/storage-proofs/src/circuit/beacon_post.rs
+++ b/storage-proofs/src/circuit/beacon_post.rs
@@ -158,8 +158,8 @@ mod tests {
             post_periods_count: 3,
         };
 
-        let pub_params =
-            beacon_post::BeaconPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&sp).unwrap();
+        let pub_params = beacon_post::BeaconPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&sp)
+            .expect("setup failed");
 
         let data0: Vec<u8> = (0..256)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
@@ -180,9 +180,12 @@ mod tests {
         let trees = [&tree0, &tree1];
         let priv_inputs = beacon_post::PrivateInputs::new(&replicas[..], &trees[..]);
 
-        let proof = BeaconPoSt::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+        let proof =
+            BeaconPoSt::prove(&pub_params, &pub_inputs, &priv_inputs).expect("proving failed");
 
-        assert!(BeaconPoSt::verify(&pub_params, &pub_inputs, &proof).unwrap());
+        let is_valid =
+            BeaconPoSt::verify(&pub_params, &pub_inputs, &proof).expect("verification failed");
+        assert!(is_valid);
 
         // actual circuit test
 

--- a/storage-proofs/src/circuit/kdf.rs
+++ b/storage-proofs/src/circuit/kdf.rs
@@ -83,7 +83,7 @@ mod tests {
             parents_bits.clone(),
             m,
         )
-        .unwrap();
+        .expect("key derivation function failed");
 
         assert!(cs.is_satisfied(), "constraints not satisfied");
         assert_eq!(cs.num_constraints(), 240282);

--- a/storage-proofs/src/circuit/pedersen.rs
+++ b/storage-proofs/src/circuit/pedersen.rs
@@ -103,8 +103,8 @@ mod tests {
                 let mut cs = cs.namespace(|| "data");
                 bytes_into_boolean_vec(&mut cs, Some(data.as_slice()), data.len()).unwrap()
             };
-            let out =
-                pedersen_md_no_padding(cs.namespace(|| "pedersen"), params, &data_bits).unwrap();
+            let out = pedersen_md_no_padding(cs.namespace(|| "pedersen"), params, &data_bits)
+                .expect("pedersen hashing failed");
 
             assert!(cs.is_satisfied(), "constraints not satisfied");
 

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -301,7 +301,8 @@ mod tests {
                 &public_params.vanilla_params,
                 setup_params.engine_params,
             )
-            .unwrap();
+            .expect("failed to generate groth params");
+
             let proof = PoRCompound::<PedersenHasher>::prove(
                 &public_params,
                 &public_inputs,
@@ -379,14 +380,13 @@ mod tests {
             );
 
             // create a non circuit proof
-            let proof =
-                merklepor::MerklePoR::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+            let proof = merklepor::MerklePoR::<H>::prove(&pub_params, &pub_inputs, &priv_inputs)
+                .expect("proving failed");
 
             // make sure it verifies
-            assert!(
-                merklepor::MerklePoR::<H>::verify(&pub_params, &pub_inputs, &proof).unwrap(),
-                "failed to verify merklepor proof"
-            );
+            let is_valid = merklepor::MerklePoR::<H>::verify(&pub_params, &pub_inputs, &proof)
+                .expect("verification failed");
+            assert!(is_valid, "failed to verify merklepor proof");
 
             // -- Circuit
 
@@ -400,7 +400,7 @@ mod tests {
                 _h: Default::default(),
             };
 
-            por.synthesize(&mut cs).unwrap();
+            por.synthesize(&mut cs).expect("circuit synthesis failed");
             assert!(cs.is_satisfied(), "constraints not satisfied");
 
             assert_eq!(cs.num_inputs(), 3, "wrong number of inputs");
@@ -487,15 +487,19 @@ mod tests {
                 &tree,
             );
 
-            let gparams = PoRCompound::<H>::groth_params(
+            let groth_params = PoRCompound::<H>::groth_params(
                 &public_params.vanilla_params,
                 setup_params.engine_params,
             )
-            .unwrap();
+            .expect("failed to generate groth params");
 
-            let proof =
-                PoRCompound::<H>::prove(&public_params, &public_inputs, &private_inputs, &gparams)
-                    .expect("failed while proving");
+            let proof = PoRCompound::<H>::prove(
+                &public_params,
+                &public_inputs,
+                &private_inputs,
+                &groth_params,
+            )
+            .expect("proving failed");
 
             {
                 let (circuit, inputs) = PoRCompound::<H>::circuit_for_test(
@@ -562,14 +566,13 @@ mod tests {
                 &pub_inputs,
                 &priv_inputs,
             )
-            .unwrap();
+            .expect("proving failed");
 
             // make sure it verifies
-            assert!(
+            let is_valid =
                 merklepor::MerklePoR::<PedersenHasher>::verify(&pub_params, &pub_inputs, &proof)
-                    .unwrap(),
-                "failed to verify merklepor proof"
-            );
+                    .expect("verification failed");
+            assert!(is_valid, "failed to verify merklepor proof");
 
             // -- Circuit
 
@@ -584,7 +587,7 @@ mod tests {
                 _h: Default::default(),
             };
 
-            por.synthesize(&mut cs).unwrap();
+            por.synthesize(&mut cs).expect("circuit synthesis failed");
             assert!(cs.is_satisfied(), "constraints not satisfied");
 
             assert_eq!(cs.num_inputs(), 2, "wrong number of inputs");

--- a/storage-proofs/src/circuit/porc.rs
+++ b/storage-proofs/src/circuit/porc.rs
@@ -334,9 +334,12 @@ mod tests {
             trees: &[&tree1, &tree2],
         };
 
-        let proof = PoRC::<PedersenHasher>::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+        let proof = PoRC::<PedersenHasher>::prove(&pub_params, &pub_inputs, &priv_inputs)
+            .expect("proving failed");
 
-        assert!(PoRC::<PedersenHasher>::verify(&pub_params, &pub_inputs, &proof).unwrap());
+        let is_valid = PoRC::<PedersenHasher>::verify(&pub_params, &pub_inputs, &proof)
+            .expect("verification failed");
+        assert!(is_valid);
 
         // actual circuit test
 
@@ -427,11 +430,11 @@ mod tests {
 
         let gparams =
             PoRCCompound::<PedersenHasher>::groth_params(&pub_params.vanilla_params, &params)
-                .unwrap();
+                .expect("failed to create groth params");
 
         let proof =
             PoRCCompound::<PedersenHasher>::prove(&pub_params, &pub_inputs, &priv_inputs, &gparams)
-                .expect("failed while proving");
+                .expect("proving failed");
 
         let (circuit, inputs) = PoRCCompound::<PedersenHasher>::circuit_for_test(
             &pub_params,

--- a/storage-proofs/src/circuit/ppor/mod.rs
+++ b/storage-proofs/src/circuit/ppor/mod.rs
@@ -186,15 +186,13 @@ mod tests {
 
             for i in 0..leaves {
                 // make sure it verifies
-                assert!(
-                    merklepor::MerklePoR::<PedersenHasher>::verify(
-                        &pub_params,
-                        &pub_inputs[i],
-                        &proofs[i]
-                    )
-                    .unwrap(),
-                    "failed to verify merklepor proof"
-                );
+                let is_valid = merklepor::MerklePoR::<PedersenHasher>::verify(
+                    &pub_params,
+                    &pub_inputs[i],
+                    &proofs[i],
+                )
+                .expect("verification failed");
+                assert!(is_valid, "failed to verify merklepor proof");
             }
 
             let auth_paths: Vec<_> = proofs.iter().map(|p| p.proof.as_options()).collect();

--- a/storage-proofs/src/circuit/sloth.rs
+++ b/storage-proofs/src/circuit/sloth.rs
@@ -170,7 +170,7 @@ mod tests {
             let a = num::AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(rng.gen())).unwrap();
             let b = num::AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(rng.gen())).unwrap();
 
-            let res = sub(cs.namespace(|| "a-b"), &a, &b).unwrap();
+            let res = sub(cs.namespace(|| "a-b"), &a, &b).expect("subtraction failed");
 
             let mut tmp = a.get_value().unwrap().clone();
             tmp.sub_assign(&b.get_value().unwrap());

--- a/storage-proofs/src/circuit/test/mod.rs
+++ b/storage-proofs/src/circuit/test/mod.rs
@@ -102,7 +102,10 @@ fn hash_lc<E: Engine>(terms: &[(Variable, E::Fr)], h: &mut Blake2s) {
             }
         }
 
-        coeff.into_repr().write_be(&mut buf[9..]).unwrap();
+        coeff
+            .into_repr()
+            .write_be(&mut buf[9..])
+            .expect("failed to write coeff");
 
         h.update(&buf[..]);
     }

--- a/storage-proofs/src/circuit/vdf_post.rs
+++ b/storage-proofs/src/circuit/vdf_post.rs
@@ -405,7 +405,8 @@ mod tests {
             sectors_count: 2,
         };
 
-        let pub_params = vdf_post::VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&sp).unwrap();
+        let pub_params = vdf_post::VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&sp)
+            .expect("setup failed");
 
         let data0: Vec<u8> = (0..1024)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
@@ -433,16 +434,16 @@ mod tests {
             &pub_inputs,
             &priv_inputs,
         )
-        .unwrap();
+        .expect("proving failed");
 
-        assert!(
-            vdf_post::VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::verify(
-                &pub_params,
-                &pub_inputs,
-                &proof
-            )
-            .unwrap()
-        );
+        let is_valid = vdf_post::VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::verify(
+            &pub_params,
+            &pub_inputs,
+            &proof,
+        )
+        .expect("verification failed");
+
+        assert!(is_valid);
 
         // actual circuit test
 
@@ -588,7 +589,7 @@ mod tests {
                 VDFPoSt<PedersenHasher, _>,
                 VDFPoStCircuit<_>,
             >>::groth_params(&pub_params.vanilla_params, &params)
-            .unwrap();
+            .expect("failed to create groth params");
 
         let proof = VDFPostCompound::prove(&pub_params, &pub_inputs, &priv_inputs, &gparams)
             .expect("failed while proving");

--- a/storage-proofs/src/circuit/xor.rs
+++ b/storage-proofs/src/circuit/xor.rs
@@ -58,7 +58,8 @@ mod tests {
                 bytes_into_boolean_vec(&mut cs, Some(data.as_slice()), data.len()).unwrap()
             };
 
-            let out_bits = xor(&mut cs, key_bits.as_slice(), data_bits.as_slice()).unwrap();
+            let out_bits =
+                xor(&mut cs, key_bits.as_slice(), data_bits.as_slice()).expect("xor failed");
 
             assert!(cs.is_satisfied(), "constraints not satisfied");
             assert_eq!(out_bits.len(), data_bits.len(), "invalid output length");
@@ -79,7 +80,7 @@ mod tests {
             // -- roundtrip
             let roundtrip_bits = {
                 let mut cs = cs.namespace(|| "roundtrip");
-                xor(&mut cs, key_bits.as_slice(), out_bits.as_slice()).unwrap()
+                xor(&mut cs, key_bits.as_slice(), out_bits.as_slice()).expect("xor faield")
             };
 
             let roundtrip = bits_to_bytes(

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -420,10 +420,10 @@ mod tests {
             layer_challenges: layer_challenges.clone(),
         };
 
-        let pp = ZigZagDrgPoRep::setup(&sp).unwrap();
+        let pp = ZigZagDrgPoRep::setup(&sp).expect("setup failed");
         let (tau, aux) =
             ZigZagDrgPoRep::replicate(&pp, &replica_id.into(), data_copy.as_mut_slice(), None)
-                .unwrap();
+                .expect("replication failed");
         assert_ne!(data, data_copy);
 
         let simplified_tau = tau.clone().simplify();
@@ -440,9 +440,13 @@ mod tests {
             tau: tau.layer_taus.into(),
         };
 
-        let proofs =
-            ZigZagDrgPoRep::prove_all_partitions(&pp, &pub_inputs, &priv_inputs, 1).unwrap();
-        assert!(ZigZagDrgPoRep::verify_all_partitions(&pp, &pub_inputs, &proofs).unwrap());
+        let proofs = ZigZagDrgPoRep::prove_all_partitions(&pp, &pub_inputs, &priv_inputs, 1)
+            .expect("failed to generate partition proofs");
+
+        let proofs_are_valid = ZigZagDrgPoRep::verify_all_partitions(&pp, &pub_inputs, &proofs)
+            .expect("failed to verify partition proofs");
+
+        assert!(proofs_are_valid);
 
         // End copied section.
 
@@ -619,14 +623,15 @@ mod tests {
             partitions: Some(partition_count),
         };
 
-        let public_params = ZigZagCompound::setup(&setup_params).unwrap();
+        let public_params = ZigZagCompound::setup(&setup_params).expect("setup failed");
         let (tau, aux) = ZigZagDrgPoRep::replicate(
             &public_params.vanilla_params,
             &replica_id.into(),
             data_copy.as_mut_slice(),
             None,
         )
-        .unwrap();
+        .expect("replication failed");
+
         assert_ne!(data, data_copy);
 
         let public_inputs = layered_drgporep::PublicInputs::<H::Domain> {
@@ -688,7 +693,8 @@ mod tests {
         // }
 
         let blank_groth_params =
-            ZigZagCompound::groth_params(&public_params.vanilla_params, params).unwrap();
+            ZigZagCompound::groth_params(&public_params.vanilla_params, params)
+                .expect("failed to generate groth params");
 
         let proof = ZigZagCompound::prove(
             &public_params,

--- a/storage-proofs/src/compound_proof.rs
+++ b/storage-proofs/src/compound_proof.rs
@@ -157,7 +157,7 @@ where
         params: &'a E::Params,
         groth_params: &groth16::Parameters<E>,
     ) -> Result<groth16::Proof<E>> {
-        let rng = &mut OsRng::new().unwrap();
+        let rng = &mut OsRng::new().expect("Failed to create `OsRng`");
 
         // We need to make the circuit repeatedly because we can't clone it.
         // Fortunately, doing so is cheap.
@@ -236,13 +236,15 @@ where
             private_inputs,
             partition_count,
         )
-        .unwrap();
+        .expect("failed to generate partition proofs");
+
         assert_eq!(vanilla_proofs.len(), partition_count);
 
-        assert!(
-            S::verify_all_partitions(vanilla_params, &public_inputs, &vanilla_proofs).unwrap(),
-            "vanilla proof didn't verify"
-        );
+        let partitions_are_verified =
+            S::verify_all_partitions(vanilla_params, &public_inputs, &vanilla_proofs)
+                .expect("failed to verify partition proofs");
+
+        assert!(partitions_are_verified, "vanilla proof didn't verify");
 
         // Some(0) because we only return a circuit and inputs for the first partition.
         // It would be more thorough to return all, though just checking one is probably

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -60,7 +60,7 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
             // that isn't caught by the FPS API.
             // Unfortunately, it's not clear how to perform this error-handling in the parallel
             // iterator case.
-            H::Domain::try_from_bytes(d).unwrap()
+            H::Domain::try_from_bytes(d).expect("failed to convert node data to domain element")
         };
 
         if parallel {
@@ -274,7 +274,7 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
 }
 
 pub fn new_seed() -> [u32; 7] {
-    OsRng::new().unwrap().gen()
+    OsRng::new().expect("Failed to create `OsRng`").gen()
 }
 
 #[cfg(test)]
@@ -289,7 +289,10 @@ mod tests {
 
     // Create and return an object of MmapMut backed by in-memory copy of data.
     pub fn mmap_from(data: &[u8]) -> MmapMut {
-        let mut mm = MmapOptions::new().len(data.len()).map_anon().unwrap();
+        let mut mm = MmapOptions::new()
+            .len(data.len())
+            .map_anon()
+            .expect("Failed to create memory map");
         mm.copy_from_slice(data);
         mm
     }

--- a/storage-proofs/src/example_helper.rs
+++ b/storage-proofs/src/example_helper.rs
@@ -31,7 +31,7 @@ pub fn prettyb(num: usize) -> String {
     );
     let pretty_bytes = format!("{:.2}", num / delimiter.powi(exponent))
         .parse::<f64>()
-        .unwrap()
+        .expect("Failed to parse `number` as `u64`")
         * 1_f64;
     let unit = units[exponent as usize];
     format!("{}{} {}", negative, pretty_bytes, unit)
@@ -337,10 +337,14 @@ pub trait Example<'a, C: Circuit<Bls12>>: Default {
         let (data_size, challenge_count, m, sloth_iter, typ) = {
             let matches = instance.clap();
 
-            let data_size = value_t!(matches, "size", usize).unwrap() * 1024;
-            let challenge_count = value_t!(matches, "challenges", usize).unwrap();
-            let m = value_t!(matches, "m", usize).unwrap();
-            let sloth_iter = value_t!(matches, "sloth", usize).unwrap();
+            let data_size = value_t!(matches, "size", usize)
+                .map(|size| size * 1024)
+                .expect("Failed to parse `size` CLI arg as `usize`");
+            let challenge_count = value_t!(matches, "challenges", usize)
+                .expect("Failed to parse `challenges` CLI arg as `usize`");
+            let m = value_t!(matches, "m", usize).expect("Failed to parse `m` CLI arg as `usize`");
+            let sloth_iter = value_t!(matches, "sloth", usize)
+                .expect("Failed to parse `sloth` CLI arg as `usize`");
 
             let typ = match matches.subcommand_name() {
                 Some("groth") => CSType::Groth,

--- a/storage-proofs/src/fr32.rs
+++ b/storage-proofs/src/fr32.rs
@@ -96,7 +96,7 @@ mod tests {
         let mut b = &bytes[..];
         let fr_result = bytes_into_fr::<E>(&mut b);
         if expect_success {
-            let f = fr_result.unwrap();
+            let f = fr_result.expect("Failed to convert bytes to `Fr`");
             let b2 = fr_into_bytes::<E>(&f);
 
             assert_eq!(bytes.to_vec(), b2);
@@ -149,7 +149,8 @@ mod tests {
 
     fn bytes_into_frs_into_bytes_test<E: Engine>(bytes: &Fr32) {
         let mut bytes = bytes.clone();
-        let frs = bytes_into_frs::<E>(&mut bytes).unwrap();
+        let frs =
+            bytes_into_frs::<E>(&mut bytes).expect("Failed to convert bytes into a `Vec<Fr>`");
         assert!(frs.len() == 3);
         let bytes_back = frs_into_bytes::<E>(&frs);
         assert!(bytes.to_vec() == bytes_back);

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -168,9 +168,13 @@ mod tests {
 
         let priv_inputs = PrivateInputs::<H>::new(leaf, &tree);
 
-        let proof = MerklePoR::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+        let proof =
+            MerklePoR::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).expect("proving failed");
 
-        assert!(MerklePoR::<H>::verify(&pub_params, &pub_inputs, &proof).unwrap());
+        let is_valid =
+            MerklePoR::<H>::verify(&pub_params, &pub_inputs, &proof).expect("verification failed");
+
+        assert!(is_valid);
     }
 
     #[test]
@@ -232,7 +236,8 @@ mod tests {
 
         let bad_proof = make_bogus_proof::<H>(&pub_inputs, rng);
 
-        let verified = MerklePoR::verify(&pub_params, &pub_inputs, &bad_proof).unwrap();
+        let verified =
+            MerklePoR::verify(&pub_params, &pub_inputs, &bad_proof).expect("verification failed");
 
         // A bad proof should not be verified!
         assert!(!verified);
@@ -279,14 +284,16 @@ mod tests {
 
         let priv_inputs = PrivateInputs::<H>::new(leaf, &tree);
 
-        let proof = MerklePoR::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+        let proof =
+            MerklePoR::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).expect("proving failed");
 
         let different_pub_inputs = PublicInputs {
             challenge: 999,
             commitment: Some(tree.root()),
         };
 
-        let verified = MerklePoR::<H>::verify(&pub_params, &different_pub_inputs, &proof).unwrap();
+        let verified = MerklePoR::<H>::verify(&pub_params, &different_pub_inputs, &proof)
+            .expect("verification failed");
 
         // A proof created with a the wrong challenge not be verified!
         assert!(!verified);

--- a/storage-proofs/src/piece_inclusion_proof.rs
+++ b/storage-proofs/src/piece_inclusion_proof.rs
@@ -381,8 +381,9 @@ mod tests {
         for (start, length) in &sections {
             let piece = &data[*start * NODE_SIZE..(*start + *length) * NODE_SIZE];
             pieces.push(piece);
-            let comm_p = generate_piece_commitment_bytes::<H>(piece);
-            comm_ps.push(comm_p.unwrap());
+            let comm_p = generate_piece_commitment_bytes::<H>(piece)
+                .expect("failed to generate piece commitment");
+            comm_ps.push(comm_p);
         }
 
         let piece_tree = create_piece_tree::<H>(
@@ -407,9 +408,11 @@ mod tests {
         if expect_alignment_error {
             assert!(proofs.is_err());
         } else {
-            let proofs = proofs.unwrap();
+            let proofs = proofs.expect("failed to create piece inclusion proofs");
             for (proof, piece_spec) in proofs.iter().zip(piece_specs.clone()) {
-                let (_, proof_length) = piece_spec.compute_packing(nodes).unwrap();
+                let (_, proof_length) = piece_spec
+                    .compute_packing(nodes)
+                    .expect("faild to compute packing");
                 assert_eq!(proof.proof_elements.len(), proof_length);
             }
 
@@ -422,7 +425,7 @@ mod tests {
                     &node_lengths,
                     nodes,
                 )
-                .unwrap()
+                .expect("failed to verify proofs")
             );
         }
 
@@ -443,19 +446,22 @@ mod tests {
             for (start, length) in &sections {
                 let wrong_piece = &wrong_data[*start * NODE_SIZE..(*start + *length) * NODE_SIZE];
                 wrong_pieces.push(wrong_piece);
-                wrong_comm_ps.push(generate_piece_commitment_bytes::<H>(wrong_piece).unwrap());
+                wrong_comm_ps.push(
+                    generate_piece_commitment_bytes::<H>(wrong_piece)
+                        .expect("failed to generate piece commitment"),
+                );
             }
 
             assert_eq!(
                 false,
                 PieceInclusionProof::verify_all(
                     &tree.root().into_bytes(),
-                    &proofs.unwrap(),
+                    &proofs.expect("failed to generate inclusion proofs"),
                     &wrong_comm_ps,
                     &node_lengths,
                     nodes
                 )
-                .unwrap(),
+                .expect("failed to verify proofs")
             )
         }
     }

--- a/storage-proofs/src/porc.rs
+++ b/storage-proofs/src/porc.rs
@@ -228,9 +228,13 @@ mod tests {
 
         let priv_inputs = PrivateInputs::<H> { trees: &[&tree] };
 
-        let proof = PoRC::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+        let proof =
+            PoRC::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).expect("proving failed");
 
-        assert!(PoRC::<H>::verify(&pub_params, &pub_inputs, &proof).unwrap());
+        let is_valid =
+            PoRC::<H>::verify(&pub_params, &pub_inputs, &proof).expect("verification failed");
+
+        assert!(is_valid);
     }
 
     #[test]
@@ -294,7 +298,8 @@ mod tests {
             make_bogus_proof::<H>(&pub_inputs, rng),
         ]);
 
-        let verified = PoRC::verify(&pub_params, &pub_inputs, &bad_proof).unwrap();
+        let verified =
+            PoRC::verify(&pub_params, &pub_inputs, &bad_proof).expect("verification failed");
 
         // A bad proof should not be verified!
         assert!(!verified);
@@ -341,7 +346,8 @@ mod tests {
 
         let priv_inputs = PrivateInputs::<H> { trees: &[&tree] };
 
-        let proof = PoRC::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).unwrap();
+        let proof =
+            PoRC::<H>::prove(&pub_params, &pub_inputs, &priv_inputs).expect("proving failed");
 
         let different_pub_inputs = PublicInputs {
             challenges: &vec![rng.gen_range(0, leaves), rng.gen_range(0, leaves)],
@@ -349,7 +355,8 @@ mod tests {
             commitments: &[tree.root()],
         };
 
-        let verified = PoRC::<H>::verify(&pub_params, &different_pub_inputs, &proof).unwrap();
+        let verified = PoRC::<H>::verify(&pub_params, &different_pub_inputs, &proof)
+            .expect("verification failed");
 
         // A proof created with a the wrong challenge not be verified!
         assert!(!verified);

--- a/storage-proofs/src/vdf_post.rs
+++ b/storage-proofs/src/vdf_post.rs
@@ -553,7 +553,8 @@ mod tests {
             sectors_count: 2,
         };
 
-        let pub_params = VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&sp).unwrap();
+        let pub_params =
+            VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::setup(&sp).expect("PoSt setup failed");
 
         let data0: Vec<u8> = (0..1024)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
@@ -583,13 +584,12 @@ mod tests {
             &pub_inputs,
             &priv_inputs,
         )
-        .unwrap();
+        .expect("proving failed");
 
-        assert!(VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::verify(
-            &pub_params,
-            &pub_inputs,
-            &proof
-        )
-        .unwrap());
+        let is_valid =
+            VDFPoSt::<PedersenHasher, vdf_sloth::Sloth>::verify(&pub_params, &pub_inputs, &proof)
+                .expect("verification failed");
+
+        assert!(is_valid);
     }
 }

--- a/storage-proofs/src/zigzag_drgporep.rs
+++ b/storage-proofs/src/zigzag_drgporep.rs
@@ -98,14 +98,15 @@ mod tests {
             layer_challenges: challenges.clone(),
         };
 
-        let mut pp = ZigZagDrgPoRep::<H>::setup(&sp).unwrap();
+        let mut pp = ZigZagDrgPoRep::<H>::setup(&sp).expect("setup failed");
         // Get the graph for the last layer.
         // In reality, this is a no-op with an even number of layers.
         for _ in 0..pp.layer_challenges.layers() {
             pp.graph = zigzag(&pp.graph);
         }
 
-        ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None).unwrap();
+        ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None)
+            .expect("replication failed");
 
         let transformed_params = PublicParams::new(pp.graph, pp.sloth_iter, challenges.clone());
 
@@ -116,7 +117,7 @@ mod tests {
             &replica_id,
             data_copy.as_mut_slice(),
         )
-        .unwrap();
+        .expect("failed to extract data");
 
         assert_eq!(data, decoded_data);
     }
@@ -162,10 +163,10 @@ mod tests {
             layer_challenges: challenges.clone(),
         };
 
-        let pp = ZigZagDrgPoRep::<H>::setup(&sp).unwrap();
+        let pp = ZigZagDrgPoRep::<H>::setup(&sp).expect("setup failed");
         let (tau, aux) =
             ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None)
-                .unwrap();
+                .expect("replication failed");
         assert_ne!(data, data_copy);
 
         let pub_inputs = PublicInputs::<H::Domain> {
@@ -182,12 +183,13 @@ mod tests {
 
         let all_partition_proofs =
             &ZigZagDrgPoRep::<H>::prove_all_partitions(&pp, &pub_inputs, &priv_inputs, partitions)
-                .unwrap();
+                .expect("failed to generate partition proofs");
 
-        assert!(
+        let proofs_are_valid =
             ZigZagDrgPoRep::<H>::verify_all_partitions(&pp, &pub_inputs, all_partition_proofs)
-                .unwrap()
-        );
+                .expect("failed to verify partition proofs");
+
+        assert!(proofs_are_valid);
     }
 
     table_tests! {
@@ -235,6 +237,6 @@ mod tests {
 
         // When this fails, the call to setup should panic, but seems to actually hang (i.e. neither return nor panic) for some reason.
         // When working as designed, the call to setup returns without error.
-        let _pp = ZigZagDrgPoRep::<PedersenHasher>::setup(&sp).unwrap();
+        let _pp = ZigZagDrgPoRep::<PedersenHasher>::setup(&sp).expect("setup failed");
     }
 }


### PR DESCRIPTION
Relates to Issue #390 
- Removes `panic`-able `unwrap`s from the `storage-proofs` subcrate.
- Does not add clippy lint for disallowing unwrapping because many `unwrap`s can't `panic`.


