### PR TITLE
feat/672 wall clock and cpu time

### DIFF
--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -32,3 +32,4 @@ paired = "0.15.0"
 rand = "0.4"
 storage-proofs = { path = "../storage-proofs"}
 tempfile = "3.0.8"
+cpu-time = "0.1.0"

--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -253,18 +253,11 @@ fn do_circuit_work<H: 'static + Hasher>(
     };
 
     if *bench || *circuit {
-        println!("generating blank metric circuit");
         let mut cs = MetricCS::<Bls12>::new();
         ZigZagCompound::blank_circuit(&pp, &engine_params).synthesize(&mut cs)?;
 
-        println!("circuit_num_inputs: {}", cs.num_inputs());
-        println!("circuit_num_constraints: {}", cs.num_constraints());
-
         report.outputs.circuit_num_inputs = Some(cs.num_inputs() as u64);
         report.outputs.circuit_num_constraints = Some(cs.num_constraints() as u64);
-        if *circuit {
-            println!("{}", cs.pretty_print());
-        }
     }
 
     if *groth {


### PR DESCRIPTION
This changeset adds CPU time measurements to the benchy output-report.

```shell
18:25 $ ./target/release/benchy zigzag --extract --groth --circuit --size=1024 | jq '.'
{
  "inputs": {
    "dataSize": 1048576,
    "m": 5,
    "expansionDegree": 8,
    "slothIter": 0,
    "partitions": 1,
    "hasher": "pedersen",
    "samples": 5,
    "layers": 10
  },
  "outputs": {
    "avgGrothVerifyingWallTimeMs": 12,
    "avgGrothVerifyingCpuTimeMs": 12,
    "circuitNumConstraints": 4634744,
    "circuitNumInputs": 164,
    "extractingCpuTimeMs": 1972,
    "extractingWallTimeMs": 1977,
    "replicationWallTimeMs": 4367,
    "replicationCpuTimeMs": 32513,
    "replicationWallTimeNsPerByte": 4164,
    "replicationCpuTimeNsPerByte": 31006,
    "totalProvingCpuTimeMs": 528659,
    "totalProvingWallTimeMs": 76505,
    "vanillaProvingCpuTimeUs": 341,
    "vanillaProvingWallTimeUs": 341,
    "vanillaVerificationWallTimeUs": 94669,
    "vanillaVerificationCpuTimeUs": 94598,
    "verifyingWallTimeAvg": 98,
    "verifyingCpuTimeAvg": 98
  }
}
```