### PR TITLE
feat(filecoin-proofs): allow paramfetch to use a specific ipfs gateway

### DIFF
--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -11,12 +11,15 @@ use storage_proofs::parameter_cache::PARAMETER_CACHE_DIR;
 
 pub fn main() {
     let matches = App::new("paramfetch")
-        .version("1.0")
+        .version("1.1")
         .about(
             &format!(
                 "
 Set $FILECOIN_PARAMETER_CACHE to specify parameter file directory.
 Defaults to '{}'
+
+Use -g,--gateway to specify ipfs gateway.
+Defaults to 'https://ipfs.io'
 ",
                 PARAMETER_CACHE_DIR
             )[..],
@@ -28,6 +31,14 @@ Defaults to '{}'
                 .short("j")
                 .long("json")
                 .help("Use specific json file"),
+        )
+        .arg(
+            Arg::with_name("gateway")
+                .value_name("URL")
+                .takes_value(true)
+                .short("g")
+                .long("gateway")
+                .help("Use specific ipfs gateway"),
         )
         .arg(
             Arg::with_name("retry")
@@ -61,6 +72,7 @@ Defaults to '{}'
 fn fetch(matches: &ArgMatches) -> Result<()> {
     let json_path = PathBuf::from(matches.value_of("json").unwrap_or("./parameters.json"));
     let retry = matches.is_present("retry");
+    let gateway = matches.value_of("gateway").unwrap_or("https://ipfs.io");
 
     if !json_path.exists() {
         return Err(err_msg(format!(
@@ -95,6 +107,7 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
                 matches.is_present("verbose"),
                 &parameter_map,
                 &parameter_id,
+                &gateway,
             ) {
                 Ok(_) => println!("ok\n"),
                 Err(err) => println!("error: {}\n", err),

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -143,6 +143,7 @@ pub fn spawn_fetch_parameter_file(
     is_verbose: bool,
     parameter_map: &ParameterMap,
     parameter_id: &str,
+    gateway: &str,
 ) -> Result<()> {
     let parameter_data = get_parameter_data(parameter_map, parameter_id)?;
     let path = get_parameter_file_path(parameter_id);
@@ -155,7 +156,7 @@ pub fn spawn_fetch_parameter_file(
     };
 
     let client = Client::new();
-    let url = Url::parse(&format!("https://ipfs.io/ipfs/{}", parameter_data.cid))?;
+    let url = Url::parse(&format!("{}/ipfs/{}", gateway, parameter_data.cid))?;
     let total_size = {
         let res = client.head(url.as_str()).send()?;
         if res.status().is_success() {


### PR DESCRIPTION
paramfetch default ipfs gateway(https://ipfs.io) is blocked by [GFW](https://en.wikipedia.org/wiki/Great_Firewall) in China. this PR can specific ipfs gateway.