### PR TITLE
fix(storage-proofs): ensure direct parent is first parent input to KDF

### DIFF
--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -325,6 +325,12 @@ where
                 //     challenge,
                 // )?;
 
+                // The direct parent should be the one hashed first, see `vde::encode`.
+                parents.sort();
+                if pub_params.graph.forward() {
+                    parents.reverse();
+                }
+
                 let extracted = decode_domain_block::<H>(
                     pub_params.sloth_iter,
                     &pub_inputs.replica_id.expect("missing replica_id"),


### PR DESCRIPTION
*Not working.*

Fixes https://github.com/filecoin-project/rust-fil-proofs/issues/677.

I don't think `parents` (and related) functions should be concerned with the order of its nodes, that seems like the responsibility of the functions that use them for KDF purposes (e.g., `encode` and similar).