### PR TITLE
fix broken `master` build: pin bitvec to not-broken version (0.11.1)

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 storage-proofs = { version = "^0.2", path = "../storage-proofs" }
 logging-toolkit = { version = "^0.2", path = "../logging-toolkit" }
-bitvec = "0.11"
+bitvec = "= 0.11.1"
 chrono = "0.4"
 rand = "0.4"
 failure = "0.1"

--- a/sector-builder/Cargo.toml
+++ b/sector-builder/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-bitvec = "0.11"
+bitvec = "= 0.11.1"
 failure = "0.1.5"
 itertools = "0.8"
 rand = "0.4"

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 logging-toolkit = { version = "^0.2", path = "../logging-toolkit" }
-bitvec = "0.11"
+bitvec = "= 0.11.1"
 rand = "0.4"
 libc = "0.2"
 merkletree = "0.6"


### PR DESCRIPTION
The bitvec folks released `0.11.2` today (around 430PM Los Angeles time), which causes our build to break (as we'd specified version `0.11` for the dependency instead of an exact version).

The bitvec folks then released 0.12.0 and 0.13.0 in quick succession. Unsure what's going on there - but I'm pinning this crate to `0.11.1` (the last verified-as-working version we've consumed) until I can research further.

## Example Failures

A broken build can be observed [here](https://circleci.com/gh/filecoin-project/rust-fil-proofs/21754). 

Excerpt:

```
---- fr32::tests::test_write_padded_alt stdout ----
thread 'fr32::tests::test_write_padded_alt' panicked at 'Index 8 is invalid for type u8', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/bitvec-0.11.2/src/bits.rs:965:3
note: Run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```