### PR TITLE
dep(storage-proofs): update merkletree to 0.7

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -13,7 +13,7 @@ logging-toolkit = { version = "^0.3", path = "../logging-toolkit" }
 bitvec = "0.11"
 rand = "0.4"
 libc = "0.2"
-merkletree = "0.6"
+merkletree = "0.7"
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"


### PR DESCRIPTION
Uses https://github.com/filecoin-project/merkle_light/pull/21.

----------------------------------

Bench summary: A replication with a sector size of 8 GiB is now reduced from a max RSS of 32 GiB (4 sector sizes) to 24 GiB (3 sector sizes). The replications time itself is considerably reduced also (the bench times are not a faithful representation of MT build time since ~60% of replication time is actually spent in the encoding phase, so the 7 minutes reduction actually represents something like ~35% reduction in MT build time). The Criterion bench is giving a strong regression in performance since the new MT build is optimized for big sector sizes, so we need to either adjust it for small sectors (if they are representative of actual use) or increase the number of nodes in those benchmarks.

Bench command:

```
# Run inside `storage-proofs/` for `disk-trees` to take effect.
cargo build                                                                   \
  -p filecoin-proofs                                                          \
  --release                                                                   \
  --example zigzag                                                            \
  --features                                                                  \
    disk-trees                                                               &&
export TREES_DIR=/home/snarky/space/rust-fil-proofs-trees-dir                &&
FIL_PROOFS_REPLICATED_TREES_DIR="$TREES_DIR"                                  \
FIL_PROOFS_GENERATE_MERKLE_TREES_IN_PARALLEL=0                                \
RUST_BACKTRACE=1                                                              \
CARGO_INCREMENTAL=1                                                           \
nohup time -v ../target/release/examples/zigzag                               \
    --size 8388608                                                            \
    --no-bench                                                                \
    --hasher blake2s                                                          \
    --m 1  --expansion 0 --layers 5                                           \
     > zigzag-8gib.out &
```

Master:

```
	Command being timed: "../target/release/examples/zigzag --size 8388608 --no-bench --hasher blake2s --m 1 --expansion 0 --layers 5"
	User time (seconds): 3410.25
	System time (seconds): 318.82
	Percent of CPU this job got: 130%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 47:36.73    <---
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 33576672             <---
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 34
	Minor (reclaiming a frame) page faults: 98608170
	Voluntary context switches: 2156
	Involuntary context switches: 378699
	Swaps: 0
	File system inputs: 153376
	File system outputs: 285219856
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```

With https://github.com/filecoin-project/merkle_light/pull/21:

```
	Command being timed: "../target/release/examples/zigzag --size 8388608 --no-bench --hasher blake2s --m 1 --expansion 0 --layers 5"
	User time (seconds): 3232.86
	System time (seconds): 195.50
	Percent of CPU this job got: 140%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 40:35.33    <---
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 25174012             <---
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 946
	Minor (reclaiming a frame) page faults: 35783849
	Voluntary context switches: 1039675
	Involuntary context switches: 280609
	Swaps: 0
	File system inputs: 0
	File system outputs: 285219624
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 0
	Page size (bytes): 4096
	Exit status: 0
```


Criterion:

```
nohup bash -c "git checkout master && cargo update && cargo bench merkletree  && git checkout bench/mt-build/reduced-temp-allocation && cargo update -p merkletree && cargo bench merkletree" > bench.out & 2>&1

Benchmarking merkletree/blake2s/128
Benchmarking merkletree/blake2s/128: Warming up for 3.0000 s
Benchmarking merkletree/blake2s/128: Collecting 20 samples in estimated 5.0232 s (27k iterations)
Benchmarking merkletree/blake2s/128: Analyzing
merkletree/blake2s/128  time:   [184.61 us 185.10 us 185.53 us]
                        change: [-6.7737% -6.4507% -6.1457%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 20 measurements (15.00%)
  3 (15.00%) high mild
Benchmarking merkletree/blake2s/1024
Benchmarking merkletree/blake2s/1024: Warming up for 3.0000 s
Benchmarking merkletree/blake2s/1024: Collecting 20 samples in estimated 5.0687 s (10k iterations)
Benchmarking merkletree/blake2s/1024: Analyzing
merkletree/blake2s/1024 time:   [508.87 us 510.00 us 510.99 us]
                        change: [-10.548% -10.179% -9.7979%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 20 measurements (10.00%)
  1 (5.00%) high mild
  1 (5.00%) high severe
Benchmarking merkletree/pedersen/128
Benchmarking merkletree/pedersen/128: Warming up for 3.0000 s
Benchmarking merkletree/pedersen/128: Collecting 20 samples in estimated 6.6311 s (840 iterations)
Benchmarking merkletree/pedersen/128: Analyzing
merkletree/pedersen/128 time:   [7.4981 ms 7.5700 ms 7.6440 ms]
                        change: [-1.5940% -0.1217% +1.3467%] (p = 0.88 > 0.05)
                        No change in performance detected.
Benchmarking merkletree/pedersen/1024
Benchmarking merkletree/pedersen/1024: Warming up for 3.0000 s
Benchmarking merkletree/pedersen/1024: Collecting 20 samples in estimated 10.574 s (210 iterations)
Benchmarking merkletree/pedersen/1024: Analyzing
merkletree/pedersen/1024
                        time:   [50.193 ms 50.234 ms 50.276 ms]
                        change: [+0.4100% +0.5625% +0.6976%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```