### PR TITLE
fix(storage-proofs): conditionally include of SP_LOG

### DIFF
--- a/storage-proofs/src/settings.rs
+++ b/storage-proofs/src/settings.rs
@@ -2,6 +2,7 @@ use std::sync::Mutex;
 
 use config::{Config, ConfigError, Environment, File};
 
+#[cfg(not(feature = "disk-trees"))]
 use crate::SP_LOG;
 
 lazy_static! {


### PR DESCRIPTION
Follow-up to https://github.com/filecoin-project/rust-fil-proofs/pull/689 to avoid Clippy warning.