### PR TITLE
bug(expose the types required/produced by the safe API)

### DIFF
--- a/filecoin-proofs/src/lib.rs
+++ b/filecoin-proofs/src/lib.rs
@@ -22,3 +22,5 @@ pub mod singletons;
 pub mod types;
 
 pub use api::*;
+pub use constants::SINGLE_PARTITION_PROOF_LEN;
+pub use types::*;


### PR DESCRIPTION
## Why is this PR needed?

The safe API requires (as input) and returns (as output) types which are not themselves exported.

## What's in this PR?

Export all the types, and export the constant required when chunking proofs.