### PR TITLE
JSON output for micro benchmarks

### DIFF
--- a/fil-proofs-tooling/src/bin/micro.rs
+++ b/fil-proofs-tooling/src/bin/micro.rs
@@ -21,7 +21,7 @@ struct CriterionResult {
     samples: u32,
     time_med: f64,
     time: Interval,
-    throughput: Interval,
+    throughput: Option<Interval>,
     slope: Interval,
     mean: Interval,
     median: Interval,
@@ -77,7 +77,7 @@ fn parse_criterion_out(s: impl AsRef<str>) -> Result<Vec<CriterionResult>, failu
                     samples: r.1.unwrap_or_default(),
                     time_med: r.2.unwrap_or_default(),
                     time: r.3.unwrap_or_default(),
-                    throughput: r.4.unwrap_or_default(),
+                    throughput: r.4,
                     slope: r.5.unwrap_or_default(),
                     mean: r.6.unwrap_or_default(),
                     median: r.7.unwrap_or_default(),
@@ -189,7 +189,7 @@ fn parse_criterion_out(s: impl AsRef<str>) -> Result<Vec<CriterionResult>, failu
             samples: r.1.unwrap_or_default(),
             time_med: r.2.unwrap_or_default(),
             time: r.3.unwrap_or_default(),
-            throughput: r.4.unwrap_or_default(),
+            throughput: r.4,
             slope: r.5.unwrap_or_default(),
             mean: r.6.unwrap_or_default(),
             median: r.7.unwrap_or_default(),
@@ -315,11 +315,7 @@ median [138.33 us 143.23 us] med. abs. dev. [1.7507 ms 8.4109 ms]";
                     end: 159.66,
                     unit: Some("us".to_string())
                 },
-                throughput: Interval {
-                    start: 0.0,
-                    end: 0.0,
-                    unit: None
-                },
+                throughput: None,
                 slope: Interval {
                     start: 141.11,
                     end: 159.66,
@@ -386,11 +382,11 @@ median [138.33 us 143.23 us] med. abs. dev. [1.7507 ms 8.4109 ms]";
                     end: 159.66,
                     unit: Some("us".to_string())
                 },
-                throughput: Interval {
+                throughput: Some(Interval {
                     start: 68.055,
                     end: 68.644,
                     unit: Some("MiB/s".to_string())
-                },
+                }),
                 slope: Interval {
                     start: 141.11,
                     end: 159.66,


### PR DESCRIPTION
Makes incremental progress towards #761.

## What's in this PR?

This PR modifies the micro benchmarker to output JSON. It omits properties with no available value, e.g. R^2, instead of emitting `0.0`. It also adds throughput to the JSON.

## Example Output

```json
[
    // ...
    {
        "mean": null,
        "med_abs_dev": null,
        "median": null,
        "name": "preprocessing/write_padded/256000",
        "r_2": null,
        "samples": 2,
        "slope": null,
        "std_dev": null,
        "throughput": {
            "end": 151.93,
            "start": 150.32,
            "unit": "MiB/s"
        },
        "throughput_med": {
            "unit": "MiB/s",
            "value": 150.64
        },
        "time": {
            "end": 1624.2,
            "start": 1606.9,
            "unit": "us"
        },
        "time_med": {
            "unit": "us",
            "value": 1620.7
        }
    },
    // ...
    {
        "mean": null,
        "med_abs_dev": null,
        "median": null,
        "name": "xor-circuit/synthesize",
        "r_2": null,
        "samples": 20,
        "slope": null,
        "std_dev": null,
        "throughput": null,
        "throughput_med": null,
        "time": {
            "end": 491.14,
            "start": 481.42,
            "unit": "us"
        },
        "time_med": {
            "unit": "us",
            "value": 486.13
        }
    }
]
```