### PR TITLE
feat(capture benchmarks on pushes to master)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
             mkdir -p ~/.ssh/
             if [[ ! -f ~/.ssh/known_hosts ]] || ! grep "${BENCHMARK_SERVER_IP_ADDR}" ~/.ssh/known_hosts; then
               echo "
-            ${BENCHMARK_SERVER_IP_ADDR} ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEP/RGRFukUX+dinqUMNdBQmLXJW14ix5tJOrGrT2bzT2nlkh3NcoSmAElA3yWIKXfzYuNa9pTcXWSbLA+y5AxEMGvYmOA6n23ZG0xL9qKMIeUb4ww6zNGcXQuj76n8mpkl9uzEUAesxgk8rMDhPr+lRmG5nPZjmJSgo2G1FnQDnPyRKoLOg6IpnqYIrf86e277DOVGzmHR/HTuWV3Y1FxzgGSWA/vL1PbaJVzrv/GEFQIsWL8PzqJjXQVy0U+MqklP/J9u84Cro7jnKizXLvNF5fvPI3G7RU/B/IZlUsrqy5reRlk837/kUrZwtOc8E+ys8lBmn9qzWn3jOykhSy/
+            ${BENCHMARK_SERVER_RSA_FINGERPRINT}
               " >> ~/.ssh/known_hosts
             fi
       - checkout
@@ -197,12 +197,12 @@ jobs:
           name: Build micro and benchy binaries
           command: cargo build --release --all
       - run:
-          name: Run ZigZag benchmarks on remote host with 1GiB sector size
-          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) | jq '.'
-          no_output_timeout: 60m
-      - run:
           name: Run micro benchmarks on remote box
           command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" | jq '.'
+          no_output_timeout: 60m
+      - run:
+          name: Run ZigZag benchmarks on remote host with 1GiB sector size
+          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) | jq '.'
           no_output_timeout: 60m
 
   rustfmt:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -323,7 +323,7 @@ workflows:
             - cargo_fetch
           filters:
             branches:
-              only: feat/786-run-benchmarks-on-master-build
+              only: master
       - build_linux_release:
           requires:
             - cargo_fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,7 +178,7 @@ jobs:
             mkdir -p ~/.ssh/
             if [[ ! -f ~/.ssh/known_hosts ]] || ! grep "${BENCHMARK_SERVER_IP_ADDR}" ~/.ssh/known_hosts; then
               echo "
-            ${BENCHMARK_SERVER_IP_ADDR} ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCg70UlnE+PZr/HMzK85SDSYRJrj9DfedUNaFmt4InUthB2ykANt941sVUZq3ieYGl8h2BFxXqqQu1m4Y442ohIXzEPdeu6klomCFrUeF5+X6WeDNL+VqTHNFbn10kimnw4G+sXeRk62UaxQpI7bY8oFjaohLaNalyVbD9u1eIo/X4V/8snKDY9QFJcUyWHv3HIEoxImEKGk9p0sLhdInFU44hyPbeT/I6TubHwHBSvEN3HxvxZJE4/COk9MqoIPhnu7WjZ/z35aHgroChXy69xqZ6GO3seK9xBPgoplRGIJyBgaJY35eQ84Wg+WqAq7MGuyuhsWUXT+2NTr9F4DgJ/
+            ${BENCHMARK_SERVER_IP_ADDR} ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDEP/RGRFukUX+dinqUMNdBQmLXJW14ix5tJOrGrT2bzT2nlkh3NcoSmAElA3yWIKXfzYuNa9pTcXWSbLA+y5AxEMGvYmOA6n23ZG0xL9qKMIeUb4ww6zNGcXQuj76n8mpkl9uzEUAesxgk8rMDhPr+lRmG5nPZjmJSgo2G1FnQDnPyRKoLOg6IpnqYIrf86e277DOVGzmHR/HTuWV3Y1FxzgGSWA/vL1PbaJVzrv/GEFQIsWL8PzqJjXQVy0U+MqklP/J9u84Cro7jnKizXLvNF5fvPI3G7RU/B/IZlUsrqy5reRlk837/kUrZwtOc8E+ys8lBmn9qzWn3jOykhSy/
               " >> ~/.ssh/known_hosts
             fi
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,6 +169,18 @@ jobs:
     working_directory: /mnt/crate
     resource_class: xlarge
     steps:
