### PR TITLE
Bugs/pip fails verification for 254mib piece

### DIFF
--- a/filecoin-proofs/src/api.rs
+++ b/filecoin-proofs/src/api.rs
@@ -642,7 +642,7 @@ fn pad_safe_fr(unpadded: &FrSafe) -> Fr32Ary {
 
 #[cfg(test)]
 mod tests {
-    use crate::constants::{LIVE_SECTOR_SIZE, TEST_SECTOR_SIZE};
+    use crate::constants::TEST_SECTOR_SIZE;
     use crate::types::SectorSize;
     use rand::Rng;
     use storage_proofs::util::NODE_SIZE;
@@ -762,8 +762,7 @@ mod tests {
     #[test]
     #[ignore]
     fn test_pip_lifecycle() -> Result<(), failure::Error> {
-        // This size is a minimal repro for the P0 API sanity check failure.
-        let sector_size = 1 << 14;
+        let sector_size = TEST_SECTOR_SIZE;
 
         let number_of_bytes_in_piece =
             UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size.clone()));

--- a/filecoin-proofs/src/api.rs
+++ b/filecoin-proofs/src/api.rs
@@ -277,7 +277,7 @@ pub fn seal<T: AsRef<Path>>(
             .into_iter()
             .map(|p| p.number_of_leaves)
             .collect::<Vec<_>>(),
-        (sector_bytes / 127) * 4,
+        sector_bytes >> 5,
     )?;
 
     if !valid_pieces {
@@ -762,8 +762,8 @@ mod tests {
     #[test]
     #[ignore]
     fn test_pip_lifecycle() -> Result<(), failure::Error> {
-        //        let sector_size = TEST_SECTOR_SIZE;
-        let sector_size = LIVE_SECTOR_SIZE;
+        // This size is a minimal repro for the P0 API sanity check failure.
+        let sector_size = 1 << 14;
 
         let number_of_bytes_in_piece =
             UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size.clone()));

--- a/filecoin-proofs/src/api.rs
+++ b/filecoin-proofs/src/api.rs
@@ -642,7 +642,7 @@ fn pad_safe_fr(unpadded: &FrSafe) -> Fr32Ary {
 
 #[cfg(test)]
 mod tests {
-    use crate::constants::TEST_SECTOR_SIZE;
+    use crate::constants::{LIVE_SECTOR_SIZE, TEST_SECTOR_SIZE};
     use crate::types::SectorSize;
     use rand::Rng;
     use storage_proofs::util::NODE_SIZE;
@@ -762,30 +762,32 @@ mod tests {
     #[test]
     #[ignore]
     fn test_pip_lifecycle() -> Result<(), failure::Error> {
-        let number_of_bytes_in_piece: u64 = 500;
-        let unpadded_number_of_bytes_in_piece = UnpaddedBytesAmount(number_of_bytes_in_piece);
-        let bytes: Vec<u8> = (0..number_of_bytes_in_piece)
+        //        let sector_size = TEST_SECTOR_SIZE;
+        let sector_size = LIVE_SECTOR_SIZE;
+
+        let number_of_bytes_in_piece =
+            UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size.clone()));
+
+        let piece_bytes: Vec<u8> = (0..number_of_bytes_in_piece.0)
             .map(|_| rand::random::<u8>())
             .collect();
+
         let mut piece_file = NamedTempFile::new()?;
-        piece_file.write_all(&bytes)?;
+        piece_file.write_all(&piece_bytes)?;
         piece_file.seek(SeekFrom::Start(0))?;
-        let comm_p =
-            generate_piece_commitment(&piece_file.path(), unpadded_number_of_bytes_in_piece)?;
+
+        let comm_p = generate_piece_commitment(&piece_file.path(), number_of_bytes_in_piece)?;
 
         let mut staged_sector_file = NamedTempFile::new()?;
-
         add_piece(
             &mut piece_file,
             &mut staged_sector_file,
-            unpadded_number_of_bytes_in_piece,
+            number_of_bytes_in_piece,
             &[],
         )?;
 
         let sealed_sector_file = NamedTempFile::new()?;
-
-        let sector_size = SectorSize(TEST_SECTOR_SIZE);
-        let config = PoRepConfig(sector_size, PoRepProofPartitions(2));
+        let config = PoRepConfig(SectorSize(sector_size.clone()), PoRepProofPartitions(2));
 
         let output = seal(
             config,
@@ -793,7 +795,7 @@ mod tests {
             &sealed_sector_file.path(),
             &[0; 31],
             &[0; 31],
-            &[unpadded_number_of_bytes_in_piece],
+            &[number_of_bytes_in_piece],
         )?;
 
         let piece_inclusion_proof_bytes: Vec<u8> = output.piece_inclusion_proofs[0].clone().into();
@@ -802,8 +804,8 @@ mod tests {
             &piece_inclusion_proof_bytes,
             &output.comm_d,
             &output.comm_ps[0],
-            unpadded_number_of_bytes_in_piece,
-            sector_size,
+            number_of_bytes_in_piece,
+            SectorSize(sector_size),
         )?;
 
         assert!(verified);

--- a/storage-proofs/src/piece_inclusion_proof.rs
+++ b/storage-proofs/src/piece_inclusion_proof.rs
@@ -310,18 +310,18 @@ impl<H: Hasher> PieceInclusionProof<H> {
         root: &[u8],
         proofs: &[PieceInclusionProof<H>],
         comm_ps: &[Fr32Ary],
-        piece_sizes: &[usize],
-        sector_size: usize,
+        piece_nodes: &[usize],
+        total_nodes: usize,
     ) -> Result<bool> {
         let root_domain = H::Domain::try_from_bytes(root)?;
 
-        Ok(proofs.iter().zip(comm_ps.iter().zip(piece_sizes)).all(
+        Ok(proofs.iter().zip(comm_ps.iter().zip(piece_nodes)).all(
             |(proof, (comm_p, piece_size))| {
                 proof.verify(
                     &root_domain,
                     &H::Domain::try_from_bytes(comm_p).unwrap(),
                     *piece_size,
-                    sector_size,
+                    total_nodes,
                 )
             },
         ))


### PR DESCRIPTION
Closes #750 .

@sidke or @laser may want to verify that my fix makes sense.

The branch provided in #750 (thanks @laser) took a really long time to run the test, so I first shrunk the sector size to something more minimal which still reproduced the issue. You may want to verify that before accepting this PR.

The problem seems to be that the sector size, in nodes, was being miscalculated. I think it was being treated as though unpadded, when actually padded. Or… something.

Feel free to fix this more robustly or just merge as-is. I didn't spend much time studying the logic behind what I changed once I eventually identified the source of the problem.