### PR TITLE
generate Groth parameter cache metadata file

### DIFF
--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -24,9 +24,13 @@ fn cache_porep_params(porep_config: PoRepConfig) {
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
     );
+
     {
         let circuit = ZigZagCompound::blank_circuit(&public_params, &ENGINE_PARAMS);
-
+        let _ = ZigZagCompound::get_param_metadata(circuit, &public_params);
+    }
+    {
+        let circuit = ZigZagCompound::blank_circuit(&public_params, &ENGINE_PARAMS);
         let _ = ZigZagCompound::get_groth_params(circuit, &public_params);
     }
     {
@@ -40,6 +44,16 @@ fn cache_post_params(post_config: PoStConfig) {
     info!(FCP_LOG, "begin PoSt parameter-cache check/populate routine for {}-byte sectors", n; "target" => "paramcache");
 
     let post_public_params = post_public_params(post_config);
+
+    {
+        let post_circuit: VDFPoStCircuit<Bls12> =
+            <VDFPostCompound as CompoundProof<
+                Bls12,
+                VDFPoSt<PedersenHasher, Sloth>,
+                VDFPoStCircuit<Bls12>,
+            >>::blank_circuit(&post_public_params, &ENGINE_PARAMS);
+        let _ = VDFPostCompound::get_param_metadata(post_circuit, &post_public_params);
+    }
     {
         let post_circuit: VDFPoStCircuit<Bls12> =
             <VDFPostCompound as CompoundProof<

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -52,6 +52,17 @@ pub fn get_local_parameter_ids() -> Result<Vec<String>> {
         Ok(read_dir(path)?
             .map(|f| f.unwrap().path())
             .filter(|p| p.is_file())
+            .filter(|f| match f.extension() {
+                // don't publish the .meta files
+                Some(ref s) => {
+                    if s.to_str().expect("can't marshal to &str") == "meta" {
+                        false
+                    } else {
+                        true
+                    }
+                }
+                None => true,
+            })
             .map(|p| {
                 p.as_path()
                     .file_name()

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -54,13 +54,7 @@ pub fn get_local_parameter_ids() -> Result<Vec<String>> {
             .filter(|p| p.is_file())
             .filter(|f| match f.extension() {
                 // don't publish the .meta files
-                Some(ref s) => {
-                    if s.to_str().expect("can't marshal to &str") == "meta" {
-                        false
-                    } else {
-                        true
-                    }
-                }
+                Some(ref s) => s.to_str().expect("can't marshal to &str") != "meta",
                 None => true,
             })
             .map(|p| {

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -42,6 +42,7 @@ ff = "0.4.0"
 bellperson = "0.2"
 paired = { version = "0.15", features = ["serde"] }
 fil-sapling-crypto = "0.1"
+serde_json = "1.0"
 
 [features]
 default = []
@@ -53,7 +54,6 @@ big-sector-sizes-bench = []
 [dev-dependencies]
 proptest = "0.7"
 criterion = "0.2"
-serde_json = "1.0"
 pretty_assertions = "0.6.1"
 
 [[bench]]

--- a/storage-proofs/src/beacon_post.rs
+++ b/storage-proofs/src/beacon_post.rs
@@ -8,7 +8,7 @@ use serde::ser::Serialize;
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::MerkleTree;
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::proof::{NoRequirements, ProofScheme};
 use crate::vdf::Vdf;
 use crate::vdf_post;
@@ -25,11 +25,15 @@ pub struct PublicParams<T: Domain, V: Vdf<T>> {
     pub post_periods_count: usize,
 }
 
-impl<T: Domain, V: Vdf<T>> ParameterSetIdentifier for PublicParams<T, V> {
-    fn parameter_set_identifier(&self) -> String {
+impl<T, V> ParameterSetMetadata for PublicParams<T, V>
+where
+    T: Domain,
+    V: Vdf<T>,
+{
+    fn identifier(&self) -> String {
         format!(
             "beacon_post::PublicParams{{vdf_post_pub_params: {}, post_periods_count: {}",
-            self.vdf_post_pub_params.parameter_set_identifier(),
+            self.vdf_post_pub_params.identifier(),
             self.post_periods_count
         )
     }

--- a/storage-proofs/src/beacon_post.rs
+++ b/storage-proofs/src/beacon_post.rs
@@ -37,6 +37,10 @@ where
             self.post_periods_count
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        Some(self.vdf_post_pub_params.sector_size as u64)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/storage-proofs/src/circuit/beacon_post.rs
+++ b/storage-proofs/src/circuit/beacon_post.rs
@@ -8,7 +8,7 @@ use crate::beacon_post::BeaconPoSt;
 use crate::circuit::vdf_post;
 use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::hasher::Hasher;
-use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
+use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::proof::ProofScheme;
 use crate::vdf::Vdf;
 
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetIdentifier> CacheableParameters<E, C, P>
+impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetMetadata> CacheableParameters<E, C, P>
     for BeaconPoStCompound
 {
     fn cache_prefix() -> String {

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -14,7 +14,7 @@ use crate::drgporep::DrgPoRep;
 use crate::drgraph::Graph;
 use crate::fr32::fr_into_bytes;
 use crate::merklepor;
-use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
+use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::proof::ProofScheme;
 use crate::util::{bytes_into_bits, bytes_into_boolean_vec};
 use std::marker::PhantomData;
@@ -142,7 +142,7 @@ where
     _g: PhantomData<G>,
 }
 
-impl<E: JubjubEngine, C: Circuit<E>, H: Hasher, G: Graph<H>, P: ParameterSetIdentifier>
+impl<E: JubjubEngine, C: Circuit<E>, H: Hasher, G: Graph<H>, P: ParameterSetMetadata>
     CacheableParameters<E, C, P> for DrgPoRepCompound<H, G>
 {
     fn cache_prefix() -> String {
@@ -154,7 +154,7 @@ impl<'a, H, G> CompoundProof<'a, Bls12, DrgPoRep<'a, H, G>, DrgPoRepCircuit<'a, 
     for DrgPoRepCompound<H, G>
 where
     H: 'a + Hasher,
-    G: 'a + Graph<H> + ParameterSetIdentifier + Sync + Send,
+    G: 'a + Graph<H> + ParameterSetMetadata + Sync + Send,
 {
     fn generate_public_inputs(
         pub_in: &<DrgPoRep<'a, H, G> as ProofScheme<'a>>::PublicInputs,

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -11,7 +11,7 @@ use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::drgraph::graph_height;
 use crate::hasher::{HashFunction, Hasher};
 use crate::merklepor::MerklePoR;
-use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
+use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::proof::ProofScheme;
 
 /// Proof of retrievability.
@@ -51,7 +51,7 @@ pub fn challenge_into_auth_path_bits(challenge: usize, leaves: usize) -> Vec<boo
     bits
 }
 
-impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetIdentifier, H: Hasher>
+impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetMetadata, H: Hasher>
     CacheableParameters<E, C, P> for PoRCompound<H>
 {
     fn cache_prefix() -> String {

--- a/storage-proofs/src/circuit/porc.rs
+++ b/storage-proofs/src/circuit/porc.rs
@@ -14,7 +14,7 @@ use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::drgraph;
 use crate::fr32::u32_into_fr;
 use crate::hasher::Hasher;
-use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
+use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::porc::PoRC;
 use crate::proof::ProofScheme;
 
@@ -61,7 +61,7 @@ where
     _h: PhantomData<H>,
 }
 
-impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetIdentifier, H: Hasher>
+impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetMetadata, H: Hasher>
     CacheableParameters<E, C, P> for PoRCCompound<H>
 {
     fn cache_prefix() -> String {

--- a/storage-proofs/src/circuit/vdf_post.rs
+++ b/storage-proofs/src/circuit/vdf_post.rs
@@ -10,7 +10,7 @@ use crate::circuit::sloth;
 use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::fr32::u32_into_fr;
 use crate::hasher::Hasher;
-use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
+use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::proof::ProofScheme;
 use crate::vdf::Vdf;
 use crate::vdf_post::{self, compute_root_commitment, VDFPoSt};
@@ -42,7 +42,7 @@ pub struct VDFPoStCircuit<'a, E: JubjubEngine> {
 #[derive(Debug)]
 pub struct VDFPostCompound {}
 
-impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetIdentifier> CacheableParameters<E, C, P>
+impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetMetadata> CacheableParameters<E, C, P>
     for VDFPostCompound
 {
     fn cache_prefix() -> String {

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -13,7 +13,7 @@ use crate::drgporep::{self, DrgPoRep};
 use crate::drgraph::Graph;
 use crate::hasher::{HashFunction, Hasher};
 use crate::layered_drgporep::{self, Layers as LayersTrait};
-use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
+use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::porep;
 use crate::proof::ProofScheme;
 use crate::zigzag_drgporep::ZigZagDrgPoRep;
@@ -260,7 +260,7 @@ pub struct ZigZagCompound {
     partitions: Option<usize>,
 }
 
-impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetIdentifier> CacheableParameters<E, C, P>
+impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetMetadata> CacheableParameters<E, C, P>
     for ZigZagCompound
 {
     fn cache_prefix() -> String {

--- a/storage-proofs/src/compound_proof.rs
+++ b/storage-proofs/src/compound_proof.rs
@@ -2,7 +2,7 @@ use rayon::prelude::*;
 
 use crate::circuit::multi_proof::MultiProof;
 use crate::error::Result;
-use crate::parameter_cache::{CacheableParameters, ParameterSetIdentifier};
+use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::partitions;
 use crate::proof::ProofScheme;
 use crate::settings;
@@ -43,7 +43,7 @@ pub trait CircuitComponent {
 pub trait CompoundProof<'a, E: JubjubEngine, S: ProofScheme<'a>, C: Circuit<E> + CircuitComponent>
 where
     S::Proof: Sync + Send,
-    S::PublicParams: ParameterSetIdentifier + Sync + Send,
+    S::PublicParams: ParameterSetMetadata + Sync + Send,
     S::PublicInputs: Clone + Sync,
     Self: CacheableParameters<E, C, S::PublicParams>,
 {

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -94,6 +94,7 @@ where
     }
 
     fn sector_size(&self) -> Option<u64> {
+        // TODO: Expose sector size, if available.
         None
     }
 }

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -10,7 +10,7 @@ use crate::error::Result;
 use crate::fr32::bytes_into_fr_repr_safe;
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::porep::{self, PoRep};
 use crate::proof::{NoRequirements, ProofScheme};
 use crate::vde::{self, decode_block, decode_domain_block};
@@ -54,7 +54,7 @@ pub struct DrgParams {
 pub struct PublicParams<H, G>
 where
     H: Hasher,
-    G: Graph<H> + ParameterSetIdentifier,
+    G: Graph<H> + ParameterSetMetadata,
 {
     pub graph: G,
     pub sloth_iter: usize,
@@ -67,7 +67,7 @@ where
 impl<H, G> PublicParams<H, G>
 where
     H: Hasher,
-    G: Graph<H> + ParameterSetIdentifier,
+    G: Graph<H> + ParameterSetMetadata,
 {
     pub fn new(graph: G, sloth_iter: usize, private: bool, challenges_count: usize) -> Self {
         PublicParams {
@@ -80,15 +80,15 @@ where
     }
 }
 
-impl<H, G> ParameterSetIdentifier for PublicParams<H, G>
+impl<H, G> ParameterSetMetadata for PublicParams<H, G>
 where
     H: Hasher,
-    G: Graph<H> + ParameterSetIdentifier,
+    G: Graph<H> + ParameterSetMetadata,
 {
-    fn parameter_set_identifier(&self) -> String {
+    fn identifier(&self) -> String {
         format!(
             "drgporep::PublicParams{{graph: {}; sloth_iter: {}}}",
-            self.graph.parameter_set_identifier(),
+            self.graph.identifier(),
             self.sloth_iter
         )
     }
@@ -242,7 +242,7 @@ where
 impl<'a, H, G> ProofScheme<'a> for DrgPoRep<'a, H, G>
 where
     H: 'a + Hasher,
-    G: 'a + Graph<H> + ParameterSetIdentifier,
+    G: 'a + Graph<H> + ParameterSetMetadata,
 {
     type PublicParams = PublicParams<H, G>;
     type SetupParams = SetupParams;
@@ -435,7 +435,7 @@ where
 impl<'a, H, G> PoRep<'a, H> for DrgPoRep<'a, H, G>
 where
     H: 'a + Hasher,
-    G: 'a + Graph<H> + ParameterSetIdentifier + Sync + Send,
+    G: 'a + Graph<H> + ParameterSetMetadata + Sync + Send,
 {
     type Tau = porep::Tau<H::Domain>;
     type ProverAux = porep::ProverAux<H>;

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -92,6 +92,10 @@ where
             self.sloth_iter
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -198,6 +198,10 @@ impl<H: Hasher> ParameterSetMetadata for BucketGraph<H> {
             H::name(),
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        Some((self.nodes * 32) as u64)
+    }
 }
 
 impl<H: Hasher> Graph<H> for BucketGraph<H> {

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -8,7 +8,7 @@ use crate::error::*;
 use crate::hasher::pedersen::PedersenHasher;
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::MerkleTree;
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node, NODE_SIZE};
 
 #[cfg(feature = "disk-trees")]
@@ -188,8 +188,8 @@ pub struct BucketGraph<H: Hasher> {
     _h: PhantomData<H>,
 }
 
-impl<H: Hasher> ParameterSetIdentifier for BucketGraph<H> {
-    fn parameter_set_identifier(&self) -> String {
+impl<H: Hasher> ParameterSetMetadata for BucketGraph<H> {
+    fn identifier(&self) -> String {
         // NOTE: Seed is not included because it does not influence parameter generation.
         format!(
             "drgraph::BucketGraph{{size: {}; degree: {}; hasher: {}}}",

--- a/storage-proofs/src/error.rs
+++ b/storage-proofs/src/error.rs
@@ -36,6 +36,8 @@ pub enum Error {
     UnalignedPiece,
     #[fail(display = "{}", _0)]
     Serde(#[cause] serde_json::error::Error),
+    #[fail(display = "unclassified error: {}", _0)]
+    Unclassified(String),
 }
 
 impl From<SynthesisError> for Error {

--- a/storage-proofs/src/error.rs
+++ b/storage-proofs/src/error.rs
@@ -34,6 +34,8 @@ pub enum Error {
     MerkleTreeGenerationError(String),
     #[fail(display = "Cannot (yet) generate inclusion proof for unaligned piece.")]
     UnalignedPiece,
+    #[fail(display = "{}", _0)]
+    Serde(#[cause] serde_json::error::Error),
 }
 
 impl From<SynthesisError> for Error {
@@ -45,5 +47,11 @@ impl From<SynthesisError> for Error {
 impl From<::std::io::Error> for Error {
     fn from(inner: ::std::io::Error) -> Error {
         Error::Io(inner)
+    }
+}
+
+impl From<serde_json::error::Error> for Error {
+    fn from(inner: serde_json::error::Error) -> Error {
+        Error::Serde(inner)
     }
 }

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -180,6 +180,10 @@ where
             self.layer_challenges,
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        self.graph.sector_size()
+    }
 }
 
 impl<'a, H, G> From<&'a PublicParams<H, G>> for PublicParams<H, G>

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -16,7 +16,7 @@ use crate::drgraph::Graph;
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, HashFunction, Hasher};
 use crate::merkle::MerkleTree;
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::porep::{self, PoRep};
 use crate::proof::ProofScheme;
 use crate::settings;
@@ -123,7 +123,7 @@ pub struct SetupParams {
 pub struct PublicParams<H, G>
 where
     H: Hasher,
-    G: Graph<H> + ParameterSetIdentifier,
+    G: Graph<H> + ParameterSetMetadata,
 {
     pub graph: G,
     pub sloth_iter: usize,
@@ -155,7 +155,7 @@ impl<T: Domain> Tau<T> {
 impl<H, G> PublicParams<H, G>
 where
     H: Hasher,
-    G: Graph<H> + ParameterSetIdentifier,
+    G: Graph<H> + ParameterSetMetadata,
 {
     pub fn new(graph: G, sloth_iter: usize, layer_challenges: LayerChallenges) -> Self {
         PublicParams {
@@ -167,15 +167,15 @@ where
     }
 }
 
-impl<H, G> ParameterSetIdentifier for PublicParams<H, G>
+impl<H, G> ParameterSetMetadata for PublicParams<H, G>
 where
     H: Hasher,
-    G: Graph<H> + ParameterSetIdentifier,
+    G: Graph<H> + ParameterSetMetadata,
 {
-    fn parameter_set_identifier(&self) -> String {
+    fn identifier(&self) -> String {
         format!(
             "layered_drgporep::PublicParams{{ graph: {}, sloth: {}, challenges: {:?} }}",
-            self.graph.parameter_set_identifier(),
+            self.graph.identifier(),
             self.sloth_iter,
             self.layer_challenges,
         )
@@ -185,7 +185,7 @@ where
 impl<'a, H, G> From<&'a PublicParams<H, G>> for PublicParams<H, G>
 where
     H: Hasher,
-    G: Graph<H> + ParameterSetIdentifier,
+    G: Graph<H> + ParameterSetMetadata,
 {
     fn from(other: &PublicParams<H, G>) -> PublicParams<H, G> {
         PublicParams::new(
@@ -269,7 +269,7 @@ type TransformedLayers<H> = (Vec<PorepTau<H>>, Vec<Tree<H>>);
 /// of layered proofs of replication. Implementations must provide transform and invert_transform methods.
 pub trait Layers {
     type Hasher: Hasher;
-    type Graph: Layerable<Self::Hasher> + ParameterSetIdentifier + Sync + Send;
+    type Graph: Layerable<Self::Hasher> + ParameterSetMetadata + Sync + Send;
 
     /// Transform a layer's public parameters, returning new public parameters corresponding to the next layer.
     /// Warning: This method will likely need to be extended for other implementations

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -25,6 +25,7 @@ impl ParameterSetMetadata for PublicParams {
     }
 
     fn sector_size(&self) -> Option<u64> {
+        // TODO: Expose sector size, if available.
         None
     }
 }

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -5,7 +5,7 @@ use crate::drgraph::graph_height;
 use crate::error::*;
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::proof::{NoRequirements, ProofScheme};
 
 /// The parameters shared between the prover and verifier.
@@ -16,8 +16,8 @@ pub struct PublicParams {
     pub private: bool,
 }
 
-impl ParameterSetIdentifier for PublicParams {
-    fn parameter_set_identifier(&self) -> String {
+impl ParameterSetMetadata for PublicParams {
+    fn identifier(&self) -> String {
         format!(
             "merklepor::PublicParams{{leaves: {}; private: {}}}",
             self.leaves, self.private

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -23,6 +23,10 @@ impl ParameterSetMetadata for PublicParams {
             self.leaves, self.private
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// The inputs that are necessary for the verifier to verify the proof.

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -99,12 +99,14 @@ pub trait ParameterSetIdentifier: Clone {
     fn parameter_set_identifier(&self) -> String;
 }
 
-pub trait CacheableParameters<E: JubjubEngine, C: Circuit<E>, PP>
+pub trait CacheableParameters<E, C, P>
 where
-    PP: ParameterSetIdentifier,
+    C: Circuit<E>,
+    E: JubjubEngine,
+    P: ParameterSetIdentifier,
 {
     fn cache_prefix() -> String;
-    fn cache_identifier(pub_params: &PP) -> String {
+    fn cache_identifier(pub_params: &P) -> String {
         let param_identifier = pub_params.parameter_set_identifier();
         info!(SP_LOG, "parameter set identifier for cache: {}", param_identifier; "target" => "params");
         let mut hasher = Sha256::default();
@@ -117,7 +119,7 @@ where
         )
     }
 
-    fn get_groth_params(circuit: C, pub_params: &PP) -> Result<groth16::Parameters<E>> {
+    fn get_groth_params(circuit: C, pub_params: &P) -> Result<groth16::Parameters<E>> {
         // Always seed the rng identically so parameter generation will be deterministic.
 
         let id = Self::cache_identifier(pub_params);
@@ -153,7 +155,7 @@ where
         })
     }
 
-    fn get_verifying_key(circuit: C, pub_params: &PP) -> Result<groth16::VerifyingKey<E>> {
+    fn get_verifying_key(circuit: C, pub_params: &P) -> Result<groth16::VerifyingKey<E>> {
         let id = Self::cache_identifier(pub_params);
         let vk_id = format!("{}.vk", id);
 

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -95,8 +95,6 @@ pub fn parameter_cache_path(filename: &str) -> PathBuf {
     dir.join(format!("v{}-{}", VERSION, filename))
 }
 
-pub trait ParameterSetIdentifier: Clone {
-    fn parameter_set_identifier(&self) -> String;
 pub fn parameter_cache_metadata_path(filename: &str) -> PathBuf {
     let name = parameter_cache_dir_name();
     let dir = Path::new(&name);
@@ -117,7 +115,7 @@ pub trait CacheableParameters<E, C, P>
 where
     C: Circuit<E>,
     E: JubjubEngine,
-    P: ParameterSetIdentifier,
+    P: ParameterSetMetadata,
 {
     fn cache_prefix() -> String;
 

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -97,6 +97,9 @@ pub fn parameter_cache_path(filename: &str) -> PathBuf {
 
 pub trait ParameterSetIdentifier: Clone {
     fn parameter_set_identifier(&self) -> String;
+pub trait ParameterSetMetadata: Clone {
+    fn identifier(&self) -> String;
+}
 }
 
 pub trait CacheableParameters<E, C, P>
@@ -107,7 +110,7 @@ where
 {
     fn cache_prefix() -> String;
     fn cache_identifier(pub_params: &P) -> String {
-        let param_identifier = pub_params.parameter_set_identifier();
+        let param_identifier = pub_params.identifier();
         info!(SP_LOG, "parameter set identifier for cache: {}", param_identifier; "target" => "params");
         let mut hasher = Sha256::default();
         hasher.input(&param_identifier.into_bytes());

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -99,6 +99,7 @@ pub trait ParameterSetIdentifier: Clone {
     fn parameter_set_identifier(&self) -> String;
 pub trait ParameterSetMetadata: Clone {
     fn identifier(&self) -> String;
+    fn sector_size(&self) -> Option<u64>;
 }
 }
 

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -101,6 +101,10 @@ pub trait ParameterSetMetadata: Clone {
     fn identifier(&self) -> String;
     fn sector_size(&self) -> Option<u64>;
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CacheEntryMetadata {
+    pub sector_size: Option<u64>,
 }
 
 pub trait CacheableParameters<E, C, P>
@@ -110,6 +114,13 @@ where
     P: ParameterSetIdentifier,
 {
     fn cache_prefix() -> String;
+
+    fn cache_meta(pub_params: &P) -> CacheEntryMetadata {
+        CacheEntryMetadata {
+            sector_size: pub_params.sector_size(),
+        }
+    }
+
     fn cache_identifier(pub_params: &P) -> String {
         let param_identifier = pub_params.identifier();
         info!(SP_LOG, "parameter set identifier for cache: {}", param_identifier; "target" => "params");

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -207,12 +207,6 @@ where
             let bytes = f.seek(SeekFrom::End(0))?;
             info!(SP_LOG, "verifying_key_bytes: {}", bytes; "target" => "stats", "id" => &vk_id);
 
-            // generate metadata file for verifying key
-            let meta_path = parameter_cache_metadata_path(&id);
-            let meta_file = LockedFile::open_exclusive(&meta_path)?;
-            serde_json::to_writer(meta_file, &Self::cache_meta(pub_params))?;
-            info!(SP_LOG, "wrote verifying key metadata to cache {:?} ", &meta_path; "target" => "verifying_key", "id" => &vk_id);
-
             Ok(p)
         })
     }

--- a/storage-proofs/src/porc.rs
+++ b/storage-proofs/src/porc.rs
@@ -40,6 +40,10 @@ impl ParameterSetMetadata for PublicParams {
             self.leaves, self.sectors_count, self.challenges_count,
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        None
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/storage-proofs/src/porc.rs
+++ b/storage-proofs/src/porc.rs
@@ -9,7 +9,7 @@ use crate::drgraph::graph_height;
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::proof::{NoRequirements, ProofScheme};
 
 #[derive(Debug, Clone)]
@@ -33,8 +33,8 @@ pub struct PublicParams {
     pub challenges_count: usize,
 }
 
-impl ParameterSetIdentifier for PublicParams {
-    fn parameter_set_identifier(&self) -> String {
+impl ParameterSetMetadata for PublicParams {
+    fn identifier(&self) -> String {
         format!(
             "porc::PublicParams{{leaves: {} sectors_count: {} challenges_count: {}}}",
             self.leaves, self.sectors_count, self.challenges_count,

--- a/storage-proofs/src/porc.rs
+++ b/storage-proofs/src/porc.rs
@@ -42,6 +42,7 @@ impl ParameterSetMetadata for PublicParams {
     }
 
     fn sector_size(&self) -> Option<u64> {
+        // TODO: Expose sector size, if available.
         None
     }
 }

--- a/storage-proofs/src/vdf_post.rs
+++ b/storage-proofs/src/vdf_post.rs
@@ -59,6 +59,10 @@ impl<T: Domain, V: Vdf<T>> ParameterSetMetadata for PublicParams<T, V> {
             self.leaves, self.sectors_count
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        Some(self.sector_size as u64)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/storage-proofs/src/vdf_post.rs
+++ b/storage-proofs/src/vdf_post.rs
@@ -14,7 +14,7 @@ use crate::error::{Error, Result};
 use crate::fr32::fr_into_bytes;
 use crate::hasher::{Domain, HashFunction, Hasher};
 use crate::merkle::MerkleTree;
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::porc::{self, PoRC};
 use crate::proof::{NoRequirements, ProofScheme};
 use crate::vdf::Vdf;
@@ -50,8 +50,8 @@ pub struct PublicParams<T: Domain, V: Vdf<T>> {
     pub seed_bits: usize,
 }
 
-impl<T: Domain, V: Vdf<T>> ParameterSetIdentifier for PublicParams<T, V> {
-    fn parameter_set_identifier(&self) -> String {
+impl<T: Domain, V: Vdf<T>> ParameterSetMetadata for PublicParams<T, V> {
+    fn identifier(&self) -> String {
         format!(
             "vdf_post::PublicParams{{challenge_count: {}, sector_size: {}, post_epochs: {}, pub_params_vdf: FIXME, leaves: {}, sectors_count: {}}}",
             self.challenge_count, self.sector_size, self.post_epochs,

--- a/storage-proofs/src/vdf_sloth.rs
+++ b/storage-proofs/src/vdf_sloth.rs
@@ -29,6 +29,10 @@ impl ParameterSetMetadata for PublicParams {
             self.key, self.rounds
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/storage-proofs/src/vdf_sloth.rs
+++ b/storage-proofs/src/vdf_sloth.rs
@@ -31,6 +31,7 @@ impl ParameterSetMetadata for PublicParams {
     }
 
     fn sector_size(&self) -> Option<u64> {
+        // TODO: Expose sector size, if available.
         None
     }
 }

--- a/storage-proofs/src/vdf_sloth.rs
+++ b/storage-proofs/src/vdf_sloth.rs
@@ -3,7 +3,7 @@ use paired::bls12_381::{Bls12, Fr};
 use crate::crypto::sloth;
 use crate::error::Result;
 use crate::hasher::pedersen::PedersenDomain;
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::vdf::Vdf;
 
 /// VDF construction using sloth.
@@ -22,8 +22,8 @@ pub struct PublicParams {
     pub rounds: usize,
 }
 
-impl ParameterSetIdentifier for PublicParams {
-    fn parameter_set_identifier(&self) -> String {
+impl ParameterSetMetadata for PublicParams {
+    fn identifier(&self) -> String {
         format!(
             "vdf_sloth::PublicParams{{key: {:?}; rounds: {}}}",
             self.key, self.rounds

--- a/storage-proofs/src/zigzag_drgporep.rs
+++ b/storage-proofs/src/zigzag_drgporep.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use crate::drgraph::Graph;
 use crate::hasher::Hasher;
 use crate::layered_drgporep::Layers;
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::zigzag_graph::{ZigZag, ZigZagBucketGraph};
 
 /// ZigZagDrgPorep is a layered PoRep which replicates layer by layer.
@@ -38,7 +38,7 @@ impl<'a, H: 'static + Hasher> Layers for ZigZagDrgPoRep<'a, H> where {
 fn zigzag<H, Z>(graph: &Z) -> Z
 where
     H: Hasher,
-    Z: ZigZag + Graph<H> + ParameterSetIdentifier,
+    Z: ZigZag + Graph<H> + ParameterSetMetadata,
 {
     graph.zigzag()
 }

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -6,7 +6,7 @@ use crate::crypto::feistel::{self, FeistelPrecomputed};
 use crate::drgraph::{BucketGraph, Graph};
 use crate::hasher::Hasher;
 use crate::layered_drgporep::Layerable;
-use crate::parameter_cache::ParameterSetIdentifier;
+use crate::parameter_cache::ParameterSetMetadata;
 use crate::settings;
 use crate::SP_LOG;
 
@@ -96,16 +96,16 @@ where
     }
 }
 
-impl<H, G> ParameterSetIdentifier for ZigZagGraph<H, G>
+impl<H, G> ParameterSetMetadata for ZigZagGraph<H, G>
 where
     H: Hasher,
-    G: Graph<H> + ParameterSetIdentifier,
+    G: Graph<H> + ParameterSetMetadata,
 {
-    fn parameter_set_identifier(&self) -> String {
+    fn identifier(&self) -> String {
         format!(
             "zigzag_graph::ZigZagGraph{{expansion_degree: {} base_graph: {} }}",
             self.expansion_degree,
-            self.base_graph.parameter_set_identifier()
+            self.base_graph.identifier()
         )
     }
 }

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -108,6 +108,10 @@ where
             self.base_graph.identifier()
         )
     }
+
+    fn sector_size(&self) -> Option<u64> {
+        self.base_graph.sector_size()
+    }
 }
 
 pub trait ZigZag: ::std::fmt::Debug + Clone + PartialEq + Eq {


### PR DESCRIPTION
Makes incremental progress towards #629 

## Why does this PR exist?

We need to give miners a way to download only the Groth parameters that plan to use when sealing. The `parameters.json` file, which we distribute with the go-filecoin binary, includes (today) only the name of each published file (Groth parameter or VK), its checksum, and IPFS cid. No metadata is published, so `paramfetch` cannot preset a miner with a choice of downloading (or not) assets based on e.g. sector size.

## What's in this PR?

This PR exposes sector size as a property of a parameter set. VDF PoSt and ZigZag PoRep (the two circuits for which we currently publish parameters and verifying keys) both produce non-`None` values. This sector size is written to a struct which in turn is JSON encoded and written to disk along with the verifying key and/or Groth parameter. In the future, `parampublish` will read these metadata files and insert their contents into the `parameters.json` file.

## Demo

Before this changeset:

```shell
06:51 $ ls /tmp/filecoin-proof-parameters/
v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6
v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6.vk
v10-zigzag-proof-of-replication-6648cd509799c8b76f944bbc971692c69d1480fa60c569bfc1284f0bd8ead988
v10-zigzag-proof-of-replication-6648cd509799c8b76f944bbc971692c69d1480fa60c569bfc1284f0bd8ead988.vk
```

After:

```shell
06:52 $ ls /tmp/filecoin-proof-parameters/
v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6
v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6.meta
v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6.vk
v10-zigzag-proof-of-replication-6648cd509799c8b76f944bbc971692c69d1480fa60c569bfc1284f0bd8ead988
v10-zigzag-proof-of-replication-6648cd509799c8b76f944bbc971692c69d1480fa60c569bfc1284f0bd8ead988.meta
v10-zigzag-proof-of-replication-6648cd509799c8b76f944bbc971692c69d1480fa60c569bfc1284f0bd8ead988.vk
```

Contents of a `.meta` file:

```shell
06:52 $ cat v10-zigzag-proof-of-replication-
v10-vdf-post-c8ddc8e74f9c2ed6a4bc83df171a9e9e84e242cf6e48e20f71585106fa8a3ce6.meta
{"sector_size":268435456}
```