+      - add_ssh_keys:
+          fingerprints:
+            - "f8:db:3c:6d:f9:74:2c:9e:07:42:3f:3f:23:07:f7:6d"
+      - run:
+          name: Add benchmark server's public key to known hosts
+          command: |
+            mkdir -p ~/.ssh/
+            if [[ ! -f ~/.ssh/known_hosts ]] || ! grep "${BENCHMARK_SERVER_IP_ADDR}" ~/.ssh/known_hosts; then
+              echo "
+            ${BENCHMARK_SERVER_IP_ADDR} ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCg70UlnE+PZr/HMzK85SDSYRJrj9DfedUNaFmt4InUthB2ykANt941sVUZq3ieYGl8h2BFxXqqQu1m4Y442ohIXzEPdeu6klomCFrUeF5+X6WeDNL+VqTHNFbn10kimnw4G+sXeRk62UaxQpI7bY8oFjaohLaNalyVbD9u1eIo/X4V/8snKDY9QFJcUyWHv3HIEoxImEKGk9p0sLhdInFU44hyPbeT/I6TubHwHBSvEN3HxvxZJE4/COk9MqoIPhnu7WjZ/z35aHgroChXy69xqZ6GO3seK9xBPgoplRGIJyBgaJY35eQ84Wg+WqAq7MGuyuhsWUXT+2NTr9F4DgJ/
+              " >> ~/.ssh/known_hosts
+            fi
       - checkout
       - attach_workspace:
           at: "."
@@ -185,11 +197,13 @@ jobs:
           name: Build micro and benchy binaries
           command: cargo build --release --all
       - run:
-          name: Capture minimal ZigZag outputs with benchy
-          command: ./fil-proofs-tooling/scripts/benchy.sh zigzag --size=1 | jq '.'
+          name: Run ZigZag benchmarks on remote host with 1GiB sector size
+          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) | jq '.'
+          no_output_timeout: 60m
       - run:
-          name: Run a single micro benchmark to ensure sane output
-          command: cargo run --bin micro --release -- hash-blake2s/non-circuit | jq '.'
+          name: Run micro benchmarks on remote box
+          command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" | jq '.'
+          no_output_timeout: 60m
 
   rustfmt:
     docker:
@@ -310,6 +324,9 @@ workflows:
       - metrics_capture:
           requires:
             - cargo_fetch
+          filters:
+            branches:
+              only: master
       - build_linux_release:
           requires:
             - cargo_fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,7 +326,7 @@ workflows:
             - cargo_fetch
           filters:
             branches:
-              only: master
+              only: feat/786-run-benchmarks-on-master-build
       - build_linux_release:
           requires:
             - cargo_fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,9 +194,6 @@ jobs:
           name: Install jq
           command: apt-get install time jq -yqq
       - run:
-          name: Build micro and benchy binaries
-          command: cargo build --release --all
-      - run:
           name: Run micro benchmarks on remote box
           command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" | jq '.'
           no_output_timeout: 60m


### PR DESCRIPTION
Fixes #786 

## Why does this PR exist?

We want to capture ZigZag and micro benchmarks for each SHA committed to `master`.

## What's in this PR?

This changeset [adds a new job which runs ZigZag and micro benchmarks](https://circleci.com/gh/filecoin-project/rust-fil-proofs/24885) on the Packet box. Environment variables are set through CircleCI configuration UI, and SSH keys are added in this way, too.

