### PR TITLE
Revert "dep(storage-proofs): update merkletree to 0.7"

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -13,7 +13,7 @@ logging-toolkit = { version = "^0.3", path = "../logging-toolkit" }
 bitvec = "0.11"
 rand = "0.4"
 libc = "0.2"
-merkletree = "0.7"
+merkletree = "0.6"
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"


### PR DESCRIPTION
This reverts commit 4d520ea247eaebbc06ae1cca28cfc49cf1f2b4c4.

Temporary fix for https://github.com/filecoin-project/rust-fil-proofs/issues/713.