### PR TITLE
fix(storage-proofs): invert compilation option in generate_merkle_tre…

### DIFF
--- a/storage-proofs/src/settings.rs
+++ b/storage-proofs/src/settings.rs
@@ -2,6 +2,8 @@ use std::sync::Mutex;
 
 use config::{Config, ConfigError, Environment, File};
 
+use crate::SP_LOG;
+
 lazy_static! {
     pub static ref SETTINGS: Mutex<Settings> =
         Mutex::new(Settings::new().expect("invalid configuration"));
@@ -42,12 +44,10 @@ impl Settings {
 
         let settings: Result<Settings, ConfigError> = s.try_into();
 
-        #[cfg(feature = "disk-trees")]
+        #[cfg(not(feature = "disk-trees"))]
         {
-            if settings.is_ok()
-                && settings.as_ref().unwrap().generate_merkle_trees_in_parallel == false
-            {
-                return Err(ConfigError::Message("Setting GENERATE_MERKLE_TREES_IN_PARALLEL to false (sequiental generation) \ndoesn't add any value if the `disk-trees` feature is not set (no offload possible)".to_string()));
+            if settings.is_ok() && !settings.as_ref().unwrap().generate_merkle_trees_in_parallel {
+                warn!(SP_LOG, "{}", "Setting GENERATE_MERKLE_TREES_IN_PARALLEL to false (sequiental generation) \ndoesn't add any value if the `disk-trees` feature is not set (no offload possible)".to_string());
             }
         }
 


### PR DESCRIPTION
…es_in_parallel