### PR TITLE
Feat/761 total cpu time and total merkle tree time

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -142,9 +142,6 @@ where
             ..
         } = &params;
 
-        let start_cpu_time = ProcessTime::now();
-        let start_wall_time = Instant::now();
-
         let mut total_proving_wall_time = Duration::new(0, 0);
         let mut total_proving_cpu_time = Duration::new(0, 0);
 
@@ -215,24 +212,6 @@ where
                 Some(avg_duration(replication_wall_time, data_size).as_nanos() as u64);
             report.outputs.replication_cpu_time_ns_per_byte =
                 Some(avg_duration(replication_cpu_time, data_size).as_nanos() as u64);
-
-            let up_to_vanilla_proof_cpu_time = start_cpu_time.elapsed();
-            let up_to_vanilla_proof_wall_time = start_wall_time.elapsed();
-
-            // report start-time to beginning of vanilla proof generation
-            report.outputs.report_start_to_vanilla_proof_gen_cpu_time_ms =
-                Some(up_to_vanilla_proof_cpu_time.as_millis() as u64);
-            report
-                .outputs
-                .report_start_to_vanilla_proof_gen_wall_time_ms =
-                Some(up_to_vanilla_proof_wall_time.as_millis() as u64);
-
-            // report start-time to beginning of vanilla proof generation minus
-            // replication time
-            report.outputs.total_merkle_tree_cpu_time_ms =
-                Some((up_to_vanilla_proof_cpu_time - replication_cpu_time).as_millis() as u64);
-            report.outputs.total_merkle_tree_wall_time_ms =
-                Some((up_to_vanilla_proof_wall_time - replication_wall_time).as_millis() as u64);
 
             let FuncMeasurement {
                 cpu_time: vanilla_proving_cpu_time,
@@ -479,10 +458,6 @@ struct Outputs {
     total_report_wall_time_ms: u64,
     total_proving_cpu_time_ms: Option<u64>,
     total_proving_wall_time_ms: Option<u64>,
-    report_start_to_vanilla_proof_gen_cpu_time_ms: Option<u64>,
-    report_start_to_vanilla_proof_gen_wall_time_ms: Option<u64>,
-    total_merkle_tree_cpu_time_ms: Option<u64>,
-    total_merkle_tree_wall_time_ms: Option<u64>,
     vanilla_proving_cpu_time_us: Option<u64>,
     vanilla_proving_wall_time_us: Option<u64>,
     vanilla_verification_wall_time_us: Option<u64>,

--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -229,10 +229,10 @@ where
 
             // report start-time to beginning of vanilla proof generation minus
             // replication time
-            report.outputs.total_merkle_tree_cpu_time_ns =
-                Some((up_to_vanilla_proof_cpu_time - replication_cpu_time).as_nanos() as u64);
-            report.outputs.total_merkle_tree_wall_time_ns =
-                Some((up_to_vanilla_proof_wall_time - replication_wall_time).as_nanos() as u64);
+            report.outputs.total_merkle_tree_cpu_time_ms =
+                Some((up_to_vanilla_proof_cpu_time - replication_cpu_time).as_millis() as u64);
+            report.outputs.total_merkle_tree_wall_time_ms =
+                Some((up_to_vanilla_proof_wall_time - replication_wall_time).as_millis() as u64);
 
             let FuncMeasurement {
                 cpu_time: vanilla_proving_cpu_time,
@@ -325,8 +325,11 @@ where
             }
         }
 
-        report.outputs.total_proving_wall_time_ms = total_proving_wall_time.as_millis() as u64;
-        report.outputs.total_proving_cpu_time_ms = total_proving_cpu_time.as_millis() as u64;
+        // total proving time is the sum of "the circuit work" and vanilla
+        // proving time
+        report.outputs.total_proving_wall_time_ms =
+            Some(total_proving_wall_time.as_millis() as u64);
+        report.outputs.total_proving_cpu_time_ms = Some(total_proving_cpu_time.as_millis() as u64);
 
         Ok(report)
     })?;
@@ -474,12 +477,12 @@ struct Outputs {
     replication_cpu_time_ns_per_byte: Option<u64>,
     total_report_cpu_time_ms: u64,
     total_report_wall_time_ms: u64,
-    total_proving_cpu_time_ms: u64,
-    total_proving_wall_time_ms: u64,
+    total_proving_cpu_time_ms: Option<u64>,
+    total_proving_wall_time_ms: Option<u64>,
     report_start_to_vanilla_proof_gen_cpu_time_ms: Option<u64>,
     report_start_to_vanilla_proof_gen_wall_time_ms: Option<u64>,
-    total_merkle_tree_cpu_time_ns: Option<u64>,
-    total_merkle_tree_wall_time_ns: Option<u64>,
+    total_merkle_tree_cpu_time_ms: Option<u64>,
+    total_merkle_tree_wall_time_ms: Option<u64>,
     vanilla_proving_cpu_time_us: Option<u64>,
     vanilla_proving_wall_time_us: Option<u64>,
     vanilla_verification_wall_time_us: Option<u64>,


### PR DESCRIPTION
## What's in this PR?

This PR adds "total report time" (the whole benchmark) and "merkle tree time" to the output.

```
$ ./fil-proofs-tooling/scripts/benchy.sh zigzag --size=1024 | jq '.'

{
  "inputs": {
    "dataSize": 1048576,
    "m": 5,
    "expansionDegree": 8,
    "slothIter": 0,
    "partitions": 1,
    "hasher": "pedersen",
    "samples": 5,
    "layers": 10
  },
  "outputs": {
    "avgGrothVerifyingCpuTimeMs": null,
    "avgGrothVerifyingWallTimeMs": null,
    "circuitNumConstraints": null,
    "circuitNumInputs": null,
    "extractingCpuTimeMs": null,
    "extractingWallTimeMs": null,
    "replicationWallTimeMs": 5393,
    "replicationCpuTimeMs": 36954,
    "replicationWallTimeNsPerByte": 5143,
    "replicationCpuTimeNsPerByte": 35242,
    "totalReportCpuTimeMs": 37534,
    "totalReportWallTimeMs": 5983,
    "totalProvingCpuTimeMs": 0,
    "totalProvingWallTimeMs": 0,
    "reportStartToVanillaProofGenCpuTimeMs": 36955,
    "reportStartToVanillaProofGenWallTimeMs": 5394,
    "totalMerkleTreeCpuTimeMs": 0,
    "totalMerkleTreeWallTimeMs": 0,
    "vanillaProvingCpuTimeUs": 478,
    "vanillaProvingWallTimeUs": 503,
    "vanillaVerificationWallTimeUs": 117209,
    "vanillaVerificationCpuTimeUs": 115014,
    "verifyingWallTimeAvgMs": 117,
    "verifyingCpuTimeAvgMs": 115,
    "maxResidentSetSizeKb": 45236
  }
}
```