### PR TITLE
bugfix(avoid ambiguous as_ref call)

### DIFF
--- a/filecoin-proofs/benches/preprocessing.rs
+++ b/filecoin-proofs/benches/preprocessing.rs
@@ -49,15 +49,15 @@ fn preprocessing_benchmark(c: &mut Criterion) {
     );
 }
 
-fn write_padded_bench(file: &mut File, mut data: Vec<u8>) {
-    let _ = write_padded(&mut data[..].as_ref(), file).unwrap();
+fn write_padded_bench(file: &mut File, data: Vec<u8>) {
+    let _ = write_padded(&mut &data[..], file).unwrap();
     let padded_written = file.seek(SeekFrom::End(0)).unwrap() as usize;
 
     assert!(padded_written > data.len());
 }
 
-fn write_padded_unpadded_bench(file: &mut File, mut data: Vec<u8>) {
-    write_padded(&mut data[..].as_ref(), file).unwrap();
+fn write_padded_unpadded_bench(file: &mut File, data: Vec<u8>) {
+    write_padded(&mut &data[..], file).unwrap();
 
     let padded_written = file.seek(SeekFrom::End(0)).unwrap() as usize;
 


### PR DESCRIPTION
Fixes #717 

## Why is this PR needed?

A recent change causes the type checker to overflow due to the `as_ref()` call being ambiguous.

## What's in this PR?

This changeset modifies the way that the `&mut Read` is constructed from the owned vector such that the type checker doesn't explode.

## Relevant Links

- [here](https://github.com/rust-lang/rust/issues/57854)
- [here](https://stackoverflow.com/questions/50189976/why-do-i-get-overflow-evaluating-the-requirement-sized-when-using-tokio-ios)