### PR TITLE
Hybrid Merkle Trees and Hybrid Domains

### DIFF
--- a/filecoin-proofs/examples/drgporep.rs
+++ b/filecoin-proofs/examples/drgporep.rs
@@ -10,6 +10,8 @@ use storage_proofs::example_helper::Example;
 use storage_proofs::hasher::PedersenHasher;
 use storage_proofs::test_helper::fake_drgpoprep_proof;
 
+const BETA_HEIGHT: usize = 0;
+
 struct DrgPoRepExample<'a, E: JubjubEngine> {
     params: &'a E::Params,
     replica_nodes: Vec<Option<E::Fr>>,
@@ -26,7 +28,7 @@ struct DrgPoRepExample<'a, E: JubjubEngine> {
 
 impl<'a> Circuit<Bls12> for DrgPoRepExample<'a, Bls12> {
     fn synthesize<CS: ConstraintSystem<Bls12>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
-        circuit::drgporep::DrgPoRepCircuit::<_, PedersenHasher>::synthesize(
+        circuit::drgporep::DrgPoRepCircuit::<_, PedersenHasher, PedersenHasher>::synthesize(
             cs.namespace(|| "drgporep"),
             self.params,
             self.replica_nodes,
@@ -39,6 +41,8 @@ impl<'a> Circuit<Bls12> for DrgPoRepExample<'a, Bls12> {
             self.data_root,
             self.replica_id,
             self.m,
+            BETA_HEIGHT,
+            usize::max_value(),
             false,
         )
     }

--- a/filecoin-proofs/src/types/porep_config.rs
+++ b/filecoin-proofs/src/types/porep_config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use paired::bls12_381::Bls12;
 use storage_proofs::circuit::zigzag::{ZigZagCircuit, ZigZagCompound};
-use storage_proofs::drgraph::DefaultTreeHasher;
+use storage_proofs::drgraph::{DefaultAlphaHasher, DefaultBetaHasher};
 use storage_proofs::parameter_cache::{self, CacheableParameters};
 
 use crate::types::*;
@@ -39,9 +39,11 @@ impl PoRepConfig {
     pub fn get_cache_identifier(&self) -> String {
         let params = crate::parameters::public_params(self.0.into(), self.1.into());
 
-        <ZigZagCompound as CacheableParameters<Bls12, ZigZagCircuit<_, DefaultTreeHasher>, _>>::cache_identifier(
-            &params,
-        )
+        <ZigZagCompound as CacheableParameters<
+            Bls12,
+            ZigZagCircuit<_, DefaultAlphaHasher, DefaultBetaHasher>,
+            _,
+        >>::cache_identifier(&params)
     }
 
     pub fn get_cache_metadata_path(&self) -> PathBuf {

--- a/storage-proofs/benches/hybrid_merkle.rs
+++ b/storage-proofs/benches/hybrid_merkle.rs
@@ -1,0 +1,87 @@
+#[macro_use]
+extern crate criterion;
+
+use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use rand::{thread_rng, Rng};
+use storage_proofs::drgraph::{new_seed, Graph};
+use storage_proofs::hasher::blake2s::Blake2sHasher;
+use storage_proofs::hasher::pedersen::PedersenHasher;
+use storage_proofs::util::NODE_SIZE;
+use storage_proofs::zigzag_graph::{ZigZag, ZigZagBucketGraph, DEFAULT_EXPANSION_DEGREE};
+
+const BASE_DEGREE: usize = 8;
+
+fn hybrid_merkle_benchmark(c: &mut Criterion) {
+    #[cfg(feature = "big-sector-sizes-bench")]
+    let params = vec![128, 1024, 1048576];
+    #[cfg(not(feature = "big-sector-sizes-bench"))]
+    let params = vec![128, 1024];
+
+    c.bench(
+        "hybrid_merkle",
+        ParameterizedBenchmark::new(
+            "blake2s_no_beta",
+            move |b, n_nodes| {
+                let mut rng = thread_rng();
+                let n_bytes = NODE_SIZE * n_nodes;
+                let data: Vec<u8> = (0..n_bytes).map(|_| rng.gen()).collect();
+                let graph = ZigZagBucketGraph::<Blake2sHasher, Blake2sHasher>::new_zigzag(
+                    *n_nodes,
+                    BASE_DEGREE,
+                    DEFAULT_EXPANSION_DEGREE,
+                    new_seed(),
+                );
+
+                // Set beta height to zero.
+                b.iter(|| black_box(graph.hybrid_merkle_tree(&data, 0).unwrap()))
+            },
+            params,
+        )
+        .with_function("pedersen_no_beta", move |b, n_nodes| {
+            let mut rng = thread_rng();
+            let n_bytes = NODE_SIZE * n_nodes;
+            let data: Vec<u8> = (0..n_bytes).map(|_| rng.gen()).collect();
+            let graph = ZigZagBucketGraph::<PedersenHasher, PedersenHasher>::new_zigzag(
+                *n_nodes,
+                BASE_DEGREE,
+                DEFAULT_EXPANSION_DEGREE,
+                new_seed(),
+            );
+
+            // Set beta height to zero.
+            b.iter(|| black_box(graph.hybrid_merkle_tree(&data, 0).unwrap()))
+        })
+        .with_function("pedersen_blake2s_no_beta", move |b, n_nodes| {
+            let mut rng = thread_rng();
+            let n_bytes = NODE_SIZE * n_nodes;
+            let data: Vec<u8> = (0..n_bytes).map(|_| rng.gen()).collect();
+            let graph = ZigZagBucketGraph::<PedersenHasher, Blake2sHasher>::new_zigzag(
+                *n_nodes,
+                BASE_DEGREE,
+                DEFAULT_EXPANSION_DEGREE,
+                new_seed(),
+            );
+
+            // Set beta height to zero.
+            b.iter(|| black_box(graph.hybrid_merkle_tree(&data, 0).unwrap()))
+        })
+        .with_function("pedersen_blake2s_beta_height_1", move |b, n_nodes| {
+            let mut rng = thread_rng();
+            let n_bytes = NODE_SIZE * n_nodes;
+            let data: Vec<u8> = (0..n_bytes).map(|_| rng.gen()).collect();
+            let graph = ZigZagBucketGraph::<PedersenHasher, Blake2sHasher>::new_zigzag(
+                *n_nodes,
+                BASE_DEGREE,
+                DEFAULT_EXPANSION_DEGREE,
+                new_seed(),
+            );
+
+            // Set beta height to zero.
+            b.iter(|| black_box(graph.hybrid_merkle_tree(&data, 1).unwrap()))
+        })
+        .sample_size(20),
+    );
+}
+
+criterion_group!(benches, hybrid_merkle_benchmark);
+criterion_main!(benches);

--- a/storage-proofs/benches/merkle.rs
+++ b/storage-proofs/benches/merkle.rs
@@ -21,7 +21,7 @@ fn merkle_benchmark(c: &mut Criterion) {
             move |b, nodes| {
                 let mut rng = thread_rng();
                 let data: Vec<u8> = (0..32 * *nodes).map(|_| rng.gen()).collect();
-                let graph = ZigZagBucketGraph::<Blake2sHasher>::new_zigzag(
+                let graph = ZigZagBucketGraph::<Blake2sHasher, Blake2sHasher>::new_zigzag(
                     *nodes,                   // #nodes
                     8,                        // degree
                     DEFAULT_EXPANSION_DEGREE, // expansion degree,
@@ -35,7 +35,7 @@ fn merkle_benchmark(c: &mut Criterion) {
         .with_function("pedersen", move |b, nodes| {
             let mut rng = thread_rng();
             let data: Vec<u8> = (0..32 * *nodes).map(|_| rng.gen()).collect();
-            let graph = ZigZagBucketGraph::<PedersenHasher>::new_zigzag(
+            let graph = ZigZagBucketGraph::<PedersenHasher, PedersenHasher>::new_zigzag(
                 *nodes,                   // #nodes
                 8,                        // degree
                 DEFAULT_EXPANSION_DEGREE, // expansion degree,

--- a/storage-proofs/benches/parents.rs
+++ b/storage-proofs/benches/parents.rs
@@ -39,12 +39,12 @@ fn stop_profile() {
 #[inline(always)]
 fn stop_profile() {}
 
-fn pregenerate_graph<H: Hasher>(size: usize) -> ZigZagBucketGraph<H> {
+fn pregenerate_graph<H: Hasher>(size: usize) -> ZigZagBucketGraph<H, H> {
     let seed = [1, 2, 3, 4, 5, 6, 7];
-    ZigZagBucketGraph::<H>::new_zigzag(size, 5, 8, seed)
+    ZigZagBucketGraph::<H, H>::new_zigzag(size, 5, 8, seed)
 }
 
-fn parents_loop<H: Hasher, G: Graph<H>>(graph: &G, parents: &mut [usize]) {
+fn parents_loop<H: Hasher, G: Graph<H, H>>(graph: &G, parents: &mut [usize]) {
     (0..graph.size())
         .map(|node| graph.parents(node, parents))
         .collect()

--- a/storage-proofs/src/challenge_derivation.rs
+++ b/storage-proofs/src/challenge_derivation.rs
@@ -3,17 +3,22 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use num_bigint::BigUint;
 use num_traits::cast::ToPrimitive;
 
+use crate::hasher::hybrid::HybridDomain;
 use crate::hasher::Domain;
 use crate::layered_drgporep::LayerChallenges;
 
-pub fn derive_challenges<D: Domain>(
+pub fn derive_challenges<AD, BD>(
     challenges: &LayerChallenges,
     layer: u8,
     leaves: usize,
-    replica_id: &D,
-    commitment: &D,
+    replica_id: &HybridDomain<AD, BD>,
+    commitment: &HybridDomain<AD, BD>,
     k: u8,
-) -> Vec<usize> {
+) -> Vec<usize>
+where
+    AD: Domain,
+    BD: Domain,
+{
     let n = challenges.challenges_for_layer(layer as usize);
     (0..n)
         .map(|i| {
@@ -40,6 +45,7 @@ pub fn derive_challenges<D: Domain>(
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::hasher::hybrid::HybridDomain;
     use crate::hasher::pedersen::PedersenDomain;
     use rand::{thread_rng, Rng};
     use std::collections::HashMap;
@@ -52,8 +58,10 @@ mod test {
         let challenges = LayerChallenges::new_fixed(layers, n);
         let leaves = 1 << 30;
         let mut rng = thread_rng();
-        let replica_id: PedersenDomain = rng.gen();
-        let commitment: PedersenDomain = rng.gen();
+        let replica_id: HybridDomain<PedersenDomain, PedersenDomain> =
+            HybridDomain::Alpha(rng.gen());
+        let commitment: HybridDomain<PedersenDomain, PedersenDomain> =
+            HybridDomain::Alpha(rng.gen());
         let partitions = 5;
         let total_challenges = partitions * n;
 
@@ -94,8 +102,10 @@ mod test {
         let n = 40;
         let leaves = 1 << 30;
         let mut rng = thread_rng();
-        let replica_id: PedersenDomain = rng.gen();
-        let commitment: PedersenDomain = rng.gen();
+        let replica_id: HybridDomain<PedersenDomain, PedersenDomain> =
+            HybridDomain::Alpha(rng.gen());
+        let commitment: HybridDomain<PedersenDomain, PedersenDomain> =
+            HybridDomain::Alpha(rng.gen());
         let partitions = 5;
         let layers = 100;
         let total_challenges = n * partitions;

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -1,7 +1,9 @@
 use std::marker::PhantomData;
 
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
-use fil_sapling_crypto::circuit::{boolean, multipack, num};
+use fil_sapling_crypto::circuit::boolean::{AllocatedBit, Boolean};
+use fil_sapling_crypto::circuit::multipack;
+use fil_sapling_crypto::circuit::num::AllocatedNum;
 use fil_sapling_crypto::jubjub::{JubjubBls12, JubjubEngine};
 use paired::bls12_381::{Bls12, Fr};
 
@@ -10,7 +12,7 @@ use crate::circuit::variables::Root;
 use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::drgraph::graph_height;
 use crate::hasher::{HashFunction, Hasher};
-use crate::merklepor::MerklePoR;
+use crate::hybrid_merklepor::HybridMerklePoR;
 use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::proof::ProofScheme;
 
@@ -23,21 +25,38 @@ use crate::proof::ProofScheme;
 /// * `auth_path` - The authentication path of the leaf in the tree.
 /// * `root` - The merkle root of the tree.
 ///
-pub struct PoRCircuit<'a, E: JubjubEngine, H: Hasher> {
+pub struct PoRCircuit<'a, E, AH, BH>
+where
+    E: JubjubEngine,
+    AH: Hasher,
+    BH: Hasher,
+{
     params: &'a E::Params,
     value: Option<E::Fr>,
     auth_path: Vec<Option<(E::Fr, bool)>>,
     root: Root<E>,
+    beta_height: usize,
     private: bool,
-    _h: PhantomData<H>,
+    _ah: PhantomData<AH>,
+    _bh: PhantomData<BH>,
 }
 
-impl<'a, E: JubjubEngine, H: Hasher> CircuitComponent for PoRCircuit<'a, E, H> {
+impl<'a, E, AH, BH> CircuitComponent for PoRCircuit<'a, E, AH, BH>
+where
+    E: JubjubEngine,
+    AH: Hasher,
+    BH: Hasher,
+{
     type ComponentPrivateInputs = Option<Root<E>>;
 }
 
-pub struct PoRCompound<H: Hasher> {
-    _h: PhantomData<H>,
+pub struct PoRCompound<AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    _ah: PhantomData<AH>,
+    _bh: PhantomData<BH>,
 }
 
 pub fn challenge_into_auth_path_bits(challenge: usize, leaves: usize) -> Vec<bool> {
@@ -51,61 +70,75 @@ pub fn challenge_into_auth_path_bits(challenge: usize, leaves: usize) -> Vec<boo
     bits
 }
 
-impl<E: JubjubEngine, C: Circuit<E>, P: ParameterSetMetadata, H: Hasher>
-    CacheableParameters<E, C, P> for PoRCompound<H>
+impl<E, C, P, AH, BH> CacheableParameters<E, C, P> for PoRCompound<AH, BH>
+where
+    E: JubjubEngine,
+    C: Circuit<E>,
+    P: ParameterSetMetadata,
+    AH: Hasher,
+    BH: Hasher,
 {
     fn cache_prefix() -> String {
-        format!("proof-of-retrievability-{}", H::name())
+        format!("proof-of-retrievability-{}-{}", AH::name(), BH::name())
     }
 }
 
-// can only implment for Bls12 because merklepor is not generic over the engine.
-impl<'a, H> CompoundProof<'a, Bls12, MerklePoR<H>, PoRCircuit<'a, Bls12, H>> for PoRCompound<H>
+// Can only implement for `Bls12` because `HybridMerklePoR` is not generic over the engine.
+impl<'a, AH, BH> CompoundProof<'a, Bls12, HybridMerklePoR<AH, BH>, PoRCircuit<'a, Bls12, AH, BH>>
+    for PoRCompound<AH, BH>
 where
-    H: 'a + Hasher,
+    AH: 'static + Hasher,
+    BH: 'static + Hasher,
 {
     fn circuit<'b>(
-        public_inputs: &<MerklePoR<H> as ProofScheme<'a>>::PublicInputs,
-        _component_private_inputs: <PoRCircuit<'a, Bls12, H> as CircuitComponent>::ComponentPrivateInputs,
-        proof: &'b <MerklePoR<H> as ProofScheme<'a>>::Proof,
-        public_params: &'b <MerklePoR<H> as ProofScheme<'a>>::PublicParams,
+        public_inputs: &<HybridMerklePoR<AH, BH> as ProofScheme<'a>>::PublicInputs,
+        _component_private_inputs: <PoRCircuit<'a, Bls12, AH, BH> as CircuitComponent>::ComponentPrivateInputs,
+        proof: &'b <HybridMerklePoR<AH, BH> as ProofScheme<'a>>::Proof,
+        public_params: &'b <HybridMerklePoR<AH, BH> as ProofScheme<'a>>::PublicParams,
         engine_params: &'a JubjubBls12,
-    ) -> PoRCircuit<'a, Bls12, H> {
+    ) -> PoRCircuit<'a, Bls12, AH, BH> {
         let (root, private) = match (*public_inputs).commitment {
-            None => (Root::Val(Some(proof.proof.root.into())), true),
+            None => {
+                let root: Fr = (*proof.proof.root()).into();
+                (Root::Val(Some(root)), true)
+            }
             Some(commitment) => (Root::Val(Some(commitment.into())), false),
         };
 
         // Ensure inputs are consistent with public params.
         assert_eq!(private, public_params.private);
 
-        PoRCircuit::<Bls12, H> {
+        PoRCircuit {
             params: engine_params,
             value: Some(proof.data.into()),
-            auth_path: proof.proof.as_options(),
+            auth_path: proof.proof.as_circuit_auth_path(),
             root,
+            beta_height: public_params.beta_height,
             private,
-            _h: Default::default(),
+            _ah: PhantomData,
+            _bh: PhantomData,
         }
     }
 
     fn blank_circuit(
-        public_params: &<MerklePoR<H> as ProofScheme<'a>>::PublicParams,
+        public_params: &<HybridMerklePoR<AH, BH> as ProofScheme<'a>>::PublicParams,
         params: &'a JubjubBls12,
-    ) -> PoRCircuit<'a, Bls12, H> {
-        PoRCircuit::<Bls12, H> {
+    ) -> PoRCircuit<'a, Bls12, AH, BH> {
+        PoRCircuit {
             params,
             value: None,
             auth_path: vec![None; graph_height(public_params.leaves)],
             root: Root::Val(None),
+            beta_height: public_params.beta_height,
             private: public_params.private,
-            _h: Default::default(),
+            _ah: PhantomData,
+            _bh: PhantomData,
         }
     }
 
     fn generate_public_inputs(
-        pub_inputs: &<MerklePoR<H> as ProofScheme<'a>>::PublicInputs,
-        pub_params: &<MerklePoR<H> as ProofScheme<'a>>::PublicParams,
+        pub_inputs: &<HybridMerklePoR<AH, BH> as ProofScheme<'a>>::PublicInputs,
+        pub_params: &<HybridMerklePoR<AH, BH> as ProofScheme<'a>>::PublicParams,
         _k: Option<usize>,
     ) -> Vec<Fr> {
         let auth_path_bits = challenge_into_auth_path_bits(pub_inputs.challenge, pub_params.leaves);
@@ -125,7 +158,12 @@ where
     }
 }
 
-impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for PoRCircuit<'a, E, H> {
+impl<'a, E, AH, BH> Circuit<E> for PoRCircuit<'a, E, AH, BH>
+where
+    E: JubjubEngine,
+    AH: Hasher,
+    BH: Hasher,
+{
     /// # Public Inputs
     ///
     /// This circuit expects the following public inputs.
@@ -137,104 +175,128 @@ impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for PoRCircuit<'a, E, H> {
     /// * value_num - packed version of `value` as bits. (might be more than one Fr)
     ///
     /// Note: All public inputs must be provided as `E::Fr`.
-    fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError>
+    fn synthesize<CS>(self, cs: &mut CS) -> Result<(), SynthesisError>
     where
         E: JubjubEngine,
+        CS: ConstraintSystem<E>,
     {
+        // Allocate the leaf value.
+        let value = AllocatedNum::alloc(cs.namespace(|| "value"), || {
+            self.value.ok_or_else(|| SynthesisError::AssignmentMissing)
+        })?;
+
         let params = self.params;
-        let value = self.value;
         let auth_path = self.auth_path;
         let root = self.root;
 
-        {
-            let value_num = num::AllocatedNum::alloc(cs.namespace(|| "value"), || {
-                value.ok_or_else(|| SynthesisError::AssignmentMissing)
+        let auth_path_len = auth_path.len();
+        let mut auth_path_bits: Vec<Boolean> = Vec::with_capacity(auth_path_len);
+
+        let mut cur = value;
+
+        for (i, opt) in auth_path.into_iter().enumerate() {
+            let cs = &mut cs.namespace(|| format!("merkle tree hash {}", i));
+
+            // Allocate a bit which describes if `cur` is a right input to the Merkle hash. If `cur`
+            // is the right input then `path_elem` is the left input.
+            let cur_is_right = Boolean::from(AllocatedBit::alloc(
+                cs.namespace(|| "position bit"),
+                opt.map(|(_path_elem, path_elem_is_left)| path_elem_is_left),
+            )?);
+
+            // Allocate the path element.
+            let path_elem = AllocatedNum::alloc(cs.namespace(|| "path element"), || {
+                opt.map(|(path_elem, _path_elem_is_left)| path_elem)
+                    .ok_or(SynthesisError::AssignmentMissing)
             })?;
 
-            let mut cur = value_num;
+            // Determine the left and right Merkle hash inputs. Swap `cur` with `path_elem` if `cur`
+            // is the right Merkle hash input.
+            let (left_input, right_input) = AllocatedNum::conditionally_reverse(
+                cs.namespace(|| "conditional reversal of preimage"),
+                &cur,
+                &path_elem,
+                &cur_is_right,
+            )?;
 
-            let mut auth_path_bits = Vec::with_capacity(auth_path.len());
+            let left_input_bits =
+                left_input.into_bits_le(cs.namespace(|| "left input into bits"))?;
 
-            // Ascend the merkle tree authentication path
-            for (i, e) in auth_path.into_iter().enumerate() {
-                let cs = &mut cs.namespace(|| format!("merkle tree hash {}", i));
+            let right_input_bits =
+                right_input.into_bits_le(cs.namespace(|| "right input into bits"))?;
 
-                // Determines if the current subtree is the "right" leaf at this
-                // depth of the tree.
-                let cur_is_right = boolean::Boolean::from(boolean::AllocatedBit::alloc(
-                    cs.namespace(|| "position bit"),
-                    e.map(|e| e.1),
-                )?);
-
-                // Witness the authentication path element adjacent
-                // at this depth.
-                let path_element =
-                    num::AllocatedNum::alloc(cs.namespace(|| "path element"), || {
-                        Ok(e.ok_or(SynthesisError::AssignmentMissing)?.0)
-                    })?;
-
-                // Swap the two if the current subtree is on the right
-                let (xl, xr) = num::AllocatedNum::conditionally_reverse(
-                    cs.namespace(|| "conditional reversal of preimage"),
-                    &cur,
-                    &path_element,
-                    &cur_is_right,
-                )?;
-
-                let xl_bits = xl.into_bits_le(cs.namespace(|| "xl into bits"))?;
-                let xr_bits = xr.into_bits_le(cs.namespace(|| "xr into bits"))?;
-
-                // Compute the new subtree value
-                cur = H::Function::hash_leaf_circuit(
-                    cs.namespace(|| "computation of pedersen hash"),
-                    &xl_bits,
-                    &xr_bits,
+            cur = if i < self.beta_height {
+                BH::Function::hash_leaf_circuit(
+                    cs.namespace(|| "computation of beta hash"),
+                    &left_input_bits,
+                    &right_input_bits,
                     i,
                     params,
-                )?;
-                auth_path_bits.push(cur_is_right);
-            }
+                )?
+            } else {
+                AH::Function::hash_leaf_circuit(
+                    cs.namespace(|| "computation of alpha hash"),
+                    &left_input_bits,
+                    &right_input_bits,
+                    i,
+                    params,
+                )?
+            };
 
-            // allocate input for is_right auth_path
-            multipack::pack_into_inputs(cs.namespace(|| "path"), &auth_path_bits)?;
-
-            {
-                // Validate that the root of the merkle tree that we calculated is the same as the input.
-
-                let rt = root.allocated(cs.namespace(|| "root_value"))?;
-                constraint::equal(cs, || "enforce root is correct", &cur, &rt);
-
-                if !self.private {
-                    // Expose the root
-                    rt.inputize(cs.namespace(|| "root"))?;
-                }
-            }
-
-            Ok(())
+            auth_path_bits.push(cur_is_right);
         }
+
+        // Compactly allocate `auth_path_bits` as inputs (each bit is not allocated individually,
+        // many bits are allocated using a single `Fr` allocation).
+        multipack::pack_into_inputs(cs.namespace(|| "path"), &auth_path_bits)?;
+
+        // Validate that the calculated Merkle Tree root is the same as the input (`self.root`).
+        let calculated_root = cur;
+        let input_root = root.allocated(cs.namespace(|| "root_value"))?;
+        constraint::equal(
+            cs,
+            || "enforce root is correct",
+            &calculated_root,
+            &input_root,
+        );
+
+        // If `private` is not set, expose the root as a public input.
+        if !self.private {
+            input_root.inputize(cs.namespace(|| "root"))?;
+        }
+
+        Ok(())
     }
 }
 
-impl<'a, E: JubjubEngine, H: Hasher> PoRCircuit<'a, E, H> {
+impl<'a, E, AH, BH> PoRCircuit<'a, E, AH, BH>
+where
+    E: JubjubEngine,
+    AH: Hasher,
+    BH: Hasher,
+{
     pub fn synthesize<CS>(
         mut cs: CS,
         params: &E::Params,
         value: Option<E::Fr>,
         auth_path: Vec<Option<(E::Fr, bool)>>,
         root: Root<E>,
+        beta_height: usize,
         private: bool,
     ) -> Result<(), SynthesisError>
     where
         E: JubjubEngine,
         CS: ConstraintSystem<E>,
     {
-        let por = PoRCircuit::<E, H> {
+        let por = PoRCircuit::<E, AH, BH> {
             params,
             value,
             auth_path,
             root,
+            beta_height,
             private,
-            _h: Default::default(),
+            _ah: PhantomData,
+            _bh: PhantomData,
         };
 
         por.synthesize(&mut cs)
@@ -252,11 +314,13 @@ mod tests {
     use rand::{Rng, SeedableRng, XorShiftRng};
 
     use crate::circuit::test::*;
-    use crate::compound_proof;
+    use crate::compound_proof::{self, CompoundProof};
     use crate::drgraph::{new_seed, BucketGraph, Graph};
-    use crate::fr32::{bytes_into_fr, fr_into_bytes};
+    use crate::fr32::fr_into_bytes;
+    use crate::hasher::blake2s::Blake2sDomain;
+    use crate::hasher::hybrid::HybridDomain;
     use crate::hasher::{Blake2sHasher, Domain, Hasher, PedersenHasher};
-    use crate::merklepor;
+    use crate::hybrid_merklepor;
     use crate::proof::ProofScheme;
     use crate::settings;
     use crate::util::data_at_node;
@@ -264,51 +328,59 @@ mod tests {
     #[test]
     #[ignore] // Slow test – run only when compiled for release.
     fn por_test_compound() {
+        const N_LEAVES: usize = 8;
+        const BETA_HEIGHT: usize = 1;
+
         let window_size = settings::SETTINGS
             .lock()
             .unwrap()
             .pedersen_hash_exp_window_size;
+
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
-        let leaves = 6;
-        let data: Vec<u8> = (0..leaves)
+        let data: Vec<u8> = (0..N_LEAVES)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
-        let graph = BucketGraph::<PedersenHasher>::new(leaves, 16, 0, new_seed());
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let graph = BucketGraph::<PedersenHasher, Blake2sHasher>::new(N_LEAVES, 16, 0, new_seed());
+        let tree = graph
+            .hybrid_merkle_tree(data.as_slice(), BETA_HEIGHT)
+            .unwrap();
 
         for i in 0..3 {
-            let public_inputs = merklepor::PublicInputs {
+            let public_inputs = hybrid_merklepor::PublicInputs {
                 challenge: i,
                 commitment: Some(tree.root()),
             };
 
             let setup_params = compound_proof::SetupParams {
-                vanilla_params: &merklepor::SetupParams {
-                    leaves,
+                vanilla_params: &hybrid_merklepor::SetupParams {
+                    leaves: N_LEAVES,
+                    beta_height: BETA_HEIGHT,
                     private: false,
                 },
                 engine_params: &JubjubBls12::new_with_window_size(window_size),
                 partitions: None,
             };
-            let public_params =
-                PoRCompound::<PedersenHasher>::setup(&setup_params).expect("setup failed");
+            let public_params = PoRCompound::<PedersenHasher, Blake2sHasher>::setup(&setup_params)
+                .expect("setup failed");
 
-            let private_inputs = merklepor::PrivateInputs::<PedersenHasher>::new(
-                bytes_into_fr::<Bls12>(
-                    data_at_node(data.as_slice(), public_inputs.challenge).unwrap(),
-                )
-                .expect("failed to create Fr from node data")
-                .into(),
-                &tree,
-            );
+            // Convert the challenge's bytes into a `HybridDomain`. Because `BETA_HEIGHT` is set to
+            // `1` the leaves in the tree will be `HybridDomain::Beta`s.
+            let leaf = {
+                let leaf_bytes = data_at_node(data.as_slice(), public_inputs.challenge).unwrap();
+                let leaf_beta = Blake2sDomain::try_from_bytes(&leaf_bytes).unwrap();
+                HybridDomain::Beta(leaf_beta)
+            };
 
-            let gparams = PoRCompound::<PedersenHasher>::groth_params(
+            let private_inputs =
+                hybrid_merklepor::PrivateInputs::<PedersenHasher, Blake2sHasher>::new(leaf, &tree);
+
+            let gparams = PoRCompound::<PedersenHasher, Blake2sHasher>::groth_params(
                 &public_params.vanilla_params,
                 setup_params.engine_params,
             )
             .expect("failed to generate groth params");
 
-            let proof = PoRCompound::<PedersenHasher>::prove(
+            let proof = PoRCompound::<PedersenHasher, Blake2sHasher>::prove(
                 &public_params,
                 &public_inputs,
                 &private_inputs,
@@ -316,7 +388,7 @@ mod tests {
             )
             .expect("failed while proving");
 
-            let verified = PoRCompound::<PedersenHasher>::verify(
+            let verified = PoRCompound::<PedersenHasher, Blake2sHasher>::verify(
                 &public_params,
                 &public_inputs,
                 &proof,
@@ -325,7 +397,7 @@ mod tests {
             .expect("failed while verifying");
             assert!(verified);
 
-            let (circuit, inputs) = PoRCompound::<PedersenHasher>::circuit_for_test(
+            let (circuit, inputs) = PoRCompound::<PedersenHasher, Blake2sHasher>::circuit_for_test(
                 &public_params,
                 &public_inputs,
                 &private_inputs,
@@ -341,72 +413,98 @@ mod tests {
 
     #[test]
     fn test_por_input_circuit_with_bls12_381_pedersen() {
-        test_por_input_circuit_with_bls12_381::<PedersenHasher>(4125);
+        test_por_input_circuit_with_bls12_381::<PedersenHasher, Blake2sHasher>(24272);
     }
 
     #[test]
     fn test_por_input_circuit_with_bls12_381_blake2s() {
-        test_por_input_circuit_with_bls12_381::<Blake2sHasher>(64566);
+        test_por_input_circuit_with_bls12_381::<Blake2sHasher, Blake2sHasher>(64566);
     }
 
-    fn test_por_input_circuit_with_bls12_381<H: Hasher>(num_constraints: usize) {
+    #[test]
+    fn test_por_input_circuit_with_bls12_381_pedersen_blake2s() {
+        test_por_input_circuit_with_bls12_381::<PedersenHasher, Blake2sHasher>(24272);
+    }
+
+    fn test_por_input_circuit_with_bls12_381<AH, BH>(num_constraints: usize)
+    where
+        AH: 'static + Hasher,
+        BH: 'static + Hasher,
+    {
+        const N_LEAVES: usize = 8;
+        const BETA_HEIGHT: usize = 1;
+
         let window_size = settings::SETTINGS
             .lock()
             .unwrap()
             .pedersen_hash_exp_window_size;
         let params = &JubjubBls12::new_with_window_size(window_size);
+
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
-        let leaves = 6;
-
-        for i in 0..6 {
+        for challenge_index in 0..N_LEAVES {
             // -- Basic Setup
 
-            let data: Vec<u8> = (0..leaves)
+            let data: Vec<u8> = (0..N_LEAVES)
                 .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
                 .collect();
 
-            let graph = BucketGraph::<H>::new(leaves, 16, 0, new_seed());
-            let tree = graph.merkle_tree(data.as_slice()).unwrap();
+            let graph = BucketGraph::<AH, BH>::new(N_LEAVES, 16, 0, new_seed());
+            let tree = graph
+                .hybrid_merkle_tree(data.as_slice(), BETA_HEIGHT)
+                .unwrap();
 
-            // -- MerklePoR
+            // -- HybridMerklePoR
 
-            let pub_params = merklepor::PublicParams {
-                leaves,
+            let pub_params = hybrid_merklepor::PublicParams {
+                leaves: N_LEAVES,
+                beta_height: BETA_HEIGHT,
                 private: true,
             };
-            let pub_inputs = merklepor::PublicInputs::<H::Domain> {
-                challenge: i,
+            let pub_inputs = hybrid_merklepor::PublicInputs::<AH::Domain, BH::Domain> {
+                challenge: challenge_index,
                 commitment: Some(tree.root()),
             };
 
-            let priv_inputs = merklepor::PrivateInputs::<H>::new(
-                H::Domain::try_from_bytes(
-                    data_at_node(data.as_slice(), pub_inputs.challenge).unwrap(),
-                )
-                .unwrap(),
-                &tree,
-            );
+            // Convert the challenge's bytes into a `HybridDomain`. Because `BETA_HEIGHT` is set to
+            // `1` the leaves in the tree will be `HybridDomain::Beta`s.
+            let leaf = {
+                let leaf_bytes = data_at_node(data.as_slice(), pub_inputs.challenge).unwrap();
+                let leaf_beta = BH::Domain::try_from_bytes(&leaf_bytes).unwrap();
+                HybridDomain::Beta(leaf_beta)
+            };
+
+            let priv_inputs = hybrid_merklepor::PrivateInputs::<AH, BH>::new(leaf, &tree);
 
             // create a non circuit proof
-            let proof = merklepor::MerklePoR::<H>::prove(&pub_params, &pub_inputs, &priv_inputs)
-                .expect("proving failed");
+            let proof = hybrid_merklepor::HybridMerklePoR::<AH, BH>::prove(
+                &pub_params,
+                &pub_inputs,
+                &priv_inputs,
+            )
+            .expect("proving failed");
 
             // make sure it verifies
-            let is_valid = merklepor::MerklePoR::<H>::verify(&pub_params, &pub_inputs, &proof)
-                .expect("verification failed");
-            assert!(is_valid, "failed to verify merklepor proof");
+            let is_valid = hybrid_merklepor::HybridMerklePoR::<AH, BH>::verify(
+                &pub_params,
+                &pub_inputs,
+                &proof,
+            )
+            .expect("verification failed");
+            assert!(is_valid, "failed to verify hybrid merklepor proof");
 
             // -- Circuit
 
             let mut cs = TestConstraintSystem::<Bls12>::new();
-            let por = PoRCircuit::<Bls12, H> {
+            let por = PoRCircuit::<Bls12, AH, BH> {
                 params,
                 value: Some(proof.data.into()),
-                auth_path: proof.proof.as_options(),
+                auth_path: proof.proof.as_circuit_auth_path(),
                 root: Root::Val(Some(pub_inputs.commitment.unwrap().into())),
+                beta_height: BETA_HEIGHT,
                 private: false,
-                _h: Default::default(),
+                _ah: PhantomData,
+                _bh: PhantomData,
             };
 
             por.synthesize(&mut cs).expect("circuit synthesis failed");
@@ -453,60 +551,77 @@ mod tests {
     #[ignore] // Slow test – run only when compiled for release.
     #[test]
     fn test_private_por_compound_pedersen() {
-        private_por_test_compound::<PedersenHasher>();
+        private_por_test_compound::<PedersenHasher, PedersenHasher>();
     }
 
     #[ignore] // Slow test – run only when compiled for release.
     #[test]
     fn test_private_por_compound_blake2s() {
-        private_por_test_compound::<Blake2sHasher>();
+        private_por_test_compound::<Blake2sHasher, Blake2sHasher>();
     }
 
-    fn private_por_test_compound<H: Hasher>() {
+    #[ignore] // Slow test – run only when compiled for release.
+    #[test]
+    fn test_private_por_compound_pedersen_blake2s() {
+        private_por_test_compound::<PedersenHasher, Blake2sHasher>();
+    }
+
+    fn private_por_test_compound<AH, BH>()
+    where
+        AH: 'static + Hasher,
+        BH: 'static + Hasher,
+    {
+        const N_LEAVES: usize = 8;
+        const BETA_HEIGHT: usize = 1;
+
         let window_size = settings::SETTINGS
             .lock()
             .unwrap()
             .pedersen_hash_exp_window_size;
+
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
-        let leaves = 6;
-        let data: Vec<u8> = (0..leaves)
+        let data: Vec<u8> = (0..N_LEAVES)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
-        let graph = BucketGraph::<H>::new(leaves, 16, 0, new_seed());
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let graph = BucketGraph::<AH, BH>::new(N_LEAVES, 16, 0, new_seed());
+        let tree = graph
+            .hybrid_merkle_tree(data.as_slice(), BETA_HEIGHT)
+            .unwrap();
 
         for i in 0..3 {
-            let public_inputs = merklepor::PublicInputs {
+            let public_inputs = hybrid_merklepor::PublicInputs {
                 challenge: i,
                 commitment: None,
             };
 
             let setup_params = compound_proof::SetupParams {
-                vanilla_params: &merklepor::SetupParams {
-                    leaves,
+                vanilla_params: &hybrid_merklepor::SetupParams {
+                    leaves: N_LEAVES,
+                    beta_height: BETA_HEIGHT,
                     private: true,
                 },
                 engine_params: &JubjubBls12::new_with_window_size(window_size),
                 partitions: None,
             };
-            let public_params = PoRCompound::<H>::setup(&setup_params).expect("setup failed");
+            let public_params = PoRCompound::<AH, BH>::setup(&setup_params).expect("setup failed");
 
-            let private_inputs = merklepor::PrivateInputs::<H>::new(
-                bytes_into_fr::<Bls12>(
-                    data_at_node(data.as_slice(), public_inputs.challenge).unwrap(),
-                )
-                .expect("failed to create Fr from node data")
-                .into(),
-                &tree,
-            );
+            // Convert the challenge's bytes into a `HybridDomain`. Because `BETA_HEIGHT` is set to
+            // `1` the leaves in the tree will be `HybridDomain::Beta`s.
+            let leaf = {
+                let leaf_bytes = data_at_node(data.as_slice(), public_inputs.challenge).unwrap();
+                let leaf_beta = BH::Domain::try_from_bytes(&leaf_bytes).unwrap();
+                HybridDomain::Beta(leaf_beta)
+            };
 
-            let groth_params = PoRCompound::<H>::groth_params(
+            let private_inputs = hybrid_merklepor::PrivateInputs::<AH, BH>::new(leaf, &tree);
+
+            let groth_params = PoRCompound::<AH, BH>::groth_params(
                 &public_params.vanilla_params,
                 setup_params.engine_params,
             )
             .expect("failed to generate groth params");
 
-            let proof = PoRCompound::<H>::prove(
+            let proof = PoRCompound::<AH, BH>::prove(
                 &public_params,
                 &public_inputs,
                 &private_inputs,
@@ -515,7 +630,7 @@ mod tests {
             .expect("proving failed");
 
             {
-                let (circuit, inputs) = PoRCompound::<H>::circuit_for_test(
+                let (circuit, inputs) = PoRCompound::<AH, BH>::circuit_for_test(
                     &public_params,
                     &public_inputs,
                     &private_inputs,
@@ -529,56 +644,68 @@ mod tests {
                 assert!(cs.verify(&inputs));
             }
 
-            let verified =
-                PoRCompound::<H>::verify(&public_params, &public_inputs, &proof, &NoRequirements)
-                    .expect("failed while verifying");
+            let verified = PoRCompound::<AH, BH>::verify(
+                &public_params,
+                &public_inputs,
+                &proof,
+                &NoRequirements,
+            )
+            .expect("failed while verifying");
             assert!(verified);
         }
     }
 
     #[test]
     fn test_private_por_input_circuit_with_bls12_381() {
+        const N_LEAVES: usize = 8;
+        const BETA_HEIGHT: usize = 1;
+
         let window_size = settings::SETTINGS
             .lock()
             .unwrap()
             .pedersen_hash_exp_window_size;
         let params = &JubjubBls12::new_with_window_size(window_size);
+
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
-        let leaves = 6;
-
-        for i in 0..6 {
+        for i in 0..N_LEAVES {
             // -- Basic Setup
 
-            let data: Vec<u8> = (0..leaves)
+            let data: Vec<u8> = (0..N_LEAVES)
                 .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
                 .collect();
 
-            let graph = BucketGraph::<PedersenHasher>::new(leaves, 16, 0, new_seed());
-            let tree = graph.merkle_tree(data.as_slice()).unwrap();
+            let graph =
+                BucketGraph::<PedersenHasher, Blake2sHasher>::new(N_LEAVES, 16, 0, new_seed());
+            let tree = graph
+                .hybrid_merkle_tree(data.as_slice(), BETA_HEIGHT)
+                .unwrap();
 
-            // -- MerklePoR
+            // -- HybridMerklePoR
 
-            let pub_params = merklepor::PublicParams {
-                leaves,
+            let pub_params = hybrid_merklepor::PublicParams {
+                leaves: N_LEAVES,
+                beta_height: BETA_HEIGHT,
                 private: true,
             };
-            let pub_inputs = merklepor::PublicInputs {
+            let pub_inputs = hybrid_merklepor::PublicInputs {
                 challenge: i,
                 commitment: None,
             };
 
-            let priv_inputs = merklepor::PrivateInputs::<PedersenHasher>::new(
-                bytes_into_fr::<Bls12>(
-                    data_at_node(data.as_slice(), pub_inputs.challenge).unwrap(),
-                )
-                .unwrap()
-                .into(),
-                &tree,
-            );
+            // Convert the challenge's bytes into a `HybridDomain`. Because `BETA_HEIGHT` is set to
+            // `1` the leaves in the tree will be `HybridDomain::Beta`s.
+            let leaf = {
+                let leaf_bytes = data_at_node(data.as_slice(), pub_inputs.challenge).unwrap();
+                let leaf_beta = Blake2sDomain::try_from_bytes(&leaf_bytes).unwrap();
+                HybridDomain::Beta(leaf_beta)
+            };
+
+            let priv_inputs =
+                hybrid_merklepor::PrivateInputs::<PedersenHasher, Blake2sHasher>::new(leaf, &tree);
 
             // create a non circuit proof
-            let proof = merklepor::MerklePoR::<PedersenHasher>::prove(
+            let proof = hybrid_merklepor::HybridMerklePoR::<PedersenHasher, Blake2sHasher>::prove(
                 &pub_params,
                 &pub_inputs,
                 &priv_inputs,
@@ -587,28 +714,34 @@ mod tests {
 
             // make sure it verifies
             let is_valid =
-                merklepor::MerklePoR::<PedersenHasher>::verify(&pub_params, &pub_inputs, &proof)
-                    .expect("verification failed");
-            assert!(is_valid, "failed to verify merklepor proof");
+                hybrid_merklepor::HybridMerklePoR::<PedersenHasher, Blake2sHasher>::verify(
+                    &pub_params,
+                    &pub_inputs,
+                    &proof,
+                )
+                .expect("verification failed");
+            assert!(is_valid, "failed to verify hybrid_merklepor proof");
 
             // -- Circuit
 
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let por = PoRCircuit::<Bls12, PedersenHasher> {
+            let por = PoRCircuit::<Bls12, PedersenHasher, Blake2sHasher> {
                 params,
                 value: Some(proof.data.into()),
-                auth_path: proof.proof.as_options(),
+                auth_path: proof.proof.as_circuit_auth_path(),
                 root: Root::Val(Some(tree.root().into())),
+                beta_height: BETA_HEIGHT,
                 private: true,
-                _h: Default::default(),
+                _ah: PhantomData,
+                _bh: PhantomData,
             };
 
             por.synthesize(&mut cs).expect("circuit synthesis failed");
             assert!(cs.is_satisfied(), "constraints not satisfied");
 
             assert_eq!(cs.num_inputs(), 2, "wrong number of inputs");
-            assert_eq!(cs.num_constraints(), 4124, "wrong number of constraints");
+            assert_eq!(cs.num_constraints(), 24271, "wrong number of constraints");
 
             let auth_path_bits: Vec<bool> = proof
                 .proof

--- a/storage-proofs/src/hasher/hybrid.rs
+++ b/storage-proofs/src/hasher/hybrid.rs
@@ -1,0 +1,256 @@
+use std::cmp::Ordering;
+
+use merkletree::merkle::Element;
+use paired::bls12_381::{Fr, FrRepr};
+use rand::{Rand, Rng};
+use serde::de::DeserializeOwned;
+use serde::ser::Serialize;
+
+use crate::error::Result;
+use crate::hasher::Domain;
+
+#[derive(Clone, Copy, Debug, Eq, Serialize, Deserialize)]
+pub enum HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    #[serde(bound(serialize = "AD: Serialize", deserialize = "AD: DeserializeOwned"))]
+    Alpha(AD),
+
+    #[serde(bound(serialize = "BD: Serialize", deserialize = "BD: DeserializeOwned"))]
+    Beta(BD),
+}
+
+impl<AD, BD> Default for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    fn default() -> Self {
+        HybridDomain::Alpha(AD::default())
+    }
+}
+
+impl<AD, BD> PartialEq for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (HybridDomain::Alpha(a), HybridDomain::Alpha(b)) => a == b,
+            (HybridDomain::Beta(a), HybridDomain::Beta(b)) => a == b,
+            _ => panic!("can't compare different variants of `HybridDomain`"),
+        }
+    }
+}
+
+impl<AD, BD> PartialOrd for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        match (self, other) {
+            (HybridDomain::Alpha(a), HybridDomain::Alpha(b)) => Some(a.cmp(b)),
+            (HybridDomain::Beta(a), HybridDomain::Beta(b)) => Some(a.cmp(b)),
+            _ => None,
+        }
+    }
+}
+
+impl<AD, BD> Ord for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.partial_cmp(other) {
+            Some(ordering) => ordering,
+            None => panic!("can't compare different variants of `HybridDomain`"),
+        }
+    }
+}
+
+impl<AD, BD> AsRef<[u8]> for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    fn as_ref(&self) -> &[u8] {
+        match self {
+            HybridDomain::Alpha(alpha) => alpha.as_ref(),
+            HybridDomain::Beta(beta) => beta.as_ref(),
+        }
+    }
+}
+
+impl<AD, BD> Element for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    fn byte_len() -> usize {
+        32
+    }
+
+    // We offload the responsibility of converting this `Alpha` to a `Beta` to the caller. The
+    // caller should always be `HybridMerkleTree`, which is aware of the when to convert between the
+    // variants via its `beta_height`.
+    fn from_slice(bytes: &[u8]) -> Self {
+        HybridDomain::Alpha(AD::from_slice(bytes))
+    }
+
+    fn copy_to_slice(&self, dest: &mut [u8]) {
+        dest.copy_from_slice(self.as_ref());
+    }
+}
+
+impl<AD, BD> Rand for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    // We offload the responsibility of converting this `Alpha` to a `Beta` to the caller.
+    fn rand<R>(rng: &mut R) -> Self
+    where
+        R: Rng,
+    {
+        let fr: Fr = rng.gen();
+        fr.into()
+    }
+}
+
+impl<AD, BD> From<Fr> for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    // We offload the responsibility of converting this `Alpha` to a `Beta` to the caller.
+    fn from(fr: Fr) -> Self {
+        HybridDomain::Alpha(AD::from(fr))
+    }
+}
+
+impl<AD, BD> From<FrRepr> for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    // We offload the responsibility of converting this `Alpha` to a `Beta` to the caller.
+    #[inline]
+    fn from(fr_repr: FrRepr) -> Self {
+        HybridDomain::Alpha(AD::from(fr_repr))
+    }
+}
+
+impl<AD, BD> From<HybridDomain<AD, BD>> for Fr
+where
+    AD: Domain,
+    BD: Domain,
+{
+    fn from(hybrid_domain: HybridDomain<AD, BD>) -> Self {
+        match hybrid_domain {
+            HybridDomain::Alpha(alpha) => alpha.into(),
+            HybridDomain::Beta(beta) => beta.into(),
+        }
+    }
+}
+
+impl<AD, BD> Domain for HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    fn serialize(&self) -> Vec<u8> {
+        match self {
+            HybridDomain::Alpha(alpha) => Domain::serialize(alpha),
+            HybridDomain::Beta(beta) => Domain::serialize(beta),
+        }
+    }
+
+    fn into_bytes(&self) -> Vec<u8> {
+        match self {
+            HybridDomain::Alpha(alpha) => alpha.into_bytes(),
+            HybridDomain::Beta(beta) => beta.into_bytes(),
+        }
+    }
+
+    // We offload the responsibility of converting this `Alpha` to a `Beta` to the caller.
+    fn try_from_bytes(bytes: &[u8]) -> Result<Self> {
+        AD::try_from_bytes(bytes).map(HybridDomain::Alpha)
+    }
+
+    fn write_bytes(&self, dest: &mut [u8]) -> Result<()> {
+        match self {
+            HybridDomain::Alpha(alpha) => alpha.write_bytes(dest),
+            HybridDomain::Beta(beta) => beta.write_bytes(dest),
+        }
+    }
+}
+
+impl<AD, BD> HybridDomain<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    pub fn alpha_value(&self) -> &AD {
+        match self {
+            HybridDomain::Alpha(alpha_value) => alpha_value,
+            _ => panic!("`HybridDomain::Beta` does not have an alpha value"),
+        }
+    }
+
+    pub fn beta_value(&self) -> &BD {
+        match self {
+            HybridDomain::Beta(beta_value) => beta_value,
+            _ => panic!("`HybridDomain::Alpha` does not have a beta value"),
+        }
+    }
+
+    pub fn is_alpha(&self) -> bool {
+        if let HybridDomain::Alpha { .. } = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn is_beta(&self) -> bool {
+        if let HybridDomain::Beta { .. } = self {
+            true
+        } else {
+            false
+        }
+    }
+
+    // Assumes that we can convert between `Alpha` and `Beta`.
+    pub fn into_alpha(self) -> Self {
+        if self.is_alpha() {
+            self
+        } else {
+            let alpha = AD::from_slice(self.as_ref());
+            HybridDomain::Alpha(alpha)
+        }
+    }
+
+    // Assumes that we can convert between `Alpha` and `Beta`.
+    pub fn into_beta(self) -> Self {
+        if self.is_beta() {
+            self
+        } else {
+            let beta = BD::from_slice(self.as_ref());
+            HybridDomain::Beta(beta)
+        }
+    }
+
+    // Assumes that we can convert between `Alpha` and `Beta`.
+    pub fn toggle(self) -> Self {
+        if self.is_alpha() {
+            self.into_beta()
+        } else {
+            self.into_alpha()
+        }
+    }
+}

--- a/storage-proofs/src/hasher/mod.rs
+++ b/storage-proofs/src/hasher/mod.rs
@@ -1,4 +1,5 @@
 pub mod blake2s;
+pub mod hybrid;
 pub mod pedersen;
 pub mod sha256;
 

--- a/storage-proofs/src/hybrid_merkle.rs
+++ b/storage-proofs/src/hybrid_merkle.rs
@@ -1,0 +1,1169 @@
+use std::iter;
+use std::marker::PhantomData;
+use std::sync::{Arc, RwLock};
+
+use merkletree::hash::Algorithm;
+#[cfg(feature = "disk-trees")]
+use merkletree::merkle::DiskMmapStore;
+#[cfg(not(feature = "disk-trees"))]
+use merkletree::merkle::MmapStore;
+use merkletree::merkle::{Element, Store};
+use paired::bls12_381::Fr;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use rayon::slice::ParallelSlice;
+
+use crate::hasher::hybrid::HybridDomain;
+use crate::hasher::{Domain, Hasher};
+
+#[cfg(feature = "disk-trees")]
+type HybridStore<AD, BD> = DiskMmapStore<HybridDomain<AD, BD>>;
+
+#[cfg(not(feature = "disk-trees"))]
+type HybridStore<AD, BD> = MmapStore<HybridDomain<AD, BD>>;
+
+const SMALL_TREE_BUILD: usize = 1024;
+
+const N_NODES_PER_CHUNK: usize = 1024;
+
+const N_CHILDREN_PER_FULL_CHUNK: usize = N_NODES_PER_CHUNK / 2;
+
+/// Returns `true` is `node_index` is the left input to a Merkle hash; all even node indices are
+/// left inputs.
+#[inline(always)]
+fn is_left_input(node_index: usize) -> bool {
+    node_index & 1 == 0
+}
+
+#[inline(always)]
+fn is_right_input(node_index: usize) -> bool {
+    node_index & 1 == 1
+}
+
+/// Returns `node_index`'s Merkle hash partner's node index (the node that `node_index` is paired
+/// with during Merkle hashing).
+#[inline(always)]
+fn get_sibling(node_index: usize) -> usize {
+    if is_left_input(node_index) {
+        node_index + 1
+    } else {
+        node_index - 1
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HybridMerkleTree<AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    n_leaves: usize,
+    height: usize,
+    beta_height: usize,
+    n_beta_nodes: usize,
+    leaves_store: HybridStore<AH::Domain, BH::Domain>,
+    top_half_store: HybridStore<AH::Domain, BH::Domain>,
+    root: HybridDomain<AH::Domain, BH::Domain>,
+    _ah: PhantomData<AH>,
+    _bh: PhantomData<BH>,
+}
+
+impl<AH, BH> HybridMerkleTree<AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    pub fn from_leaves<I>(leaves: I, beta_height: usize) -> Self
+    where
+        I: IntoIterator<Item = HybridDomain<AH::Domain, BH::Domain>>,
+    {
+        let leaves = leaves.into_iter();
+        let n_leaves = leaves
+            .size_hint()
+            .1
+            .expect("non-deterministically sized leaves iterator");
+
+        assert!(n_leaves > 1);
+        assert!(n_leaves.is_power_of_two());
+
+        let mut leaves_store = HybridStore::new(n_leaves);
+        let top_half_store = HybridStore::new(n_leaves);
+
+        let tree_is_alpha = beta_height == 0;
+
+        for leaf in leaves {
+            if tree_is_alpha {
+                assert!(leaf.is_alpha());
+            } else {
+                assert!(leaf.is_beta());
+            }
+            leaves_store.push(leaf);
+        }
+
+        let n_beta_nodes = (0..beta_height).fold(0, |mut acc, layer_index| {
+            let n_nodes_in_layer = n_leaves >> layer_index;
+            acc += n_nodes_in_layer;
+            acc
+        });
+
+        HybridMerkleTree::build(
+            leaves_store,
+            top_half_store,
+            n_leaves,
+            beta_height,
+            n_beta_nodes,
+        )
+    }
+
+    #[cfg(feature = "disk-trees")]
+    pub fn from_leaves_with_store<I>(
+        leaves: I,
+        beta_height: usize,
+        mut leaves_store: HybridStore<AH::Domain, BH::Domain>,
+        top_half_store: HybridStore<AH::Domain, BH::Domain>,
+    ) -> Self
+    where
+        I: IntoIterator<Item = HybridDomain<AH::Domain, BH::Domain>>,
+    {
+        let leaves = leaves.into_iter();
+        let n_leaves = leaves
+            .size_hint()
+            .1
+            .expect("non-deterministically sized leaves iterator");
+
+        assert!(n_leaves > 1);
+        assert!(n_leaves.is_power_of_two());
+
+        let tree_is_alpha = beta_height == 0;
+
+        for leaf in leaves {
+            if tree_is_alpha {
+                assert!(leaf.is_alpha());
+            } else {
+                assert!(leaf.is_beta());
+            }
+            leaves_store.push(leaf);
+        }
+
+        let n_beta_nodes = (0..beta_height).fold(0, |mut acc, layer_index| {
+            let n_nodes_in_layer = n_leaves >> layer_index;
+            acc += n_nodes_in_layer;
+            acc
+        });
+
+        HybridMerkleTree::build(
+            leaves_store,
+            top_half_store,
+            n_leaves,
+            beta_height,
+            n_beta_nodes,
+        )
+    }
+
+    pub fn from_leaves_par_iter<I>(leaves: I, beta_height: usize) -> Self
+    where
+        I: IntoParallelIterator<Item = HybridDomain<AH::Domain, BH::Domain>>,
+    {
+        // Hybrid Merkle Trees do not re-hash the leaves; we assume the user has passed in the
+        // correct leaf nodes.
+        let leaves: Vec<HybridDomain<AH::Domain, BH::Domain>> = leaves.into_par_iter().collect();
+        let n_leaves = leaves.len();
+
+        assert!(n_leaves > 1);
+        assert!(n_leaves.is_power_of_two());
+
+        let mut leaves_store = HybridStore::new(n_leaves);
+        let top_half_store = HybridStore::new(n_leaves);
+
+        let tree_is_alpha = beta_height == 0;
+
+        for leaf in leaves {
+            if tree_is_alpha {
+                assert!(leaf.is_alpha());
+            } else {
+                assert!(leaf.is_beta());
+            }
+            leaves_store.push(leaf);
+        }
+
+        let n_beta_nodes = (0..beta_height).fold(0, |mut acc, layer_index| {
+            let n_nodes_in_layer = n_leaves >> layer_index;
+            acc += n_nodes_in_layer;
+            acc
+        });
+
+        HybridMerkleTree::build(
+            leaves_store,
+            top_half_store,
+            n_leaves,
+            beta_height,
+            n_beta_nodes,
+        )
+    }
+
+    pub fn from_leaf_preimages<'a, I>(preimages: I, beta_height: usize) -> Self
+    where
+        I: IntoIterator<Item = &'a [u8]>,
+    {
+        let preimages = preimages.into_iter();
+
+        let n_leaves = preimages
+            .size_hint()
+            .1
+            .expect("non-deterministically sized preimages iterator");
+
+        assert!(n_leaves > 1);
+        assert!(n_leaves.is_power_of_two());
+
+        let mut leaves_store = HybridStore::new(n_leaves);
+        let top_half_store = HybridStore::new(n_leaves);
+
+        let tree_is_alpha = beta_height == 0;
+
+        for leaf_preimage in preimages {
+            let leaf = if tree_is_alpha {
+                AH::Domain::try_from_bytes(leaf_preimage)
+                    .map(HybridDomain::Alpha)
+                    .expect("failed to create alpha domain from leaf preimage")
+            } else {
+                BH::Domain::try_from_bytes(leaf_preimage)
+                    .map(HybridDomain::Beta)
+                    .expect("failed to create beta domain from leaf preimage")
+            };
+            leaves_store.push(leaf);
+        }
+
+        let n_beta_nodes = (0..beta_height).fold(0, |mut acc, layer_index| {
+            let n_nodes_in_layer = n_leaves >> layer_index;
+            acc += n_nodes_in_layer;
+            acc
+        });
+
+        HybridMerkleTree::build(
+            leaves_store,
+            top_half_store,
+            n_leaves,
+            beta_height,
+            n_beta_nodes,
+        )
+    }
+
+    fn build(
+        leaves_store: HybridStore<AH::Domain, BH::Domain>,
+        top_half_store: HybridStore<AH::Domain, BH::Domain>,
+        n_leaves: usize,
+        beta_height: usize,
+        n_beta_nodes: usize,
+    ) -> Self {
+        if n_leaves <= SMALL_TREE_BUILD {
+            return Self::build_small_tree(
+                leaves_store,
+                top_half_store,
+                n_leaves,
+                beta_height,
+                n_beta_nodes,
+            );
+        }
+
+        let height = (n_leaves as f32).log2() as usize;
+        let n_layers = height + 1;
+        let n_bytes_per_node = HybridDomain::<AH::Domain, BH::Domain>::byte_len();
+
+        let leaves_store = Arc::new(RwLock::new(leaves_store));
+        let top_half_store = Arc::new(RwLock::new(top_half_store));
+
+        let layer_index = 0;
+        let next_layer_is_seam = beta_height == 1;
+
+        // If the number of nodes in the leaves layer is not divisible by `N_NODES_PER_CHUNK` then
+        // set `partial_last_chunk` to `true`.
+        let (n_chunks, partial_last_chunk) = {
+            let n_chunks = n_leaves as f32 / N_NODES_PER_CHUNK as f32;
+            let partial_last_chunk = n_chunks.fract() != 0.0;
+            let n_chunks = n_chunks.ceil() as usize;
+            (n_chunks, partial_last_chunk)
+        };
+
+        (0..n_chunks).into_par_iter().for_each(|chunk_index| {
+            let is_last_chunk = chunk_index == n_chunks - 1;
+
+            // If the number of nodes in the layer being read is not divisible by
+            // `N_NODES_PER_CHUNK` then the last chunk will have fewer nodes than
+            // `N_NODES_PER_CHUNK`.
+            let n_nodes_in_chunk = if is_last_chunk && partial_last_chunk {
+                n_leaves % N_NODES_PER_CHUNK
+            } else {
+                N_NODES_PER_CHUNK
+            };
+
+            let read_start = chunk_index * N_NODES_PER_CHUNK;
+            let read_stop = read_start + n_nodes_in_chunk;
+            let write_start = chunk_index * N_CHILDREN_PER_FULL_CHUNK;
+
+            let nodes = leaves_store
+                .read()
+                .unwrap()
+                .read_range(read_start..read_stop);
+
+            let n_children = n_nodes_in_chunk / 2;
+            let n_children_bytes = n_children * n_bytes_per_node;
+            let mut children_bytes = Vec::<u8>::with_capacity(n_children_bytes);
+
+            for pair in nodes.chunks(2) {
+                let child = if next_layer_is_seam {
+                    // `Store.read_range()` always returns `HybridDomain::Alpha`s (because it
+                    // call `HybridDomain::from_slice` under the hood) so we must convert the
+                    // alphas to betas before passing them into the beta hasher.
+                    let left_beta = *pair[0].into_beta().beta_value();
+                    let right_beta = *pair[1].into_beta().beta_value();
+                    let child_beta =
+                        BH::Function::default().node(left_beta, right_beta, layer_index);
+                    let child_alpha = AH::Domain::from_slice(child_beta.as_ref());
+                    HybridDomain::Alpha(child_alpha)
+                } else if layer_index < beta_height {
+                    // `Store.read_range()` always returns `HybridDomain::Alpha`s (because it
+                    // call `HybridDomain::from_slice` under the hood) so we must convert the
+                    // alphas to betas before passing them into the beta hasher.
+                    let left_beta = *pair[0].into_beta().beta_value();
+                    let right_beta = *pair[1].into_beta().beta_value();
+                    let child_beta =
+                        BH::Function::default().node(left_beta, right_beta, layer_index);
+                    HybridDomain::Beta(child_beta)
+                } else {
+                    let left_alpha = *pair[0].alpha_value();
+                    let right_alpha = *pair[1].alpha_value();
+                    let child_alpha =
+                        AH::Function::default().node(left_alpha, right_alpha, layer_index);
+                    HybridDomain::Alpha(child_alpha)
+                };
+
+                children_bytes.extend_from_slice(child.as_ref());
+            }
+
+            top_half_store
+                .write()
+                .unwrap()
+                .copy_from_slice(&children_bytes, write_start);
+        });
+
+        for layer_index in 1..n_layers - 1 {
+            let n_nodes_in_layer = n_leaves >> layer_index;
+            let n_nodes_written_in_top_half = top_half_store.read().unwrap().len();
+            let next_layer_is_seam = layer_index + 1 == beta_height;
+
+            let (n_chunks, partial_last_chunk) = {
+                let n_chunks = n_nodes_in_layer as f32 / N_NODES_PER_CHUNK as f32;
+                let partial_last_chunk = n_chunks.fract() != 0.0;
+                let n_chunks = n_chunks.ceil() as usize;
+                (n_chunks, partial_last_chunk)
+            };
+
+            (0..n_chunks).into_par_iter().for_each(|chunk_index| {
+                let is_last_chunk = chunk_index == n_chunks - 1;
+
+                let n_nodes_in_chunk = if is_last_chunk && partial_last_chunk {
+                    n_nodes_in_layer % N_NODES_PER_CHUNK
+                } else {
+                    N_NODES_PER_CHUNK
+                };
+
+                let read_start = {
+                    let read_start_layer = n_nodes_written_in_top_half - n_nodes_in_layer;
+                    read_start_layer + chunk_index * N_NODES_PER_CHUNK
+                };
+
+                let read_stop = read_start + n_nodes_in_chunk;
+
+                let write_start =
+                    n_nodes_written_in_top_half + chunk_index * N_CHILDREN_PER_FULL_CHUNK;
+
+                let nodes = top_half_store
+                    .read()
+                    .unwrap()
+                    .read_range(read_start..read_stop);
+
+                let n_children = n_nodes_in_chunk / 2;
+                let n_children_bytes = n_children * n_bytes_per_node;
+                let mut children_bytes = Vec::<u8>::with_capacity(n_children_bytes);
+
+                for pair in nodes.chunks(2) {
+                    let child = if next_layer_is_seam {
+                        // `Store.read_range()` always returns `HybridDomain::Alpha`s (because
+                        // it call `HybridDomain::from_slice` under the hood) so we must convert
+                        // the alphas to betas before passing them into the beta hasher.
+                        let left_beta = *pair[0].into_beta().beta_value();
+                        let right_beta = *pair[1].into_beta().beta_value();
+                        let child_beta =
+                            BH::Function::default().node(left_beta, right_beta, layer_index);
+                        let child_alpha = AH::Domain::from_slice(child_beta.as_ref());
+                        HybridDomain::Alpha(child_alpha)
+                    } else if layer_index < beta_height {
+                        // `Store.read_range()` always returns `HybridDomain::Alpha`s (because
+                        // it call `HybridDomain::from_slice` under the hood) so we must convert
+                        // the alphas to betas before passing them into the beta hasher.
+                        let left_beta = *pair[0].into_beta().beta_value();
+                        let right_beta = *pair[1].into_beta().beta_value();
+                        let child_beta =
+                            BH::Function::default().node(left_beta, right_beta, layer_index);
+                        HybridDomain::Beta(child_beta)
+                    } else {
+                        let left_alpha = *pair[0].alpha_value();
+                        let right_alpha = *pair[1].alpha_value();
+                        let child_alpha =
+                            AH::Function::default().node(left_alpha, right_alpha, layer_index);
+                        HybridDomain::Alpha(child_alpha)
+                    };
+
+                    children_bytes.extend_from_slice(child.as_ref());
+                }
+
+                top_half_store
+                    .write()
+                    .unwrap()
+                    .copy_from_slice(&children_bytes, write_start);
+            });
+        }
+
+        let leaves_store = Arc::try_unwrap(leaves_store).unwrap().into_inner().unwrap();
+
+        let top_half_store = Arc::try_unwrap(top_half_store)
+            .unwrap()
+            .into_inner()
+            .unwrap();
+
+        // `Store.read_at()` always returns `HybridDomain::Alpha`, if necessary convert it to
+        // `HybridDomain::Beta`.
+        let root = {
+            let read_at = top_half_store.len() - 1;
+            let root_alpha = top_half_store.read_at(read_at);
+
+            if beta_height > height {
+                root_alpha.into_beta()
+            } else {
+                root_alpha
+            }
+        };
+
+        HybridMerkleTree {
+            n_leaves,
+            height,
+            beta_height,
+            n_beta_nodes,
+            leaves_store,
+            top_half_store,
+            root,
+            _ah: PhantomData,
+            _bh: PhantomData,
+        }
+    }
+
+    fn build_small_tree(
+        leaves_store: HybridStore<AH::Domain, BH::Domain>,
+        mut top_half_store: HybridStore<AH::Domain, BH::Domain>,
+        n_leaves: usize,
+        beta_height: usize,
+        n_beta_nodes: usize,
+    ) -> Self {
+        let height = (n_leaves as f32).log2() as usize;
+        let n_layers = height + 1;
+
+        let layer_index = 0;
+        let second_layer_is_seam = beta_height == 1;
+
+        let second_layer: Vec<HybridDomain<AH::Domain, BH::Domain>> = leaves_store
+            .read_range(0..n_leaves)
+            .par_chunks(2)
+            .map(|pair| {
+                if second_layer_is_seam {
+                    // `Store.read_range()` always returns `HybridDomain::Alpha`s (because it call
+                    // `HybridDomain::from_slice` under the hood) so we must convert the alphas to
+                    // betas before passing them into the beta hasher.
+                    let left_beta = *pair[0].into_beta().beta_value();
+                    let right_beta = *pair[1].into_beta().beta_value();
+                    let child_beta =
+                        BH::Function::default().node(left_beta, right_beta, layer_index);
+                    let child_alpha = AH::Domain::from_slice(child_beta.as_ref());
+                    HybridDomain::Alpha(child_alpha)
+                } else if layer_index < beta_height {
+                    // `Store.read_range()` always returns `HybridDomain::Alpha`s (because it call
+                    // `HybridDomain::from_slice` under the hood) so we must convert the alphas to
+                    // betas before passing them into the beta hasher.
+                    let left_beta = *pair[0].into_beta().beta_value();
+                    let right_beta = *pair[1].into_beta().beta_value();
+                    let child_beta =
+                        BH::Function::default().node(left_beta, right_beta, layer_index);
+                    HybridDomain::Beta(child_beta)
+                } else {
+                    let left_alpha = *pair[0].alpha_value();
+                    let right_alpha = *pair[1].alpha_value();
+                    let child_alpha =
+                        AH::Function::default().node(left_alpha, right_alpha, layer_index);
+                    HybridDomain::Alpha(child_alpha)
+                }
+            })
+            .collect();
+
+        for (i, node) in second_layer.into_iter().enumerate() {
+            top_half_store.write_at(node, i);
+        }
+
+        for layer_index in 1..n_layers - 1 {
+            let n_nodes_written_in_top_half = top_half_store.len();
+            let n_nodes_in_layer = n_leaves >> layer_index;
+
+            let read_start = n_nodes_written_in_top_half - n_nodes_in_layer;
+            let read_stop = n_nodes_written_in_top_half;
+            let write_start = n_nodes_written_in_top_half;
+
+            let next_layer_is_seam = layer_index + 1 == beta_height;
+
+            let next_layer: Vec<HybridDomain<AH::Domain, BH::Domain>> = top_half_store
+                .read_range(read_start..read_stop)
+                .par_chunks(2)
+                .map(|pair| {
+                    if next_layer_is_seam {
+                        // `Store.read_range()` always returns `HybridDomain::Alpha`s (because it
+                        // call `HybridDomain::from_slice` under the hood) so we must convert the
+                        // alphas to betas before passing them into the beta hasher.
+                        let left_beta = *pair[0].into_beta().beta_value();
+                        let right_beta = *pair[1].into_beta().beta_value();
+                        let child_beta =
+                            BH::Function::default().node(left_beta, right_beta, layer_index);
+                        let child_alpha = AH::Domain::from_slice(child_beta.as_ref());
+                        HybridDomain::Alpha(child_alpha)
+                    } else if layer_index < beta_height {
+                        // `Store.read_range()` always returns `HybridDomain::Alpha`s (because it
+                        // call `HybridDomain::from_slice` under the hood) so we must convert the
+                        // alphas to betas before passing them into the beta hasher.
+                        let left_beta = *pair[0].into_beta().beta_value();
+                        let right_beta = *pair[1].into_beta().beta_value();
+                        let child_beta =
+                            BH::Function::default().node(left_beta, right_beta, layer_index);
+                        HybridDomain::Beta(child_beta)
+                    } else {
+                        let left_alpha = *pair[0].alpha_value();
+                        let right_alpha = *pair[1].alpha_value();
+                        let child_alpha =
+                            AH::Function::default().node(left_alpha, right_alpha, layer_index);
+                        HybridDomain::Alpha(child_alpha)
+                    }
+                })
+                .collect();
+
+            for (i, node) in next_layer.into_iter().enumerate() {
+                top_half_store.write_at(node, write_start + i);
+            }
+        }
+
+        // `Store.read_at()` always returns `HybridDomain::Alpha`, if necessary convert it to
+        // `HybridDomain::Beta`.
+        let root = {
+            let read_at = top_half_store.len() - 1;
+            let root_alpha = top_half_store.read_at(read_at);
+
+            if beta_height > height {
+                root_alpha.into_beta()
+            } else {
+                root_alpha
+            }
+        };
+
+        HybridMerkleTree {
+            n_leaves,
+            height,
+            beta_height,
+            n_beta_nodes,
+            leaves_store,
+            top_half_store,
+            root,
+            _ah: PhantomData,
+            _bh: PhantomData,
+        }
+    }
+
+    pub fn read_at(&self, node_index: usize) -> HybridDomain<AH::Domain, BH::Domain> {
+        // Calling `Store.read_at()` always returns an `HybridDomain::Alpha`.
+        let alpha_node = if self.is_leaf(node_index) {
+            self.leaves_store.read_at(node_index)
+        } else {
+            self.top_half_store.read_at(node_index - self.n_leaves)
+        };
+
+        let convert_to_beta = node_index < self.n_beta_nodes;
+
+        if convert_to_beta {
+            alpha_node.into_beta()
+        } else {
+            alpha_node
+        }
+    }
+
+    pub fn read_into(&self, node_index: usize, dest: &mut [u8]) {
+        // `self.read_at()` returns the correct variant of `HybridDomain` (unlike
+        // `Store::read_at()`) so no `HybridDomain` variant conversion is necessary.
+        self.read_at(node_index).copy_to_slice(dest)
+    }
+
+    pub fn gen_proof(&self, challenge_index: usize) -> HybridMerkleProof<AH, BH> {
+        assert!(self.is_leaf(challenge_index));
+
+        let challenge_value = self.read_at(challenge_index);
+
+        let path_len = self.height;
+        let mut path = Vec::with_capacity(path_len);
+
+        let first_sibling_index = get_sibling(challenge_index);
+        let first_sibling_value = self.read_at(first_sibling_index);
+        let first_sibling_is_left = is_left_input(first_sibling_index);
+        path.push((first_sibling_value, first_sibling_is_left));
+
+        let mut first_node_in_next_layer = self.n_leaves;
+        let mut child_index = first_node_in_next_layer + challenge_index / 2;
+
+        for layer_index in 1..path_len {
+            let curr_index = child_index;
+            let sibling_index = get_sibling(curr_index);
+            let sibling_value = self.read_at(sibling_index);
+            let sibling_is_left = is_left_input(sibling_index);
+            path.push((sibling_value, sibling_is_left));
+
+            let n_nodes_in_layer = self.n_leaves >> layer_index;
+            let index_in_layer = curr_index % n_nodes_in_layer;
+            first_node_in_next_layer += n_nodes_in_layer;
+            child_index = first_node_in_next_layer + index_in_layer / 2;
+        }
+
+        HybridMerkleProof {
+            challenge_value,
+            path,
+            root: self.root,
+            beta_height: self.beta_height,
+            _ah: PhantomData,
+            _bh: PhantomData,
+        }
+    }
+
+    pub fn try_offload_store(&self) -> bool {
+        self.leaves_store.try_offload() && self.top_half_store.try_offload()
+    }
+
+    #[inline]
+    pub fn root(&self) -> HybridDomain<AH::Domain, BH::Domain> {
+        self.root
+    }
+
+    #[inline]
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    #[inline]
+    pub fn beta_height(&self) -> usize {
+        self.beta_height
+    }
+
+    #[inline]
+    pub fn n_nodes(&self) -> usize {
+        self.leaves_store.len() + self.top_half_store.len()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.n_nodes()
+    }
+
+    #[inline]
+    pub fn n_leaves(&self) -> usize {
+        self.n_leaves
+    }
+
+    #[inline]
+    pub fn leafs(&self) -> usize {
+        self.n_leaves
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.leaves_store.is_empty() && self.top_half_store.is_empty()
+    }
+
+    /// Returns whether or not the node at `node_index` is a leaf in the tree.
+    #[inline]
+    fn is_leaf(&self, node_index: usize) -> bool {
+        node_index < self.n_leaves
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct HybridMerkleProof<AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    challenge_value: HybridDomain<AH::Domain, BH::Domain>,
+    #[allow(clippy::type_complexity)]
+    path: Vec<(HybridDomain<AH::Domain, BH::Domain>, bool)>,
+    root: HybridDomain<AH::Domain, BH::Domain>,
+    beta_height: usize,
+
+    #[serde(skip)]
+    _ah: PhantomData<AH>,
+
+    #[serde(skip)]
+    _bh: PhantomData<BH>,
+}
+
+impl<AH, BH> HybridMerkleProof<AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    // Used in tests. Equivalent to `crate::merkle::make_proof_for_test`.
+    #[allow(clippy::type_complexity)]
+    pub fn new(
+        challenge_value: HybridDomain<AH::Domain, BH::Domain>,
+        path: Vec<(HybridDomain<AH::Domain, BH::Domain>, bool)>,
+        root: HybridDomain<AH::Domain, BH::Domain>,
+        beta_height: usize,
+    ) -> Self {
+        HybridMerkleProof {
+            challenge_value,
+            path,
+            root,
+            beta_height,
+            _ah: PhantomData,
+            _bh: PhantomData,
+        }
+    }
+
+    pub fn new_empty(height: usize) -> Self {
+        let path = vec![(HybridDomain::default(), false); height];
+        HybridMerkleProof {
+            path,
+            ..Default::default()
+        }
+    }
+
+    /// Given the challenge's node index, returns whether or not the "is_left" bits in the proof's
+    /// path are correct.
+    fn left_bits_match_challenge(&self, challenge_index: usize) -> bool {
+        let mut index_in_layer = challenge_index;
+
+        for (_, path_elem_is_left) in self.path.iter() {
+            if is_right_input(index_in_layer) != *path_elem_is_left {
+                return false;
+            }
+            index_in_layer >>= 1;
+        }
+
+        true
+    }
+
+    /// Checks if the path in this proof corresponds to the challenge leaf `challenge_index` and
+    /// checks that reconstructing the path results in the this proof's root.
+    pub fn validate(&self, challenge_index: usize) -> bool {
+        if !self.left_bits_match_challenge(challenge_index) {
+            return false;
+        }
+
+        let layer_index = 0;
+        let (sibling, sibling_is_left) = self.path[0];
+
+        let (left, right) = if sibling_is_left {
+            (sibling, self.challenge_value)
+        } else {
+            (self.challenge_value, sibling)
+        };
+
+        let mut child = if self.beta_height == 0 {
+            let left_alpha = *left.alpha_value();
+            let right_alpha = *right.alpha_value();
+            let child_alpha = AH::Function::default().node(left_alpha, right_alpha, layer_index);
+            HybridDomain::Alpha(child_alpha)
+        } else if self.beta_height == 1 {
+            let left_beta = *left.beta_value();
+            let right_beta = *right.beta_value();
+            let child_beta = BH::Function::default().node(left_beta, right_beta, layer_index);
+            let child_alpha = AH::Domain::from_slice(child_beta.as_ref());
+            HybridDomain::Alpha(child_alpha)
+        } else {
+            let left_beta = *left.beta_value();
+            let right_beta = *right.beta_value();
+            let child_beta = BH::Function::default().node(left_beta, right_beta, layer_index);
+            HybridDomain::Beta(child_beta)
+        };
+
+        for (layer_index, (sibling, sibling_is_left)) in self.path.iter().enumerate().skip(1) {
+            let (left, right) = if *sibling_is_left {
+                (sibling, &child)
+            } else {
+                (&child, sibling)
+            };
+
+            let next_layer_is_seam = self.beta_height == layer_index + 1;
+
+            child = if next_layer_is_seam {
+                let left_beta = *left.beta_value();
+                let right_beta = *right.beta_value();
+                let child_beta = BH::Function::default().node(left_beta, right_beta, layer_index);
+                let child_alpha = AH::Domain::from_slice(child_beta.as_ref());
+                HybridDomain::Alpha(child_alpha)
+            } else if layer_index < self.beta_height {
+                let left_beta = *left.beta_value();
+                let right_beta = *right.beta_value();
+                let child_beta = BH::Function::default().node(left_beta, right_beta, layer_index);
+                HybridDomain::Beta(child_beta)
+            } else {
+                let left_alpha = *left.alpha_value();
+                let right_alpha = *right.alpha_value();
+                let child_alpha =
+                    AH::Function::default().node(left_alpha, right_alpha, layer_index);
+                HybridDomain::Alpha(child_alpha)
+            };
+        }
+
+        let calculated_root = child;
+        self.root == calculated_root
+    }
+
+    /// Checks that `data` matches the challenge leaf's value in the tree. Equivalent to
+    /// `crate::merkle::MerkleProof::validate_data()`.
+    pub fn challenge_value_matches_bytes(&self, bytes: &[u8]) -> bool {
+        self.challenge_value.as_ref() == bytes
+    }
+
+    pub fn leaf(&self) -> &HybridDomain<AH::Domain, BH::Domain> {
+        &self.challenge_value
+    }
+
+    pub fn root(&self) -> &HybridDomain<AH::Domain, BH::Domain> {
+        &self.root
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn path(&self) -> &[(HybridDomain<AH::Domain, BH::Domain>, bool)] {
+        &self.path
+    }
+
+    pub fn beta_height(&self) -> usize {
+        self.beta_height
+    }
+
+    /// Returns the number of elements in the proof; the number of path elements plus 2 for the leaf
+    /// and root elements.
+    pub fn path_len(&self) -> usize {
+        self.path.len()
+    }
+
+    /// Serializes this proof into bytes.
+    pub fn serialize(&self) -> Vec<u8> {
+        let mut bytes: Vec<u8> = vec![];
+
+        for (path_elem, path_elem_is_left) in self.path.iter() {
+            bytes.extend_from_slice(path_elem.as_ref());
+            bytes.push(*path_elem_is_left as u8);
+        }
+
+        bytes.extend_from_slice(self.challenge_value.as_ref());
+        bytes.extend_from_slice(self.root.as_ref());
+        bytes
+    }
+
+    /// Convert the path into the format expected by the circuits; a vector of `Option`s of tuples.
+    /// The returned vector does not include the challenge leaf and root values.
+    ///
+    /// Equivalent to `crate::merkle::MerkleProof::as_options()`.
+    pub fn as_circuit_auth_path(&self) -> Vec<Option<(Fr, bool)>> {
+        self.path
+            .iter()
+            .enumerate()
+            .map(|(layer_index, (path_elem, path_elem_is_left))| {
+                let path_elem = if layer_index < self.beta_height {
+                    (*path_elem.beta_value()).into()
+                } else {
+                    (*path_elem.alpha_value()).into()
+                };
+                Some((path_elem, *path_elem_is_left))
+            })
+            .collect()
+    }
+
+    /// Iterates over the proof path bookended with the root. Only used in Piece Inclusion Proofs.
+    pub fn path_with_root(&self) -> impl Iterator<Item = &HybridDomain<AH::Domain, BH::Domain>> {
+        self.path
+            .iter()
+            .map(|(path_elem, _)| path_elem)
+            .chain(iter::once(&self.root))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter;
+
+    use merkletree::hash::Algorithm;
+    use merkletree::merkle::Element;
+    use rand::{thread_rng, Rng};
+
+    use crate::hasher::blake2s::{Blake2sDomain, Blake2sFunction, Blake2sHasher};
+    use crate::hasher::hybrid::HybridDomain;
+    use crate::hasher::pedersen::{PedersenDomain, PedersenFunction, PedersenHasher};
+    use crate::hybrid_merkle::HybridMerkleTree;
+
+    const N_LEAVES: usize = 16;
+    const HEIGHT: usize = 4;
+    const N_NODES: usize = 31;
+    const CHALLENGES: [usize; 4] = [0, 7, 10, 15];
+
+    lazy_static! {
+        static ref ALPHA_LEAVES: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = {
+            let mut rng = thread_rng();
+            (0..N_LEAVES)
+                .map(|_| HybridDomain::Alpha(rng.gen()))
+                .collect()
+        };
+        static ref BETA_LEAVES: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = {
+            let mut rng = thread_rng();
+            (0..N_LEAVES)
+                .map(|_| HybridDomain::Beta(rng.gen()))
+                .collect()
+        };
+    }
+
+    fn expected_alpha_only_nodes() -> Vec<HybridDomain<PedersenDomain, Blake2sDomain>> {
+        let layer_0 = ALPHA_LEAVES.clone();
+
+        let layer_1: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_0
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].alpha_value().clone();
+                let right = pair[1].alpha_value().clone();
+                let alpha_value = PedersenFunction::default().node(left, right, 0);
+                HybridDomain::Alpha(alpha_value)
+            })
+            .collect();
+
+        let layer_2: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_1
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].alpha_value().clone();
+                let right = pair[1].alpha_value().clone();
+                let alpha_value = PedersenFunction::default().node(left, right, 1);
+                HybridDomain::Alpha(alpha_value)
+            })
+            .collect();
+
+        let layer_3: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_2
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].alpha_value().clone();
+                let right = pair[1].alpha_value().clone();
+                let alpha_value = PedersenFunction::default().node(left, right, 2);
+                HybridDomain::Alpha(alpha_value)
+            })
+            .collect();
+
+        let root: HybridDomain<PedersenDomain, Blake2sDomain> = {
+            let layer_3_len = layer_3.len();
+            let left = layer_3[layer_3_len - 2].alpha_value().clone();
+            let right = layer_3[layer_3_len - 1].alpha_value().clone();
+            let alpha_value = PedersenFunction::default().node(left, right, 3);
+            HybridDomain::Alpha(alpha_value)
+        };
+
+        layer_0
+            .into_iter()
+            .chain(layer_1.into_iter())
+            .chain(layer_2.into_iter())
+            .chain(layer_3.into_iter())
+            .chain(iter::once(root))
+            .collect()
+    }
+
+    fn expected_beta_only_nodes() -> Vec<HybridDomain<PedersenDomain, Blake2sDomain>> {
+        let layer_0 = BETA_LEAVES.clone();
+
+        let layer_1: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_0
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].beta_value().clone();
+                let right = pair[1].beta_value().clone();
+                let beta_value = Blake2sFunction::default().node(left, right, 0);
+                HybridDomain::Beta(beta_value)
+            })
+            .collect();
+
+        let layer_2: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_1
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].beta_value().clone();
+                let right = pair[1].beta_value().clone();
+                let beta_value = Blake2sFunction::default().node(left, right, 1);
+                HybridDomain::Beta(beta_value)
+            })
+            .collect();
+
+        let layer_3: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_2
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].beta_value().clone();
+                let right = pair[1].beta_value().clone();
+                let beta_value = Blake2sFunction::default().node(left, right, 2);
+                HybridDomain::Beta(beta_value)
+            })
+            .collect();
+
+        let root: HybridDomain<PedersenDomain, Blake2sDomain> = {
+            let layer_3_len = layer_3.len();
+            let left = layer_3[layer_3_len - 2].beta_value().clone();
+            let right = layer_3[layer_3_len - 1].beta_value().clone();
+            let beta_value = Blake2sFunction::default().node(left, right, 3);
+            HybridDomain::Beta(beta_value)
+        };
+
+        layer_0
+            .into_iter()
+            .chain(layer_1.into_iter())
+            .chain(layer_2.into_iter())
+            .chain(layer_3.into_iter())
+            .chain(iter::once(root))
+            .collect()
+    }
+
+    fn expected_nodes_with_beta_height_2() -> Vec<HybridDomain<PedersenDomain, Blake2sDomain>> {
+        let layer_0 = BETA_LEAVES.clone();
+
+        let layer_1: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_0
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].beta_value().clone();
+                let right = pair[1].beta_value().clone();
+                let beta_value = Blake2sFunction::default().node(left, right, 0);
+                HybridDomain::Beta(beta_value)
+            })
+            .collect();
+
+        let layer_2: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_1
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].beta_value().clone();
+                let right = pair[1].beta_value().clone();
+                let beta_value = Blake2sFunction::default().node(left, right, 1);
+                let alpha_value = PedersenDomain::from_slice(beta_value.as_ref());
+                HybridDomain::Alpha(alpha_value)
+            })
+            .collect();
+
+        let layer_3: Vec<HybridDomain<PedersenDomain, Blake2sDomain>> = layer_2
+            .chunks(2)
+            .map(|pair| {
+                let left = pair[0].alpha_value().clone();
+                let right = pair[1].alpha_value().clone();
+                let alpha_value = PedersenFunction::default().node(left, right, 2);
+                HybridDomain::Alpha(alpha_value)
+            })
+            .collect();
+
+        let root: HybridDomain<PedersenDomain, Blake2sDomain> = {
+            let layer_3_len = layer_3.len();
+            let left = layer_3[layer_3_len - 2].alpha_value().clone();
+            let right = layer_3[layer_3_len - 1].alpha_value().clone();
+            let alpha_value = PedersenFunction::default().node(left, right, 3);
+            HybridDomain::Alpha(alpha_value)
+        };
+
+        layer_0
+            .into_iter()
+            .chain(layer_1.into_iter())
+            .chain(layer_2.into_iter())
+            .chain(layer_3.into_iter())
+            .chain(iter::once(root))
+            .collect()
+    }
+
+    #[test]
+    fn test_hybrid_merkle_tree_alpha_only() {
+        let leaves = (*ALPHA_LEAVES).clone();
+        let tree = HybridMerkleTree::<PedersenHasher, Blake2sHasher>::from_leaves(leaves, 0);
+        assert_eq!(tree.n_nodes(), N_NODES);
+
+        let expected_nodes = expected_alpha_only_nodes();
+
+        for node_index in 0..N_NODES {
+            let tree_node = tree.read_at(node_index);
+            let expected_node = expected_nodes[node_index];
+            assert_eq!(tree_node, expected_node);
+        }
+
+        for challenge_index in CHALLENGES.iter() {
+            let proof = tree.gen_proof(*challenge_index);
+            assert!(proof.validate(*challenge_index));
+        }
+    }
+
+    #[test]
+    fn test_hybrid_merkle_tree_beta_only() {
+        let leaves = (*BETA_LEAVES).clone();
+        let tree =
+            HybridMerkleTree::<PedersenHasher, Blake2sHasher>::from_leaves(leaves, HEIGHT + 1);
+        assert_eq!(tree.n_nodes(), N_NODES);
+
+        let expected_nodes = expected_beta_only_nodes();
+
+        for node_index in 0..N_NODES {
+            let tree_node = tree.read_at(node_index);
+            let expected_node = expected_nodes[node_index];
+            assert_eq!(tree_node, expected_node);
+        }
+
+        for challenge_index in CHALLENGES.iter() {
+            let proof = tree.gen_proof(*challenge_index);
+            assert!(proof.validate(*challenge_index));
+        }
+    }
+
+    #[test]
+    fn test_hybrid_merkle_tree_seam_root() {
+        let leaves = (*BETA_LEAVES).clone();
+        let tree = HybridMerkleTree::<PedersenHasher, Blake2sHasher>::from_leaves(leaves, HEIGHT);
+        assert_eq!(tree.n_nodes(), N_NODES);
+
+        let expected_nodes = expected_beta_only_nodes();
+
+        for node_index in 0..N_NODES - 1 {
+            let tree_node = tree.read_at(node_index);
+            let expected_node = expected_nodes[node_index];
+            assert_eq!(tree_node, expected_node);
+        }
+
+        let expected_alpha_root = expected_nodes[N_NODES - 1].into_alpha();
+        assert_eq!(tree.root(), expected_alpha_root);
+
+        for challenge_index in CHALLENGES.iter() {
+            let proof = tree.gen_proof(*challenge_index);
+            assert!(proof.validate(*challenge_index));
+        }
+    }
+
+    #[test]
+    fn test_hybrid_merkle_tree_with_seam() {
+        const BETA_HEIGHT: usize = 2;
+
+        let leaves = (*BETA_LEAVES).clone();
+        let tree =
+            HybridMerkleTree::<PedersenHasher, Blake2sHasher>::from_leaves(leaves, BETA_HEIGHT);
+        assert_eq!(tree.n_nodes(), N_NODES);
+
+        let expected_nodes = expected_nodes_with_beta_height_2();
+
+        for node_index in 0..N_NODES {
+            let tree_node = tree.read_at(node_index);
+            let expected_node = expected_nodes[node_index];
+            assert_eq!(tree_node, expected_node);
+        }
+
+        for challenge_index in CHALLENGES.iter() {
+            let proof = tree.gen_proof(*challenge_index);
+            assert!(proof.validate(*challenge_index));
+        }
+    }
+}

--- a/storage-proofs/src/hybrid_merklepor.rs
+++ b/storage-proofs/src/hybrid_merklepor.rs
@@ -1,0 +1,401 @@
+use std::marker::PhantomData;
+
+use crate::drgporep::DataProof;
+use crate::drgraph::graph_height;
+use crate::error::{Error, Result};
+use crate::hasher::hybrid::HybridDomain;
+use crate::hasher::{Domain, Hasher};
+use crate::hybrid_merkle::HybridMerkleTree;
+use crate::parameter_cache::ParameterSetMetadata;
+use crate::proof::{NoRequirements, ProofScheme};
+
+/// The parameters shared between the prover and verifier.
+#[derive(Clone, Debug)]
+pub struct PublicParams {
+    /// How many leaves the underlying merkle tree has.
+    pub leaves: usize,
+    pub beta_height: usize,
+    pub private: bool,
+}
+
+impl ParameterSetMetadata for PublicParams {
+    fn identifier(&self) -> String {
+        format!(
+            "merklepor::PublicParams{{leaves: {}; beta_height: {}, private: {}}}",
+            self.leaves, self.beta_height, self.private
+        )
+    }
+
+    fn sector_size(&self) -> u64 {
+        unimplemented!("required for parameter metadata file generation")
+    }
+}
+
+/// The inputs that are necessary for the verifier to verify the proof.
+#[derive(Debug, Clone)]
+pub struct PublicInputs<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    /// The root hash of the underlying merkle tree.
+    pub commitment: Option<HybridDomain<AD, BD>>,
+    /// The challenge, which leaf to prove.
+    pub challenge: usize,
+}
+
+/// The inputs that are only available to the prover.
+#[derive(Debug)]
+pub struct PrivateInputs<'a, AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    /// The data of the leaf.
+    pub leaf: HybridDomain<AH::Domain, BH::Domain>,
+    /// The underlying merkle tree.
+    pub tree: &'a HybridMerkleTree<AH, BH>,
+    _ah: PhantomData<AH>,
+    _bh: PhantomData<BH>,
+}
+
+impl<'a, AH, BH> PrivateInputs<'a, AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    pub fn new(
+        leaf: HybridDomain<AH::Domain, BH::Domain>,
+        tree: &'a HybridMerkleTree<AH, BH>,
+    ) -> Self {
+        PrivateInputs {
+            leaf,
+            tree,
+            _ah: PhantomData,
+            _bh: PhantomData,
+        }
+    }
+}
+
+/// The proof that is returned from `prove`.
+pub type Proof<AH, BH> = DataProof<AH, BH>;
+
+#[derive(Debug)]
+pub struct SetupParams {
+    pub leaves: usize,
+    pub beta_height: usize,
+    pub private: bool,
+}
+
+/// Merkle tree based proof of retrievability.
+#[derive(Debug, Default)]
+pub struct HybridMerklePoR<AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    _ah: PhantomData<AH>,
+    _bh: PhantomData<BH>,
+}
+
+impl<'a, AH, BH> ProofScheme<'a> for HybridMerklePoR<AH, BH>
+where
+    AH: 'static + Hasher,
+    BH: 'static + Hasher,
+{
+    type PublicParams = PublicParams;
+    type SetupParams = SetupParams;
+    type PublicInputs = PublicInputs<AH::Domain, BH::Domain>;
+    type PrivateInputs = PrivateInputs<'a, AH, BH>;
+    type Proof = Proof<AH, BH>;
+    type Requirements = NoRequirements;
+
+    fn setup(sp: &SetupParams) -> Result<PublicParams> {
+        Ok(PublicParams {
+            leaves: sp.leaves,
+            beta_height: sp.beta_height,
+            private: sp.private,
+        })
+    }
+
+    fn prove<'b>(
+        pub_params: &'b Self::PublicParams,
+        pub_inputs: &'b Self::PublicInputs,
+        priv_inputs: &'b Self::PrivateInputs,
+    ) -> Result<Self::Proof> {
+        let challenge = pub_inputs.challenge % pub_params.leaves;
+        let tree = priv_inputs.tree;
+
+        if let Some(ref commitment) = pub_inputs.commitment {
+            if commitment != &tree.root() {
+                return Err(Error::InvalidCommitment);
+            }
+        }
+
+        Ok(Proof {
+            proof: tree.gen_proof(challenge),
+            data: priv_inputs.leaf,
+        })
+    }
+
+    fn verify(
+        pub_params: &Self::PublicParams,
+        pub_inputs: &Self::PublicInputs,
+        proof: &Self::Proof,
+    ) -> Result<bool> {
+        let commitments_match = match pub_inputs.commitment {
+            Some(ref commitment) => commitment == proof.proof.root(),
+            None => true,
+        };
+
+        if !commitments_match {
+            return Ok(false);
+        }
+
+        let path_lengths_match = graph_height(pub_params.leaves) == proof.proof.path_len();
+
+        if !path_lengths_match {
+            return Ok(false);
+        }
+
+        let challenge_bytes_match = proof
+            .proof
+            .challenge_value_matches_bytes(&proof.data.as_ref());
+
+        if !challenge_bytes_match {
+            return Ok(false);
+        }
+
+        let is_valid = proof.proof.validate(pub_inputs.challenge);
+        Ok(is_valid)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use paired::bls12_381::Bls12;
+    use rand::{Rng, SeedableRng, XorShiftRng};
+
+    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::fr32::fr_into_bytes;
+    use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
+    use crate::hybrid_merkle::HybridMerkleProof;
+    use crate::util::data_at_node;
+
+    const N_LEAVES: usize = 32;
+    const BETA_HEIGHT: usize = 1;
+
+    fn test_merklepor<AH, BH>()
+    where
+        AH: 'static + Hasher,
+        BH: 'static + Hasher,
+    {
+        let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+
+        let pub_params = PublicParams {
+            leaves: N_LEAVES,
+            beta_height: BETA_HEIGHT,
+            private: false,
+        };
+
+        let data: Vec<u8> = (0..N_LEAVES)
+            .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
+            .collect();
+
+        let graph = BucketGraph::<AH, BH>::new(N_LEAVES, 5, 0, new_seed());
+        let tree = graph.hybrid_merkle_tree(&data, BETA_HEIGHT).unwrap();
+
+        let pub_inputs = PublicInputs {
+            challenge: 3,
+            commitment: Some(tree.root()),
+        };
+
+        // `BETA_HEIGHT` is set to 1, therefore each leaf will be a `HybridDomain::Beta`.
+        let leaf = {
+            let leaf_data = data_at_node(&data, pub_inputs.challenge).unwrap();
+            let leaf_beta = BH::Domain::try_from_bytes(leaf_data).unwrap();
+            HybridDomain::Beta(leaf_beta)
+        };
+
+        let priv_inputs = PrivateInputs::<AH, BH>::new(leaf, &tree);
+
+        let proof = HybridMerklePoR::<AH, BH>::prove(&pub_params, &pub_inputs, &priv_inputs)
+            .expect("proving failed");
+
+        let is_valid = HybridMerklePoR::<AH, BH>::verify(&pub_params, &pub_inputs, &proof)
+            .expect("verification failed");
+
+        assert!(is_valid);
+    }
+
+    #[test]
+    fn merklepor_pedersen() {
+        test_merklepor::<PedersenHasher, PedersenHasher>();
+    }
+
+    #[test]
+    fn merklepor_sha256() {
+        test_merklepor::<Sha256Hasher, Sha256Hasher>();
+    }
+
+    #[test]
+    fn merklepor_blake2s() {
+        test_merklepor::<Blake2sHasher, Blake2sHasher>();
+    }
+
+    #[test]
+    fn merklepor_pedersen_blake2s() {
+        test_merklepor::<PedersenHasher, Blake2sHasher>();
+    }
+
+    // Construct a proof that satisfies a cursory validation:
+    // Data and proof are minimally consistent.
+    // Proof root matches that requested in public inputs.
+    // However, note that data has no relationship to anything,
+    // and proof path does not actually prove that data was in the tree corresponding to expected root.
+    fn make_bogus_proof<AH, BH>(
+        pub_inputs: &PublicInputs<AH::Domain, BH::Domain>,
+        rng: &mut XorShiftRng,
+    ) -> Proof<AH, BH>
+    where
+        AH: Hasher,
+        BH: Hasher,
+    {
+        // Beta height is 1, so leaves are `Hybrid::Beta`s.
+        let leaf: HybridDomain<AH::Domain, BH::Domain> = HybridDomain::Beta(rng.gen());
+        let merkle_path = vec![(leaf, true)];
+        let root = pub_inputs.commitment.unwrap();
+        let merkle_proof = HybridMerkleProof::new(leaf, merkle_path, root, BETA_HEIGHT);
+
+        Proof {
+            data: leaf,
+            proof: merkle_proof,
+        }
+    }
+
+    fn test_merklepor_validates<AH, BH>()
+    where
+        AH: 'static + Hasher,
+        BH: 'static + Hasher,
+    {
+        let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+
+        let pub_params = PublicParams {
+            leaves: N_LEAVES,
+            beta_height: BETA_HEIGHT,
+            private: false,
+        };
+
+        let data: Vec<u8> = (0..N_LEAVES)
+            .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
+            .collect();
+
+        let graph = BucketGraph::<AH, BH>::new(N_LEAVES, 5, 0, new_seed());
+        let tree = graph.hybrid_merkle_tree(&data, BETA_HEIGHT).unwrap();
+
+        let pub_inputs = PublicInputs {
+            challenge: 3,
+            commitment: Some(tree.root()),
+        };
+
+        let bad_proof = make_bogus_proof::<AH, BH>(&pub_inputs, rng);
+
+        let verified = HybridMerklePoR::verify(&pub_params, &pub_inputs, &bad_proof)
+            .expect("verification failed");
+
+        // A bad proof should not be verified!
+        assert!(!verified);
+    }
+
+    #[test]
+    fn merklepor_actually_validates_sha256() {
+        test_merklepor_validates::<Sha256Hasher, Sha256Hasher>();
+    }
+
+    #[test]
+    fn merklepor_actually_validates_blake2s() {
+        test_merklepor_validates::<Blake2sHasher, Blake2sHasher>();
+    }
+
+    #[test]
+    fn merklepor_actually_validates_pedersen() {
+        test_merklepor_validates::<PedersenHasher, PedersenHasher>();
+    }
+
+    #[test]
+    fn merklepor_actually_validates_pedersen_blake2s() {
+        test_merklepor_validates::<PedersenHasher, Blake2sHasher>();
+    }
+
+    fn test_merklepor_validates_challenge_identity<AH, BH>()
+    where
+        AH: 'static + Hasher,
+        BH: 'static + Hasher,
+    {
+        let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+
+        let pub_params = PublicParams {
+            leaves: N_LEAVES,
+            beta_height: BETA_HEIGHT,
+            private: false,
+        };
+
+        let data: Vec<u8> = (0..N_LEAVES)
+            .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
+            .collect();
+
+        let graph = BucketGraph::<AH, BH>::new(N_LEAVES, 5, 0, new_seed());
+        let tree = graph.hybrid_merkle_tree(&data, BETA_HEIGHT).unwrap();
+
+        let pub_inputs = PublicInputs {
+            challenge: 3,
+            commitment: Some(tree.root()),
+        };
+
+        // Beta height is set to 1, therefore each leaf will be a `HybridDomain::Beta`.
+        let leaf = {
+            let leaf_data = data_at_node(&data, pub_inputs.challenge).unwrap();
+            let leaf_beta = BH::Domain::try_from_bytes(leaf_data).unwrap();
+            HybridDomain::Beta(leaf_beta)
+        };
+
+        let priv_inputs = PrivateInputs::<AH, BH>::new(leaf, &tree);
+
+        let proof = HybridMerklePoR::<AH, BH>::prove(&pub_params, &pub_inputs, &priv_inputs)
+            .expect("proving failed");
+
+        let different_pub_inputs = PublicInputs {
+            challenge: 999,
+            commitment: Some(tree.root()),
+        };
+
+        let verified =
+            HybridMerklePoR::<AH, BH>::verify(&pub_params, &different_pub_inputs, &proof)
+                .expect("verification failed");
+
+        // A proof created with the wrong challenge not be verified!
+        assert!(!verified);
+    }
+
+    #[test]
+    fn merklepor_actually_validates_challenge_identity_sha256() {
+        test_merklepor_validates_challenge_identity::<Sha256Hasher, Sha256Hasher>();
+    }
+
+    #[test]
+    fn merklepor_actually_validates_challenge_identity_blake2s() {
+        test_merklepor_validates_challenge_identity::<Blake2sHasher, Blake2sHasher>();
+    }
+
+    #[test]
+    fn merklepor_actually_validates_challenge_identity_pedersen() {
+        test_merklepor_validates_challenge_identity::<PedersenHasher, PedersenHasher>();
+    }
+
+    #[test]
+    fn merklepor_actually_validates_challenge_identity_pedersen_blake2s() {
+        test_merklepor_validates_challenge_identity::<PedersenHasher, Blake2sHasher>();
+    }
+}

--- a/storage-proofs/src/lib.rs
+++ b/storage-proofs/src/lib.rs
@@ -36,6 +36,8 @@ pub mod drgraph;
 pub mod error;
 pub mod fr32;
 pub mod hasher;
+pub mod hybrid_merkle;
+pub mod hybrid_merklepor;
 pub mod layered_drgporep;
 pub mod merkle;
 pub mod merklepor;

--- a/storage-proofs/src/porep.rs
+++ b/storage-proofs/src/porep.rs
@@ -1,6 +1,10 @@
+use serde::de::Deserialize;
+use serde::ser::Serialize;
+
 use crate::error::Result;
+use crate::hasher::hybrid::HybridDomain;
 use crate::hasher::{Domain, HashFunction, Hasher};
-use crate::merkle::MerkleTree;
+use crate::hybrid_merkle::HybridMerkleTree;
 use crate::proof::ProofScheme;
 
 #[derive(Debug)]
@@ -9,22 +13,43 @@ pub struct PublicParams {
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct Tau<T> {
-    pub comm_r: T,
-    pub comm_d: T,
+pub struct Tau<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    #[serde(bound(
+        serialize = "HybridDomain<AD, BD>: Serialize",
+        deserialize = "HybridDomain<AD, BD>: Deserialize<'de>"
+    ))]
+    pub comm_r: HybridDomain<AD, BD>,
+
+    #[serde(bound(
+        serialize = "HybridDomain<AD, BD>: Serialize",
+        deserialize = "HybridDomain<AD, BD>: Deserialize<'de>"
+    ))]
+    pub comm_d: HybridDomain<AD, BD>,
 }
 
-impl<T: Domain> Tau<T> {
-    pub fn new(comm_d: T, comm_r: T) -> Self {
+impl<AD, BD> Tau<AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
+    pub fn new(comm_d: HybridDomain<AD, BD>, comm_r: HybridDomain<AD, BD>) -> Self {
         Tau { comm_d, comm_r }
     }
 }
 
 #[derive(Debug)]
-pub struct PublicInputs<'a, T: Domain> {
+pub struct PublicInputs<'a, AD, BD>
+where
+    AD: Domain,
+    BD: Domain,
+{
     pub id: &'a [u8],
     pub r: usize,
-    pub tau: Tau<T>,
+    pub tau: Tau<AD, BD>,
 }
 
 #[derive(Debug)]
@@ -33,44 +58,56 @@ pub struct PrivateInputs<'a> {
 }
 
 #[derive(Debug, Clone)]
-pub struct ProverAux<H: Hasher> {
-    pub tree_d: MerkleTree<H::Domain, H::Function>,
-    pub tree_r: MerkleTree<H::Domain, H::Function>,
+pub struct ProverAux<AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    pub tree_d: HybridMerkleTree<AH, BH>,
+    pub tree_r: HybridMerkleTree<AH, BH>,
 }
 
-impl<H: Hasher> ProverAux<H> {
-    pub fn new(
-        tree_d: MerkleTree<H::Domain, H::Function>,
-        tree_r: MerkleTree<H::Domain, H::Function>,
-    ) -> Self {
+impl<AH, BH> ProverAux<AH, BH>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
+    pub fn new(tree_d: HybridMerkleTree<AH, BH>, tree_r: HybridMerkleTree<AH, BH>) -> Self {
         ProverAux { tree_d, tree_r }
     }
 }
 
-pub trait PoRep<'a, H: Hasher>: ProofScheme<'a> {
+pub trait PoRep<'a, AH, BH>: ProofScheme<'a>
+where
+    AH: Hasher,
+    BH: Hasher,
+{
     type Tau;
     type ProverAux;
 
     fn replicate(
         pub_params: &'a Self::PublicParams,
-        replica_id: &H::Domain,
+        replica_id: &HybridDomain<AH::Domain, BH::Domain>,
         data: &mut [u8],
-        data_tree: Option<MerkleTree<H::Domain, H::Function>>,
+        data_tree: Option<HybridMerkleTree<AH, BH>>,
     ) -> Result<(Self::Tau, Self::ProverAux)>;
 
     fn extract_all(
         pub_params: &'a Self::PublicParams,
-        replica_id: &H::Domain,
+        replica_id: &HybridDomain<AH::Domain, BH::Domain>,
         replica: &[u8],
     ) -> Result<Vec<u8>>;
+
     fn extract(
         pub_params: &'a Self::PublicParams,
-        replica_id: &H::Domain,
+        replica_id: &HybridDomain<AH::Domain, BH::Domain>,
         replica: &[u8],
         node: usize,
     ) -> Result<Vec<u8>>;
 }
 
+// The caller of this function is responsible for converting the returned `Domain` into the correct
+// `HybridDomain` variant because this function does not have access to the beta-height.
 pub fn replica_id<H: Hasher>(prover_id: [u8; 32], sector_id: [u8; 32]) -> H::Domain {
     let mut to_hash = [0; 64];
     to_hash[..32].copy_from_slice(&prover_id);

--- a/storage-proofs/src/zigzag_drgporep.rs
+++ b/storage-proofs/src/zigzag_drgporep.rs
@@ -18,27 +18,38 @@ use crate::zigzag_graph::{ZigZag, ZigZagBucketGraph};
 /// However, it is fortunately not necessary that the base DRG components also have this property.
 
 #[derive(Debug)]
-pub struct ZigZagDrgPoRep<'a, H: 'a + Hasher> {
-    _a: PhantomData<&'a H>,
+pub struct ZigZagDrgPoRep<'a, AH, BH>
+where
+    AH: 'a + Hasher,
+    BH: 'a + Hasher,
+{
+    _ah: PhantomData<&'a AH>,
+    _bh: PhantomData<&'a BH>,
 }
 
-impl<'a, H: 'static + Hasher> Layers for ZigZagDrgPoRep<'a, H> {
-    type Hasher = <ZigZagBucketGraph<H> as ZigZag>::BaseHasher;
-    type Graph = ZigZagBucketGraph<Self::Hasher>;
+impl<'a, AH, BH> Layers for ZigZagDrgPoRep<'a, AH, BH>
+where
+    AH: 'static + Hasher,
+    BH: 'static + Hasher,
+{
+    type AlphaHasher = <ZigZagBucketGraph<AH, BH> as ZigZag>::BaseAlphaHasher;
+    type BetaHasher = <ZigZagBucketGraph<AH, BH> as ZigZag>::BaseBetaHasher;
+    type Graph = ZigZagBucketGraph<Self::AlphaHasher, Self::BetaHasher>;
 
     fn transform(graph: &Self::Graph) -> Self::Graph {
-        zigzag::<Self::Hasher, Self::Graph>(graph)
+        zigzag::<Self::AlphaHasher, Self::BetaHasher, Self::Graph>(graph)
     }
 
     fn invert_transform(graph: &Self::Graph) -> Self::Graph {
-        zigzag::<Self::Hasher, Self::Graph>(graph)
+        zigzag::<Self::AlphaHasher, Self::BetaHasher, Self::Graph>(graph)
     }
 }
 
-fn zigzag<H, Z>(graph: &Z) -> Z
+fn zigzag<AH, BH, Z>(graph: &Z) -> Z
 where
-    H: Hasher,
-    Z: ZigZag + Graph<H> + ParameterSetMetadata,
+    AH: Hasher,
+    BH: Hasher,
+    Z: ZigZag + Graph<AH, BH> + ParameterSetMetadata,
 {
     graph.zigzag()
 }
@@ -53,34 +64,50 @@ mod tests {
     use crate::drgporep;
     use crate::drgraph::new_seed;
     use crate::fr32::fr_into_bytes;
+    use crate::hasher::hybrid::HybridDomain;
     use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
     use crate::layered_drgporep::{
         LayerChallenges, PrivateInputs, PublicInputs, PublicParams, SetupParams,
     };
     use crate::porep::PoRep;
     use crate::proof::ProofScheme;
+    use crate::util::NODE_SIZE;
 
     const DEFAULT_ZIGZAG_LAYERS: usize = 10;
+    const BETA_HEIGHTS: [usize; DEFAULT_ZIGZAG_LAYERS] = [1; DEFAULT_ZIGZAG_LAYERS];
 
     #[test]
     fn extract_all_pedersen() {
-        test_extract_all::<PedersenHasher>();
+        test_extract_all::<PedersenHasher, PedersenHasher>();
     }
 
     #[test]
     fn extract_all_sha256() {
-        test_extract_all::<Sha256Hasher>();
+        test_extract_all::<Sha256Hasher, Sha256Hasher>();
     }
 
     #[test]
     fn extract_all_blake2s() {
-        test_extract_all::<Blake2sHasher>();
+        test_extract_all::<Blake2sHasher, Blake2sHasher>();
     }
 
-    fn test_extract_all<H: 'static + Hasher>() {
+    #[test]
+    fn extract_all_pedersen_blake2s() {
+        test_extract_all::<PedersenHasher, Blake2sHasher>();
+    }
+
+    fn test_extract_all<AH, BH>()
+    where
+        AH: 'static + Hasher,
+        BH: 'static + Hasher,
+    {
+        const N_NODES: usize = 4;
+
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
-        let replica_id: H::Domain = rng.gen();
-        let data = vec![2u8; 32 * 3];
+
+        let replica_id: HybridDomain<AH::Domain, BH::Domain> = HybridDomain::Beta(rng.gen());
+
+        let data = vec![2u8; N_NODES * NODE_SIZE];
         let challenges = LayerChallenges::new_fixed(DEFAULT_ZIGZAG_LAYERS, 5);
 
         // create a copy, so we can compare roundtrips
@@ -88,29 +115,31 @@ mod tests {
 
         let sp = SetupParams {
             drg: drgporep::DrgParams {
-                nodes: data.len() / 32,
+                nodes: N_NODES,
                 degree: 5,
                 expansion_degree: 8,
                 seed: new_seed(),
             },
             layer_challenges: challenges.clone(),
+            beta_heights: BETA_HEIGHTS.to_vec(),
         };
 
-        let mut pp = ZigZagDrgPoRep::<H>::setup(&sp).expect("setup failed");
+        let mut pp = ZigZagDrgPoRep::<AH, BH>::setup(&sp).expect("setup failed");
         // Get the graph for the last layer.
         // In reality, this is a no-op with an even number of layers.
         for _ in 0..pp.layer_challenges.layers() {
             pp.graph = zigzag(&pp.graph);
         }
 
-        ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None)
+        ZigZagDrgPoRep::<AH, BH>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None)
             .expect("replication failed");
 
-        let transformed_params = PublicParams::new(pp.graph, challenges.clone());
+        let transformed_params =
+            PublicParams::new(pp.graph, challenges.clone(), BETA_HEIGHTS.to_vec());
 
         assert_ne!(data, data_copy);
 
-        let decoded_data = ZigZagDrgPoRep::<H>::extract_all(
+        let decoded_data = ZigZagDrgPoRep::<AH, BH>::extract_all(
             &transformed_params,
             &replica_id,
             data_copy.as_mut_slice(),
@@ -123,25 +152,33 @@ mod tests {
     fn prove_verify_fixed(n: usize, i: usize) {
         let challenges = LayerChallenges::new_fixed(DEFAULT_ZIGZAG_LAYERS, 5);
 
-        test_prove_verify::<PedersenHasher>(n, i, challenges.clone());
-        test_prove_verify::<Sha256Hasher>(n, i, challenges.clone());
-        test_prove_verify::<Blake2sHasher>(n, i, challenges.clone());
+        test_prove_verify::<PedersenHasher, PedersenHasher>(n, i, challenges.clone());
+        test_prove_verify::<Sha256Hasher, Sha256Hasher>(n, i, challenges.clone());
+        test_prove_verify::<Blake2sHasher, Blake2sHasher>(n, i, challenges.clone());
+        test_prove_verify::<PedersenHasher, Blake2sHasher>(n, i, challenges.clone());
     }
 
     fn prove_verify_tapered(n: usize, i: usize) {
         let challenges = LayerChallenges::new_tapered(5, 10, 5, 0.9);
 
-        test_prove_verify::<PedersenHasher>(n, i, challenges.clone());
-        test_prove_verify::<Sha256Hasher>(n, i, challenges.clone());
-        test_prove_verify::<Blake2sHasher>(n, i, challenges.clone());
+        test_prove_verify::<PedersenHasher, PedersenHasher>(n, i, challenges.clone());
+        test_prove_verify::<Sha256Hasher, Sha256Hasher>(n, i, challenges.clone());
+        test_prove_verify::<Blake2sHasher, Blake2sHasher>(n, i, challenges.clone());
+        test_prove_verify::<PedersenHasher, Blake2sHasher>(n, i, challenges.clone());
     }
 
-    fn test_prove_verify<H: 'static + Hasher>(n: usize, i: usize, challenges: LayerChallenges) {
+    fn test_prove_verify<AH, BH>(n: usize, i: usize, challenges: LayerChallenges)
+    where
+        AH: 'static + Hasher,
+        BH: 'static + Hasher,
+    {
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
         let degree = 1 + i;
         let expansion_degree = i;
-        let replica_id: H::Domain = rng.gen();
+
+        let replica_id: HybridDomain<AH::Domain, BH::Domain> = HybridDomain::Beta(rng.gen());
+
         let data: Vec<u8> = (0..n)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
@@ -157,15 +194,16 @@ mod tests {
                 seed: new_seed(),
             },
             layer_challenges: challenges.clone(),
+            beta_heights: BETA_HEIGHTS.to_vec(),
         };
 
-        let pp = ZigZagDrgPoRep::<H>::setup(&sp).expect("setup failed");
+        let pp = ZigZagDrgPoRep::<AH, BH>::setup(&sp).expect("setup failed");
         let (tau, aux) =
-            ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None)
+            ZigZagDrgPoRep::<AH, BH>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None)
                 .expect("replication failed");
         assert_ne!(data, data_copy);
 
-        let pub_inputs = PublicInputs::<H::Domain> {
+        let pub_inputs = PublicInputs::<AH::Domain, BH::Domain> {
             replica_id,
             seed: None,
             tau: Some(tau.simplify().into()),
@@ -178,12 +216,16 @@ mod tests {
             tau: tau.layer_taus,
         };
 
-        let all_partition_proofs =
-            &ZigZagDrgPoRep::<H>::prove_all_partitions(&pp, &pub_inputs, &priv_inputs, partitions)
-                .expect("failed to generate partition proofs");
+        let all_partition_proofs = &ZigZagDrgPoRep::<AH, BH>::prove_all_partitions(
+            &pp,
+            &pub_inputs,
+            &priv_inputs,
+            partitions,
+        )
+        .expect("failed to generate partition proofs");
 
         let proofs_are_valid =
-            ZigZagDrgPoRep::<H>::verify_all_partitions(&pp, &pub_inputs, all_partition_proofs)
+            ZigZagDrgPoRep::<AH, BH>::verify_all_partitions(&pp, &pub_inputs, all_partition_proofs)
                 .expect("failed to verify partition proofs");
 
         assert!(proofs_are_valid);
@@ -199,16 +241,16 @@ mod tests {
             // prove_verify_32_3_1(32, 3, 1);
             // prove_verify_32_3_2(32, 3, 2);
 
-           prove_verify_fixed_32_5_1(5, 1);
-           prove_verify_fixed_32_5_2(5, 2);
-           prove_verify_fixed_32_5_3(5, 3);
+           prove_verify_fixed_32_8_1(8, 1);
+           prove_verify_fixed_32_8_2(8, 2);
+           prove_verify_fixed_32_8_3(8, 3);
         }
     }
     table_tests! {
         prove_verify_tapered{
-            prove_verify_tapered_32_5_1(5, 1);
-            prove_verify_tapered_32_5_2(5, 2);
-            prove_verify_tapered_32_5_3(5, 3);
+            prove_verify_tapered_32_8_1(8, 1);
+            prove_verify_tapered_32_8_2(8, 2);
+            prove_verify_tapered_32_8_3(8, 3);
         }
     }
 
@@ -228,10 +270,12 @@ mod tests {
                 seed: new_seed(),
             },
             layer_challenges: layer_challenges.clone(),
+            beta_heights: BETA_HEIGHTS.to_vec(),
         };
 
         // When this fails, the call to setup should panic, but seems to actually hang (i.e. neither return nor panic) for some reason.
         // When working as designed, the call to setup returns without error.
-        let _pp = ZigZagDrgPoRep::<PedersenHasher>::setup(&sp).expect("setup failed");
+        let _pp =
+            ZigZagDrgPoRep::<PedersenHasher, Blake2sHasher>::setup(&sp).expect("setup failed");
     }
 }


### PR DESCRIPTION
### Description

Hybrid Merkle Trees are Merkle Trees that use two hashers, one hasher (the "beta" hasher) is used for the first n layers and a second hasher (the "alpha" hasher) is used for the remaining layers until the tree's root is reached.

In order to store two different `Hasher` domains in a single `merkle_light::merkle::Store`, we implement a wrapper enum called `HybridDomain`.

### What's in This PR

- Implements `HybridDomain` in [`storage_proofs/src/hasher/hybrid.rs`](https://github.com/filecoin-project/rust-fil-proofs/blob/hybrid-merkle-hybrid-domain/storage-proofs/src/hasher/hybrid.rs).
- Implements Hybrid Merkle Trees in [`storage_proofs/src/hybrid_merkle.rs`](https://github.com/filecoin-project/rust-fil-proofs/blob/hybrid-merkle-hybrid-domain/storage-proofs/src/hybrid_merkle.rs)
- Adds module for Hybrid Merkle backed PoR [`storage_proofs/src/hybrid_merklepor.rs`](https://github.com/filecoin-project/rust-fil-proofs/blob/hybrid-merkle-hybrid-domain/storage-proofs/src/hybrid_merklepor.rs)
- Changes PIPs to use Hyrbid Merkle Trees 
- Refactors storage-proofs and filecoin-proofs to use Hybrid Merkle Trees and Hybrid Domains
- Adds benchmarking for Hybrid Merkle Trees [`storage-proofs/benches/hybrid_merkle.rs`](https://github.com/filecoin-project/rust-fil-proofs/blob/hybrid-merkle-hybrid-domain/storage-proofs/benches/hybrid_merkle.rs)