### PR TITLE
Feat/faster padding

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 storage-proofs = { version = "^0.4", path = "../storage-proofs" }
 logging-toolkit = { version = "^0.4", path = "../logging-toolkit" }
-bitvec = "0.11"
+bitvec = "0.5"
 chrono = "0.4"
 rand = "0.4"
 failure = "0.1"

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -34,6 +34,7 @@ bellperson = "0.2"
 paired = "0.15"
 fil-sapling-crypto = "0.1"
 clap = "2"
+bufstream = { git = "https://github.com/alexcrichton/bufstream" }
 
 [dependencies.reqwest]
 version = "0.9"

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -34,7 +34,6 @@ bellperson = "0.2"
 paired = "0.15"
 fil-sapling-crypto = "0.1"
 clap = "2"
-bufstream = { git = "https://github.com/alexcrichton/bufstream" }
 
 [dependencies.reqwest]
 version = "0.9"

--- a/filecoin-proofs/src/fr32.rs
+++ b/filecoin-proofs/src/fr32.rs
@@ -650,11 +650,16 @@ where
     let mut buffer = [0; CHUNK_SIZE];
     let mut written = 0;
 
-    while let Ok(bytes_read) = source.read(&mut buffer) {
+    use std::io::BufReader;
+    // ensure we use buffered readers and writers to minimize sys calls.
+    let mut source_buf = BufReader::new(source);
+    let mut target_buf = bufstream::BufStream::new(target);
+
+    while let Ok(bytes_read) = source_buf.read(&mut buffer) {
         if bytes_read == 0 {
             break;
         }
-        written += write_padded_aux(&FR32_PADDING_MAP, &buffer[..bytes_read], target)?;
+        written += write_padded_aux(&FR32_PADDING_MAP, &buffer[..bytes_read], &mut target_buf)?;
     }
 
     Ok(written)

--- a/filecoin-proofs/src/fr32.rs
+++ b/filecoin-proofs/src/fr32.rs
@@ -766,7 +766,7 @@ where
         // after the `data_bits_to_write` taken to complete the previous element.
         let mut read_pos = data_bits_to_write;
         // TODO: Rename `data_bits_to_write` (it's confusing outside of its context).
-        let mut shift_buf = Vec::new();
+        let mut shift_buf = Vec::with_capacity(source.len());
 
         while read_pos < source_bits {
             // TODO: Optimization: We can determine how many full data units are and
@@ -924,7 +924,7 @@ where
     // that may not be byte-aligned.
     let mut write_bit_offset = 0;
 
-    let mut recovered = Vec::new();
+    let mut recovered = Vec::with_capacity(source.len());
 
     // If there is no more data to read or no more space to write stop.
     while read_pos.bytes < source.len() && written_bits < max_write_size_bits {

--- a/filecoin-proofs/src/fr32.rs
+++ b/filecoin-proofs/src/fr32.rs
@@ -646,16 +646,14 @@ where
     let mut buffer = [0; CHUNK_SIZE];
     let mut written = 0;
 
-    use std::io::BufReader;
-    // ensure we use buffered readers and writers to minimize sys calls.
-    let mut source_buf = BufReader::new(source);
-    let mut target_buf = bufstream::BufStream::new(target);
+    // use a buffered reader for reads
+    let mut source_buf = std::io::BufReader::new(source);
 
     while let Ok(bytes_read) = source_buf.read(&mut buffer) {
         if bytes_read == 0 {
             break;
         }
-        written += write_padded_aux(&FR32_PADDING_MAP, &buffer[..bytes_read], &mut target_buf)?;
+        written += write_padded_aux(&FR32_PADDING_MAP, &buffer[..bytes_read], target)?;
     }
 
     Ok(written)
@@ -739,6 +737,9 @@ where
             .into_iter()
             .take(data_bits_to_write),
     );
+
+    // Use buffered writer for the following operations.
+    let mut target = std::io::BufWriter::new(target);
 
     target.write_all(last_bits.as_ref())?;
     // The `as_slice` conversion will byte-align the bit stream and implicitly

--- a/filecoin-proofs/src/fr32.rs
+++ b/filecoin-proofs/src/fr32.rs
@@ -1175,6 +1175,46 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_write_padded_chained_byte_source() {
+        let random_bytes: Vec<u8> = (0..127).map(|_| rand::random::<u8>()).collect();
+
+        // read 127 bytes from a non-chained source
+        let (n, output_x) = {
+            let mut input_x = Cursor::new(random_bytes.clone());
+            let mut output_x = Cursor::new(Vec::new());
+
+            let n_x = write_padded(&mut input_x, &mut output_x).unwrap();
+            output_x.seek(SeekFrom::Start(0)).expect("could not seek");
+
+            let mut buf_x = Vec::new();
+            output_x.read_to_end(&mut buf_x).expect("could not seek");
+
+            (n_x, buf_x)
+        };
+
+        // read 127 bytes from a 32-byte buffer and then a 95-byte buffer
+        let (m, output_y) = {
+            let mut input_y =
+                Cursor::new(random_bytes.iter().take(32).cloned().collect::<Vec<u8>>()).chain(
+                    Cursor::new(random_bytes.iter().skip(32).cloned().collect::<Vec<u8>>()),
+                );
+
+            let mut output_y = Cursor::new(Vec::new());
+
+            let n_y = write_padded(&mut input_y, &mut output_y).unwrap();
+            output_y.seek(SeekFrom::Start(0)).expect("could not seek");
+
+            let mut buf_y = Vec::new();
+            output_y.read_to_end(&mut buf_y).expect("could not seek");
+
+            (n_y, buf_y)
+        };
+
+        assert_eq!(n, m, "should have written same number of bytes");
+        assert_eq!(output_x, output_y, "should have written same bytes")
+    }
+
     // `write_padded` for 256 bytes of 1s, splitting it in two calls of 127 bytes,
     // aligning the calls with the padded element boundaries, check padding.
     #[test]

--- a/filecoin-proofs/src/fr32.rs
+++ b/filecoin-proofs/src/fr32.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 use std::io::{self, Error, ErrorKind, Read, Seek, SeekFrom, Write};
 
-use bitvec::prelude::*;
+use bitvec::{BitVec, LittleEndian};
 
 /** PaddingMap represents a mapping between data and its padded equivalent.
 
@@ -739,7 +739,7 @@ where
             .take(data_bits_to_write),
     );
 
-    target.write_all(last_bits.as_slice())?;
+    target.write_all(last_bits.as_ref())?;
     // The `as_slice` conversion will byte-align the bit stream and implicitly
     // add the padding bits (that by definition are the bits necessary to reach the byte
     // boundary).
@@ -1034,7 +1034,7 @@ mod tests {
             let shifted_bv: BitVecLEu8 = bv >> new_offset;
 
             assert_eq!(
-                shifted_bv.as_slice(),
+                shifted_bv.as_ref(),
                 &extract_bits_and_shift(&data, pos, num_bits, new_offset)[..],
             );
         }
@@ -1061,7 +1061,7 @@ mod tests {
                 }
                 // We use the opposite shift notation (see `shift_bits`).
 
-                assert_eq!(bv.as_slice(), shifted_bits.as_slice());
+                assert_eq!(bv.as_ref(), shifted_bits.as_slice());
             }
         }
     }
@@ -1092,7 +1092,7 @@ mod tests {
             }
         }
 
-        padded_data.into()
+        padded_data.into_boxed_slice()
     }
 
     // `write_padded` for 151 bytes of 1s, check padding.


### PR DESCRIPTION
Closes #749 
Closes #752

- Includes #752 and test from @laser for measuring. 
- Reduces allocation and reads/writes to make the fastest padding/unpadding known as of today

Numbers on my machine


```
# 256MB Sector
29ns START generate 266338304B vector of random data
4.585972165s FINISH generate 266338304B vector of random data
4.585988887s START write_padded 266338304B vector of random data
5.403359483s FINISH write_padded 266338304B vector of random data (wrote 266338304B)

# 1GB Sector
23ns START generate 1065353216B vector of random data
18.549253293s FINISH generate 1065353216B vector of random data
18.550249933s START write_padded 1065353216B vector of random data
21.955183029s FINISH write_padded 1065353216B vector of random data (wrote 1065353216B)
```


Bench preprocessing

```
preprocessing/write_padded/128
                        time:   [189.22 us 193.37 us 194.41 us]
                        thrpt:  [642.97 KiB/s 646.43 KiB/s 660.61 KiB/s]
preprocessing/write_padded/256
                        time:   [188.59 us 192.18 us 193.08 us]
                        thrpt:  [1.2644 MiB/s 1.2703 MiB/s 1.2946 MiB/s]
preprocessing/write_padded/512
                        time:   [194.53 us 195.55 us 195.80 us]
                        thrpt:  [2.4938 MiB/s 2.4970 MiB/s 2.5100 MiB/s]
Benchmarking preprocessing/write_padded/256000: Collecting 2 samples in estimated 5.0008 s (3504 iteration                                                                                                          preprocessing/write_padded/256000
                        time:   [1.1577 ms 1.1893 ms 1.1973 ms]
                        thrpt:  [203.92 MiB/s 205.27 MiB/s 210.89 MiB/s]
Benchmarking preprocessing/write_padded/512000: Collecting 2 samples in estimated 5.0014 s (2382 iteration                                                                                                          preprocessing/write_padded/512000
                        time:   [1.8624 ms 1.8789 ms 1.9449 ms]
                        thrpt:  [251.05 MiB/s 259.87 MiB/s 262.17 MiB/s]
Benchmarking preprocessing/write_padded/1024000: Collecting 2 samples in estimated 5.0095 s (1269 iteratio                                                                                                          preprocessing/write_padded/1024000
                        time:   [3.3558 ms 3.3577 ms 3.3655 ms]
                        thrpt:  [290.17 MiB/s 290.84 MiB/s 291.01 MiB/s]
Benchmarking preprocessing/write_padded/2048000: Collecting 2 samples in estimated 5.0250 s (600 iteration                                                                                                          preprocessing/write_padded/2048000
                        time:   [6.7113 ms 6.8058 ms 7.1842 ms]
                        thrpt:  [271.87 MiB/s 286.98 MiB/s 291.02 MiB/s]
Benchmarking preprocessing/write_padded-memory/128: Collecting 2 samples in estimated 5.0000 s (964k itera                                                                                                          preprocessing/write_padded-memory/128
                        time:   [5.2110 us 5.2945 us 5.6285 us]
                        thrpt:  [21.688 MiB/s 23.056 MiB/s 23.426 MiB/s]
Benchmarking preprocessing/write_padded-memory/256: Collecting 2 samples in estimated 5.0000 s (946k itera                                                                                                          preprocessing/write_padded-memory/256
                        time:   [5.4245 us 5.4285 us 5.4445 us]
                        thrpt:  [44.842 MiB/s 44.974 MiB/s 45.007 MiB/s]
Benchmarking preprocessing/write_padded-memory/512: Collecting 2 samples in estimated 5.0000 s (744k itera                                                                                                          preprocessing/write_padded-memory/512
                        time:   [6.5579 us 6.5596 us 6.5666 us]
                        thrpt:  [74.358 MiB/s 74.437 MiB/s 74.457 MiB/s]
Benchmarking preprocessing/write_padded-memory/256000: Collecting 2 samples in estimated 5.0023 s (5745 it                                                                                                          preprocessing/write_padded-memory/256000
                        time:   [840.48 us 841.68 us 846.48 us]
                        thrpt:  [288.42 MiB/s 290.06 MiB/s 290.48 MiB/s]
Benchmarking preprocessing/write_padded-memory/512000: Collecting 2 samples in estimated 5.0048 s (2733 it                                                                                                          preprocessing/write_padded-memory/512000
                        time:   [1.7401 ms 1.9015 ms 1.9419 ms]
                        thrpt:  [251.45 MiB/s 256.79 MiB/s 280.61 MiB/s]
Benchmarking preprocessing/write_padded-memory/1024000: Collecting 2 samples in estimated 5.0131 s (1128 i                                                                                                          preprocessing/write_padded-memory/1024000
                        time:   [3.4878 ms 3.5598 ms 3.5778 ms]
                        thrpt:  [272.95 MiB/s 274.33 MiB/s 280.00 MiB/s]
Benchmarking preprocessing/write_padded-memory/2048000: Collecting 2 samples in estimated 5.0143 s (603 it                                                                                                          preprocessing/write_padded-memory/2048000
                        time:   [6.5591 ms 6.6577 ms 6.6824 ms]
                        thrpt:  [292.28 MiB/s 293.36 MiB/s 297.77 MiB/s]
Benchmarking preprocessing/write_padded + unpadded/128: Collecting 2 samples in estimated 5.0010 s (14k it                                                                                                          preprocessing/write_padded + unpadded/128
                        time:   [364.28 us 373.77 us 376.14 us]
                        thrpt:  [332.32 KiB/s 334.43 KiB/s 343.14 KiB/s]
Benchmarking preprocessing/write_padded + unpadded/256: Collecting 2 samples in estimated 5.0010 s (11k it                                                                                                          preprocessing/write_padded + unpadded/256
                        time:   [386.78 us 394.51 us 396.44 us]
                        thrpt:  [630.61 KiB/s 633.70 KiB/s 646.36 KiB/s]
Benchmarking preprocessing/write_padded + unpadded/512: Collecting 2 samples in estimated 5.0010 s (13k it                                                                                                          preprocessing/write_padded + unpadded/512
                        time:   [384.77 us 407.40 us 413.06 us]
                        thrpt:  [1.1821 MiB/s 1.1985 MiB/s 1.2690 MiB/s]
Benchmarking preprocessing/write_padded + unpadded/256000: Collecting 2 samples in estimated 5.0044 s (159                                                                                                          preprocessing/write_padded + unpadded/256000
                        time:   [2.9917 ms 3.0590 ms 3.0759 ms]
                        thrpt:  [79.373 MiB/s 79.809 MiB/s 81.606 MiB/s]
Benchmarking preprocessing/write_padded + unpadded/512000: Collecting 2 samples in estimated 5.0027 s (819                                                                                                          preprocessing/write_padded + unpadded/512000
                        time:   [5.3832 ms 5.4202 ms 5.5681 ms]
                        thrpt:  [87.693 MiB/s 90.086 MiB/s 90.705 MiB/s]
Benchmarking preprocessing/write_padded + unpadded/1024000: Collecting 2 samples in estimated 5.0050 s (42                                                                                                          preprocessing/write_padded + unpadded/1024000
                        time:   [10.151 ms 10.309 ms 10.938 ms]
                        thrpt:  [89.284 MiB/s 94.732 MiB/s 96.200 MiB/s]
Benchmarking preprocessing/write_padded + unpadded/2048000: Collecting 2 samples in estimated 5.0047 s (18                                                                                                          preprocessing/write_padded + unpadded/2048000
                        time:   [22.940 ms 23.119 ms 23.164 ms]
                        thrpt:  [84.318 MiB/s 84.481 MiB/s 85.140 MiB/s]


```