### PR TITLE
feat(kebab-case instead of camelCase)

### DIFF
--- a/fil-proofs-tooling/scripts/benchy.sh
+++ b/fil-proofs-tooling/scripts/benchy.sh
@@ -6,7 +6,7 @@ BENCHY_OUT=$(mktemp)
 TIME_OUT=$(mktemp)
 
 BIN="env time"
-CMD="-f '{ \"outputs\": { \"maxResidentSetSizeKb\": %M } }' cargo run --quiet --bin benchy --release -- ${@} > ${BENCHY_OUT} 2> ${TIME_OUT}"
+CMD="-f '{ \"outputs\": { \"max-resident-set-size-kb\": %M } }' cargo run --quiet --bin benchy --release -- ${@} > ${BENCHY_OUT} 2> ${TIME_OUT}"
 
 if [[ $(env time --version 2>&1) != *"GNU"* ]]; then
     if [[ $(/usr/bin/time --version 2>&1) != *"GNU"* ]]; then

--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -430,7 +430,7 @@ fn do_circuit_work<H: 'static + Hasher>(
 }
 
 #[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 struct Inputs {
     sector_size: usize,
     base_degree: usize,
@@ -444,7 +444,7 @@ struct Inputs {
 }
 
 #[derive(Serialize, Default)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 struct Outputs {
     avg_groth_verifying_cpu_time_ms: Option<u64>,
     avg_groth_verifying_wall_time_ms: Option<u64>,
