### PR TITLE
DRGraph ParameterSetMetadata is missing `sector_size

### DIFF
--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -200,7 +200,7 @@ impl<H: Hasher> ParameterSetMetadata for BucketGraph<H> {
     }
 
     fn sector_size(&self) -> u64 {
-        unimplemented!("required for parameter metadata file generation")
+        (self.nodes * 32) as u64
     }
 }
 


### PR DESCRIPTION
## Why does this PR exist?

I forgot to add the sector size computation for DRGraph.

## What's in the PR?

This PR adds the sector size computation for DRGraph.