### PR TITLE
Fix log in encoding

### DIFF
--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -419,7 +419,7 @@ pub trait Layers {
                 sorted_trees.push(tree_d);
 
                 if layer < layers {
-                    info!(SP_LOG, "encoding"; "layer {}" => format!("{}", layer));
+                    info!(SP_LOG, "encoding"; "layer" => format!("{}", layer));
                     vde::encode(&current_graph, sloth_iter, replica_id, data)
                         .expect("encoding failed in thread");
                 }
@@ -496,7 +496,7 @@ pub trait Layers {
                         threads.push(thread);
 
                         if layer < layers {
-                            info!(SP_LOG, "encoding"; "layer {}" => format!("{}", layer));
+                            info!(SP_LOG, "encoding"; "layer" => format!("{}", layer));
                             vde::encode(&current_graph, sloth_iter, replica_id, data)
                                 .expect("encoding failed in thread");
                         }


### PR DESCRIPTION
I'm not sure how many _trillion_ times I've read that log and this is the first time I've noticed it.