### PR TITLE
fix(examples): assert not equal after decoding

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -218,8 +218,8 @@ where
             let start = Instant::now();
             let decoded_data = ZigZagDrgPoRep::<H>::extract_all(&pp, &replica_id, &data)?;
             let extracting = start.elapsed();
-            assert_eq!(&(*data), decoded_data.as_slice());
             report.outputs.extracting = Some(extracting.as_millis() as u64);
+            assert_ne!(&(*data), decoded_data.as_slice());
         }
     }
 

--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -382,7 +382,7 @@ fn do_the_work<H: 'static>(
             let extracting = start.elapsed();
             info!("extracting_time: {:?}", extracting);
 
-            assert_eq!(&(*data), decoded_data.as_slice());
+            assert_ne!(&(*data), decoded_data.as_slice());
         }
     }
 }


### PR DESCRIPTION
The comparison is between the decoded and the encoded data, so the check should be not equal. 


Closes #768