### PR TITLE
Feat/761 json output from benchy

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -1,5 +1,5 @@
 #[macro_use]
-extern crate prometheus;
+extern crate serde;
 
 use clap::{value_t, App, Arg, SubCommand};
 
@@ -119,11 +119,6 @@ fn main() {
                         .long("taper-layers")
                         .help("number of layers to taper")
                         .takes_value(true)
-                )
-                .arg(
-                    Arg::with_name("push-prometheus")
-                        .long("push-prometheus")
-                        .help("When enabled pushes the collected stats to a prometheus pushgateway")
                 )).get_matches();
 
     match matches.subcommand() {
@@ -147,7 +142,6 @@ fn main() {
                         no_bench: m.is_present("no-bench"),
                         no_tmp: m.is_present("no-tmp"),
                         partitions: value_t!(m, "partitions", usize)?,
-                        push_prometheus: m.is_present("push-prometheus"),
                         size: value_t!(m, "size", usize)?,
                         sloth: value_t!(m, "sloth", usize)?,
                         taper: value_t!(m, "taper", f64)?,

--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -324,6 +324,7 @@ fn do_circuit_work<H: 'static + Hasher>(
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct Inputs {
     data_size: usize,
     m: usize,
@@ -336,6 +337,7 @@ struct Inputs {
 }
 
 #[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
 struct Outputs {
     avg_groth_verifying_ms: Option<u64>,
     circuit_num_constraints: Option<u64>,
@@ -350,6 +352,7 @@ struct Outputs {
 }
 
 #[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
 struct Report {
     inputs: Inputs,
     outputs: Outputs,

--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -233,7 +233,7 @@ fn do_circuit_work<H: 'static + Hasher>(
     pub_in: Option<<ZigZagDrgPoRep<H> as ProofScheme>::PublicInputs>,
     priv_in: Option<<ZigZagDrgPoRep<H> as ProofScheme>::PrivateInputs>,
     params: &Params,
-    mut report: &mut Report,
+    report: &mut Report,
 ) -> Result<Duration, failure::Error> {
     let mut proving_time = Duration::new(0, 0);
     let Params {


### PR DESCRIPTION
## Why does this PR exist?

We need to expose ZigZag benchy output in a machine-readable format.

## What's in this PR?

This PR dumps all the Prometheus stuff and instead collects benchy output to a struct which it JSON-serializes and writes to STDOUT.

### New Output

```
07:52 $ cargo build --release --all && ./target/release/benchy zigzag --size=1024 | jq '.'
   Compiling fil-proofs-tooling v0.5.0 (/Users/erinswenson-healey/dev/rust-proofs/fil-proofs-tooling)
    Finished release [optimized] target(s) in 25.36s
{
  "inputs": {
    "dataSize": 1048576,
    "m": 5,
    "expansionDegree": 8,
    "slothIter": 0,
    "partitions": 1,
    "hasher": "pedersen",
    "samples": 5,
    "layers": 10
  },
  "outputs": {
    "avgGrothVerifyingMs": null,
    "circuitNumConstraints": null,
    "circuitNumInputs": null,
    "extracting": null,
    "replicationTimeMs": 5172,
    "replicationTimeNsPerByte": 4932,
    "totalProvingMs": 0,
    "vanillaProvingTimeUs": 425,
    "vanillaVerificationTimeUs": 102918,
    "verifyAvgMs": 102
  }
}
```

### Old Output

```shell
17:52 $ cargo build --release --all && ./target/release/benchy zigzag --size=1024
   Compiling fil-proofs-tooling v0.5.0 (/Users/erinswenson-healey/dev/rust-proofs/fil-proofs-tooling)
    Finished release [optimized] target(s) in 28.54s
zigzag: Params {
    samples: 5,
    data_size: 1048576,
    m: 5,
    expansion_degree: 8,
    sloth_iter: 0,
    layer_challenges: Fixed {
        layers: 10,
        count: 1,
    },
    partitions: 1,
    circuit: false,
    groth: false,
    bench: false,
    extract: false,
    use_tmp: true,
    dump_proofs: false,
    bench_only: false,
    hasher: "pedersen",
}
Replication: total time: 4.9060s
Replication: time per byte: 4.6780us
Vanilla proving: 532.0440us
Avg verifying: 0.1042s
Total proving: 0.0000s
# HELP circuit_num_constraints Number of constraints of the circuit
# TYPE circuit_num_constraints gauge
circuit_num_constraints{data_size_bytes="1048576",expansion_degree="8",hasher="pedersen",layers="10",m="5",partitions="1",samples="5",sloth_iter="0"} 0
# HELP circuit_num_inputs Number of inputs to the circuit
# TYPE circuit_num_inputs gauge
circuit_num_inputs{data_size_bytes="1048576",expansion_degree="8",hasher="pedersen",layers="10",m="5",partitions="1",samples="5",sloth_iter="0"} 0
# HELP replication_time_ms Total replication timea
# TYPE replication_time_ms gauge
replication_time_ms{data_size_bytes="1048576",expansion_degree="8",hasher="pedersen",layers="10",m="5",partitions="1",samples="5",sloth_iter="0"} 4906
# HELP replication_time_ns_per_byte Replication time per byte
# TYPE replication_time_ns_per_byte gauge
replication_time_ns_per_byte{data_size_bytes="1048576",expansion_degree="8",hasher="pedersen",layers="10",m="5",partitions="1",samples="5",sloth_iter="0"} 4678
# HELP vanilla_proving_time_us Vanilla proving time
# TYPE vanilla_proving_time_us gauge
vanilla_proving_time_us{data_size_bytes="1048576",expansion_degree="8",hasher="pedersen",layers="10",m="5",partitions="1",samples="5",sloth_iter="0"} 532
# HELP vanilla_verification_time_us Vanilla verification time
# TYPE vanilla_verification_time_us gauge
vanilla_verification_time_us{data_size_bytes="1048576",expansion_degree="8",hasher="pedersen",layers="10",m="5",partitions="1",samples="5",sloth_iter="0"} 99963

```