@@ -469,7 +469,7 @@ struct Outputs {
 }
 
 #[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "kebab-case")]
 struct Report {
     inputs: Inputs,
     outputs: Outputs,

--- a/fil-proofs-tooling/src/bin/micro.rs
+++ b/fil-proofs-tooling/src/bin/micro.rs
@@ -11,6 +11,7 @@ use std::io::{self, BufRead};
 use fil_proofs_tooling::metadata::Metadata;
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 struct Interval {
     start: f64,
     end: f64,
@@ -18,12 +19,14 @@ struct Interval {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 struct Point {
     value: f64,
     unit: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
 struct CriterionResult {
     name: String,
     samples: u32,

--- a/fil-proofs-tooling/src/metadata.rs
+++ b/fil-proofs-tooling/src/metadata.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 
 /// Captures metadata about the current setup.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct Metadata<T> {
     git: GitMetadata,
     system: SystemMetadata,
@@ -23,6 +24,7 @@ impl<T> Metadata<T> {
 
 /// Captures git specific metadata about the current repo.
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct GitMetadata {
     hash: String,
     date: DateTime<Utc>,
@@ -44,6 +46,7 @@ impl GitMetadata {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
 pub struct SystemMetadata {
     system: String,
     release: String,


### PR DESCRIPTION
This PR changes the JSON property-casing from `camelCase` to `kebab-case`:

```json
{
  "git": {
    "hash": "bfb453a9a7796a535d94696826182c416bac00c8",
    "date": "2019-08-07T01:35:27Z"
  },
  "system": {
    "system": "Darwin",
    "release": "18.7.0",
    "version": "Darwin Kernel Version 18.7.0: Thu Jun 20 18:42:21 PDT 2019; root:xnu-4903.270.47~4/RELEASE_X86_64",
    "architecture": "x86_64",
    "processor": "Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz",
    "processor-base-frequency-hz": 3100,
    "processor-max-frequency-hz": 4100,
    "processor-features": "FeatureInfo { eax: 591593, ebx: 101713920, edx_ecx: SSE3 | PCLMULQDQ | DTES64 | MONITOR | DSCPL | VMX | SMX | EIST | TM2 | SSSE3 | FMA | CMPXCHG16B | PDCM | PCID | SSE41 | SSE42 | X2APIC | MOVBE | POPCNT | TSC_DEADLINE | AESNI | XSAVE | OSXSAVE | AVX | F16C | RDRAND | FPU | VME | DE | PSE | TSC | MSR | PAE | MCE | CX8 | APIC | SEP | MTRR | PGE | MCA | CMOV | PAT | PSE36 | CLFSH | DS | ACPI | MMX | FXSR | SSE | SSE2 | SS | HTT | TM | PBE }",
    "processor-cores-logical": 8,
    "processor-cores-physical": 4,
    "memory-total-bytes": 17179869184
  },
  "benchmarks": {
    "inputs": {
      "sector-size": 1024,
      "base-degree": 5,
      "expansion-degree": 8,
      "partitions": 1,
      "hasher": "pedersen",
      "samples": 5,
      "layers": 10,
      "partition-challenges": 10,
      "total-challenges": 10
    },
    "outputs": {
      "avg-groth-verifying-cpu-time-ms": null,
      "avg-groth-verifying-wall-time-ms": null,
      "circuit-num-constraints": null,
      "circuit-num-inputs": null,
      "extracting-cpu-time-ms": null,
      "extracting-wall-time-ms": null,
      "replication-wall-time-ms": 69,
      "replication-cpu-time-ms": 105,
      "replication-wall-time-ns-per-byte": 68046,
      "replication-cpu-time-ns-per-byte": 103351,
      "total-report-cpu-time-ms": 283,
      "total-report-wall-time-ms": 247,
      "total-proving-cpu-time-ms": 0,
      "total-proving-wall-time-ms": 0,
      "vanilla-proving-cpu-time-us": 262,
      "vanilla-proving-wall-time-us": 261,
      "vanilla-verification-wall-time-us": 35783,
      "vanilla-verification-cpu-time-us": 35684,
      "verifying-wall-time-avg-ms": 35,
      "verifying-cpu-time-avg-ms": 35
    }
  },
  "outputs": {
    "max-resident-set-size-kb": 486796
  }
}
```

```json
{
  "git": {
    "hash": "2f4d9127a9d0668d1824294fa6e3fb2d52028abd",
    "date": "2019-08-07T01:48:26Z"
  },
  "system": {
    "system": "Darwin",
    "release": "18.7.0",
    "version": "Darwin Kernel Version 18.7.0: Thu Jun 20 18:42:21 PDT 2019; root:xnu-4903.270.47~4/RELEASE_X86_64",
    "architecture": "x86_64",
    "processor": "Intel(R) Core(TM) i7-7920HQ CPU @ 3.10GHz",
    "processor-base-frequency-hz": 3100,
    "processor-max-frequency-hz": 4100,
    "processor-features": "FeatureInfo { eax: 591593, ebx: 1050624, edx_ecx: SSE3 | PCLMULQDQ | DTES64 | MONITOR | DSCPL | VMX | SMX | EIST | TM2 | SSSE3 | FMA | CMPXCHG16B | PDCM | PCID | SSE41 | SSE42 | X2APIC | MOVBE | POPCNT | TSC_DEADLINE | AESNI | XSAVE | OSXSAVE | AVX | F16C | RDRAND | FPU | VME | DE | PSE | TSC | MSR | PAE | MCE | CX8 | APIC | SEP | MTRR | PGE | MCA | CMOV | PAT | PSE36 | CLFSH | DS | ACPI | MMX | FXSR | SSE | SSE2 | SS | HTT | TM | PBE }",
    "processor-cores-logical": 8,
    "processor-cores-physical": 4,
    "memory-total-bytes": 17179869184
  },
  "benchmarks": [
    {
      "name": "hash-blake2s/non-circuit/32",
      "samples": 100,
      "time-med": {
        "value": 0.1183,
        "unit": "us"
      },
      "time": {
        "start": 0.1172,
        "end": 0.1194,
        "unit": "us"
      },
      "throughput": null,
      "throughput-med": null,
      "slope": {
        "start": 0.1172,
        "end": 0.1194,
        "unit": "us"
      },
      "mean": {
        "start": 0.1166,
        "end": 0.1187,
        "unit": "us"
      },
      "median": {
        "start": 0.1157,
        "end": 0.1183,
        "unit": "us"
      },
      "r-2": {
        "start": 0.8583483,
        "end": 0.8578348,
        "unit": null
      },
      "std-dev": {
        "start": 0.0044,
        "end": 0.0062,
        "unit": "us"
      },
      "med-abs-dev": {
        "start": 0.0034,
        "end": 0.0063,
        "unit": "us"
      }
    },
    {
      "name": "hash-blake2s/non-circuit/64",
      "samples": 100,
      "time-med": {
        "value": 0.1212,
        "unit": "us"
      },
      "time": {
        "start": 0.1197,
        "end": 0.1228,
        "unit": "us"
      },
      "throughput": null,
      "throughput-med": null,
      "slope": {
        "start": 0.1197,
        "end": 0.1228,
        "unit": "us"
      },
      "mean": {
        "start": 0.1216,
        "end": 0.1247,
        "unit": "us"
      },
      "median": {
        "start": 0.121,
        "end": 0.1261,
        "unit": "us"
      },
      "r-2": {
        "start": 0.6500354,
        "end": 0.6477139,
        "unit": null
      },
      "std-dev": {
        "start": 0.0072,
        "end": 0.0088,
        "unit": "us"
      },
      "med-abs-dev": {
        "start": 0.0073,
        "end": 0.0111,
        "unit": "us"
      }
    },
    {
      "name": "hash-blake2s/non-circuit/320",
      "samples": 100,
      "time-med": {
        "value": 0.4857,
        "unit": "us"
      },
      "time": {
        "start": 0.4754,
        "end": 0.4967,
        "unit": "us"
      },
      "throughput": null,
      "throughput-med": null,
      "slope": {
        "start": 0.4754,
        "end": 0.4967,
        "unit": "us"
      },
      "mean": {
        "start": 0.4767,
        "end": 0.4899,
        "unit": "us"
      },
      "median": {
        "start": 0.4687,
        "end": 0.4857,
        "unit": "us"
      },
      "r-2": {
        "start": 0.4555735,
        "end": 0.453221,
        "unit": null
      },
      "std-dev": {
        "start": 0.0273,
        "end": 0.0399,
        "unit": "us"
      },
      "med-abs-dev": {
        "start": 0.0228,
        "end": 0.0396,
        "unit": "us"
      }
    }
  ]
}
```