### PR TITLE
refactor(storage-proofs): make base and expansion parents compile time constants

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,10 @@ jobs:
             - parameter-cache-{{ .Revision }}
       - run:
           name: Test (stable) in release profile
-          command: cargo +stable test --verbose --release --all -- --ignored
+          command: |
+              # We must change directories into `storage-proofs` for the `unchecked-degrees` feature to take effect.
+              cd storage-proofs
+              cargo +stable test --verbose --release --all --features unchecked-degrees -- --ignored
       - save_cache:
           key: parameter-cache-{{ .Revision }}
           paths:

--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -19,20 +19,6 @@ fn main() {
                         .takes_value(true),
                 )
                 .arg(
-                    Arg::with_name("m")
-                        .help("The size of m")
-                        .long("m")
-                        .default_value("5")
-                        .takes_value(true),
-                )
-                .arg(
-                    Arg::with_name("exp")
-                        .help("Expansion degree")
-                        .long("expansion")
-                        .default_value("8")
-                        .takes_value(true),
-                )
-                .arg(
                     Arg::with_name("challenges")
                         .long("challenges")
                         .help("How many challenges to execute")
@@ -134,12 +120,10 @@ fn main() {
                         challenges: value_t!(m, "challenges", usize)?,
                         circuit: m.is_present("circuit"),
                         dump: m.is_present("dump"),
-                        exp: value_t!(m, "exp", usize)?,
                         extract: m.is_present("extract"),
                         groth: m.is_present("groth"),
                         hasher: value_t!(m, "hasher", String)?,
                         layers,
-                        m: value_t!(m, "m", usize)?,
                         no_bench: m.is_present("no-bench"),
                         no_tmp: m.is_present("no-tmp"),
                         partitions: value_t!(m, "partitions", usize)?,

--- a/filecoin-proofs/examples/drgporep-vanilla-disk.rs
+++ b/filecoin-proofs/examples/drgporep-vanilla-disk.rs
@@ -34,9 +34,10 @@ fn file_backed_mmap_from_random_bytes(n: usize) -> MmapMut {
     unsafe { MmapOptions::new().map_mut(&tmpfile).unwrap() }
 }
 
-fn do_the_work<H: Hasher>(data_size: usize, m: usize, challenge_count: usize) {
+fn do_the_work<H: Hasher>(data_size: usize, challenge_count: usize) {
     let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
     let challenges = vec![2; challenge_count];
+    let m = BASE_DEGREE;
 
     info!("data_size:  {}", prettyb(data_size));
     info!("challenge_count: {}", challenge_count);
@@ -137,13 +138,6 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("m")
-                .help("The size of m")
-                .long("m")
-                .default_value("6")
-                .takes_value(true),
-        )
-        .arg(
             Arg::with_name("challenges")
                 .long("challenges")
                 .help("How many challenges to execute, defaults to 1")
@@ -160,20 +154,19 @@ fn main() {
         .get_matches();
 
     let data_size = value_t!(matches, "size", usize).unwrap() * 1024;
-    let m = value_t!(matches, "m", usize).unwrap();
     let challenge_count = value_t!(matches, "challenges", usize).unwrap();
 
     let hasher = value_t!(matches, "hasher", String).unwrap();
     info!("hasher: {}", hasher);
     match hasher.as_ref() {
         "pedersen" => {
-            do_the_work::<PedersenHasher>(data_size, m, challenge_count);
+            do_the_work::<PedersenHasher>(data_size, challenge_count);
         }
         "sha256" => {
-            do_the_work::<Sha256Hasher>(data_size, m, challenge_count);
+            do_the_work::<Sha256Hasher>(data_size, challenge_count);
         }
         "blake2s" => {
-            do_the_work::<Blake2sHasher>(data_size, m, challenge_count);
+            do_the_work::<Blake2sHasher>(data_size, challenge_count);
         }
         _ => panic!(format!("invalid hasher: {}", hasher)),
     }

--- a/filecoin-proofs/examples/drgporep-vanilla.rs
+++ b/filecoin-proofs/examples/drgporep-vanilla.rs
@@ -45,9 +45,10 @@ fn stop_profile() {
 #[inline(always)]
 fn stop_profile() {}
 
-fn do_the_work<H: Hasher>(data_size: usize, m: usize, challenge_count: usize) {
+fn do_the_work<H: Hasher>(data_size: usize, challenge_count: usize) {
     let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
     let challenges = vec![2; challenge_count];
+    let m = BASE_DEGREE;
 
     info!("data_size:  {}", prettyb(data_size));
     info!("challenge_count: {}", challenge_count);
@@ -157,13 +158,6 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("m")
-                .help("The size of m")
-                .long("m")
-                .default_value("6")
-                .takes_value(true),
-        )
-        .arg(
             Arg::with_name("challenges")
                 .long("challenges")
                 .help("How many challenges to execute, defaults to 1")
@@ -180,19 +174,18 @@ fn main() {
         .get_matches();
 
     let data_size = value_t!(matches, "size", usize).unwrap() * 1024;
-    let m = value_t!(matches, "m", usize).unwrap();
     let challenge_count = value_t!(matches, "challenges", usize).unwrap();
     let hasher = value_t!(matches, "hasher", String).unwrap();
     info!("hasher: {}", hasher);
     match hasher.as_ref() {
         "pedersen" => {
-            do_the_work::<PedersenHasher>(data_size, m, challenge_count);
+            do_the_work::<PedersenHasher>(data_size, challenge_count);
         }
         "sha256" => {
-            do_the_work::<Sha256Hasher>(data_size, m, challenge_count);
+            do_the_work::<Sha256Hasher>(data_size, challenge_count);
         }
         "blake2s" => {
-            do_the_work::<Blake2sHasher>(data_size, m, challenge_count);
+            do_the_work::<Blake2sHasher>(data_size, challenge_count);
         }
         _ => panic!(format!("invalid hasher: {}", hasher)),
     }

--- a/filecoin-proofs/examples/encoding.rs
+++ b/filecoin-proofs/examples/encoding.rs
@@ -25,6 +25,7 @@ use storage_proofs::layered_drgporep::{self, LayerChallenges};
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::vde;
 use storage_proofs::zigzag_drgporep::*;
+use storage_proofs::zigzag_graph::EXP_DEGREE;
 
 #[cfg(feature = "cpu-profile")]
 #[inline(always)]
@@ -70,11 +71,13 @@ pub fn file_backed_mmap_from(data: &[u8]) -> MmapMut {
     unsafe { MmapOptions::new().map_mut(&tmpfile).unwrap() }
 }
 
-fn do_the_work<H: 'static>(data_size: usize, m: usize, expansion_degree: usize)
+fn do_the_work<H: 'static>(data_size: usize)
 where
     H: Hasher,
 {
     let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+    let m = BASE_DEGREE;
+    let expansion_degree = EXP_DEGREE;
 
     info!("data size: {}", prettyb(data_size));
     info!("m: {}", m);
@@ -133,20 +136,6 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("m")
-                .help("The size of m")
-                .long("m")
-                .default_value("5")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("exp")
-                .help("Expansion degree")
-                .long("expansion")
-                .default_value("6")
-                .takes_value(true),
-        )
-        .arg(
             Arg::with_name("layers")
                 .long("layers")
                 .help("How many layers to use")
@@ -156,8 +145,5 @@ fn main() {
         .get_matches();
 
     let data_size = value_t!(matches, "size", usize).unwrap() * 1024;
-    let m = value_t!(matches, "m", usize).unwrap();
-    let expansion_degree = value_t!(matches, "exp", usize).unwrap();
-
-    do_the_work::<PedersenHasher>(data_size, m, expansion_degree);
+    do_the_work::<PedersenHasher>(data_size);
 }

--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -36,6 +36,7 @@ use storage_proofs::porep::PoRep;
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::settings;
 use storage_proofs::zigzag_drgporep::*;
+use storage_proofs::zigzag_graph::EXP_DEGREE;
 
 // We can only one of the profilers at a time, either CPU (`profile`)
 // or memory (`heap-profile`), duplicating the function so they won't
@@ -141,8 +142,6 @@ fn dump_proof_bytes<H: Hasher>(all_partition_proofs: &[layered_drgporep::Proof<H
 
 fn do_the_work<H: 'static>(
     data_size: usize,
-    m: usize,
-    expansion_degree: usize,
     layer_challenges: LayerChallenges,
     partitions: usize,
     circuit: bool,
@@ -156,6 +155,9 @@ fn do_the_work<H: 'static>(
     H: Hasher,
 {
     let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
+
+    let m = BASE_DEGREE;
+    let expansion_degree = EXP_DEGREE;
 
     info!("data size: {}", prettyb(data_size));
     info!("m: {}", m);
@@ -405,20 +407,6 @@ fn main() {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("m")
-                .help("The size of m")
-                .long("m")
-                .default_value("5")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("exp")
-                .help("Expansion degree")
-                .long("expansion")
-                .default_value("8")
-                .takes_value(true),
-        )
-        .arg(
             Arg::with_name("challenges")
                 .long("challenges")
                 .help("How many challenges to execute")
@@ -499,8 +487,6 @@ fn main() {
         .get_matches();
 
     let data_size = value_t!(matches, "size", usize).unwrap() * 1024;
-    let m = value_t!(matches, "m", usize).unwrap();
-    let expansion_degree = value_t!(matches, "exp", usize).unwrap();
     let challenge_count = value_t!(matches, "challenges", usize).unwrap();
     let hasher = value_t!(matches, "hasher", String).unwrap();
     let layers = value_t!(matches, "layers", usize).unwrap();
@@ -526,8 +512,6 @@ fn main() {
         "pedersen" => {
             do_the_work::<PedersenHasher>(
                 data_size,
-                m,
-                expansion_degree,
                 challenges,
                 partitions,
                 circuit,
@@ -542,8 +526,6 @@ fn main() {
         "sha256" => {
             do_the_work::<Sha256Hasher>(
                 data_size,
-                m,
-                expansion_degree,
                 challenges,
                 partitions,
                 circuit,
@@ -558,8 +540,6 @@ fn main() {
         "blake2s" => {
             do_the_work::<Blake2sHasher>(
                 data_size,
-                m,
-                expansion_degree,
                 challenges,
                 partitions,
                 circuit,

--- a/filecoin-proofs/src/parameters.rs
+++ b/filecoin-proofs/src/parameters.rs
@@ -1,5 +1,5 @@
 use storage_proofs::drgporep::DrgParams;
-use storage_proofs::drgraph::DefaultTreeHasher;
+use storage_proofs::drgraph::{DefaultTreeHasher, BASE_DEGREE};
 use storage_proofs::hasher::PedersenHasher;
 use storage_proofs::layered_drgporep;
 use storage_proofs::layered_drgporep::LayerChallenges;
@@ -7,15 +7,13 @@ use storage_proofs::proof::ProofScheme;
 use storage_proofs::rational_post;
 use storage_proofs::rational_post::RationalPoSt;
 use storage_proofs::zigzag_drgporep::ZigZagDrgPoRep;
-use storage_proofs::zigzag_graph::ZigZagBucketGraph;
+use storage_proofs::zigzag_graph::{ZigZagBucketGraph, EXP_DEGREE};
 
 use crate::constants::POREP_MINIMUM_CHALLENGES;
 use crate::types::{PaddedBytesAmount, PoStConfig};
 
 const POST_CHALLENGE_COUNT: usize = 30; // TODO: correct value
 
-const DEGREE: usize = 5;
-const EXPANSION_DEGREE: usize = 8;
 const LAYERS: usize = 4; // TODO: 10;
 const TAPER_LAYERS: usize = 2; // TODO: 7
 const TAPER: f64 = 1.0 / 3.0;
@@ -68,8 +66,8 @@ pub fn setup_params(
     layered_drgporep::SetupParams {
         drg: DrgParams {
             nodes,
-            degree: DEGREE,
-            expansion_degree: EXPANSION_DEGREE,
+            degree: BASE_DEGREE,
+            expansion_degree: EXP_DEGREE,
             seed: DRG_SEED,
         },
         layer_challenges: challenges,

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -53,6 +53,7 @@ simd = []
 asm = ["sha2/sha2-asm"]
 disk-trees = []
 big-sector-sizes-bench = []
+unchecked-degrees = []
 
 [dev-dependencies]
 proptest = "0.7"

--- a/storage-proofs/benches/drgraph.rs
+++ b/storage-proofs/benches/drgraph.rs
@@ -8,7 +8,12 @@ use storage_proofs::hasher::pedersen::*;
 fn drgraph(c: &mut Criterion) {
     let params: Vec<_> = vec![12, 24, 128, 1024]
         .iter()
-        .map(|n| (BucketGraph::<PedersenHasher>::new(*n, 6, 0, new_seed()), 2))
+        .map(|n| {
+            (
+                BucketGraph::<PedersenHasher>::new(*n, BASE_DEGREE, 0, new_seed()),
+                2,
+            )
+        })
         .collect();
     c.bench(
         "sample",

--- a/storage-proofs/benches/merkle.rs
+++ b/storage-proofs/benches/merkle.rs
@@ -3,10 +3,10 @@ extern crate criterion;
 
 use criterion::{black_box, Criterion, ParameterizedBenchmark};
 use rand::{thread_rng, Rng};
-use storage_proofs::drgraph::{new_seed, Graph};
+use storage_proofs::drgraph::{new_seed, Graph, BASE_DEGREE};
 use storage_proofs::hasher::blake2s::Blake2sHasher;
 use storage_proofs::hasher::pedersen::PedersenHasher;
-use storage_proofs::zigzag_graph::{ZigZag, ZigZagBucketGraph, DEFAULT_EXPANSION_DEGREE};
+use storage_proofs::zigzag_graph::{ZigZag, ZigZagBucketGraph, EXP_DEGREE};
 
 fn merkle_benchmark(c: &mut Criterion) {
     #[cfg(feature = "big-sector-sizes-bench")]
@@ -18,13 +18,13 @@ fn merkle_benchmark(c: &mut Criterion) {
         "merkletree",
         ParameterizedBenchmark::new(
             "blake2s",
-            move |b, nodes| {
+            move |b, n_nodes| {
                 let mut rng = thread_rng();
-                let data: Vec<u8> = (0..32 * *nodes).map(|_| rng.gen()).collect();
+                let data: Vec<u8> = (0..32 * *n_nodes).map(|_| rng.gen()).collect();
                 let graph = ZigZagBucketGraph::<Blake2sHasher>::new_zigzag(
-                    *nodes,                   // #nodes
-                    8,                        // degree
-                    DEFAULT_EXPANSION_DEGREE, // expansion degree,
+                    *n_nodes,
+                    BASE_DEGREE,
+                    EXP_DEGREE,
                     new_seed(),
                 );
 
@@ -32,13 +32,13 @@ fn merkle_benchmark(c: &mut Criterion) {
             },
             params,
         )
-        .with_function("pedersen", move |b, nodes| {
+        .with_function("pedersen", move |b, n_nodes| {
             let mut rng = thread_rng();
-            let data: Vec<u8> = (0..32 * *nodes).map(|_| rng.gen()).collect();
+            let data: Vec<u8> = (0..32 * *n_nodes).map(|_| rng.gen()).collect();
             let graph = ZigZagBucketGraph::<PedersenHasher>::new_zigzag(
-                *nodes,                   // #nodes
-                8,                        // degree
-                DEFAULT_EXPANSION_DEGREE, // expansion degree,
+                *n_nodes,
+                BASE_DEGREE,
+                EXP_DEGREE,
                 new_seed(),
             );
 

--- a/storage-proofs/benches/parents.rs
+++ b/storage-proofs/benches/parents.rs
@@ -4,12 +4,12 @@ extern crate criterion;
 extern crate gperftools;
 
 use criterion::{black_box, Criterion, ParameterizedBenchmark};
-use storage_proofs::drgraph::Graph;
+use storage_proofs::drgraph::{Graph, BASE_DEGREE};
 use storage_proofs::hasher::blake2s::Blake2sHasher;
 use storage_proofs::hasher::pedersen::PedersenHasher;
 use storage_proofs::hasher::sha256::Sha256Hasher;
 use storage_proofs::hasher::Hasher;
-use storage_proofs::zigzag_graph::{ZigZag, ZigZagBucketGraph};
+use storage_proofs::zigzag_graph::{ZigZag, ZigZagBucketGraph, EXP_DEGREE};
 
 #[cfg(feature = "cpu-profile")]
 #[inline(always)]
@@ -41,7 +41,7 @@ fn stop_profile() {}
 
 fn pregenerate_graph<H: Hasher>(size: usize) -> ZigZagBucketGraph<H> {
     let seed = [1, 2, 3, 4, 5, 6, 7];
-    ZigZagBucketGraph::<H>::new_zigzag(size, 5, 8, seed)
+    ZigZagBucketGraph::<H>::new_zigzag(size, BASE_DEGREE, EXP_DEGREE, seed)
 }
 
 fn parents_loop<H: Hasher, G: Graph<H>>(graph: &G, parents: &mut [usize]) {

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -430,6 +430,7 @@ impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for DrgPoRepCircuit<'a, E, H> {
             let replica_parents = &self.replica_parents[i];
             let data_node = &self.data_nodes[i];
 
+            assert_eq!(replica_parents.len(), replica_parents_paths.len());
             assert_eq!(data_node_path.len(), replica_node_path.len());
             assert_eq!(replica_node.is_some(), data_node.is_some());
 
@@ -522,7 +523,7 @@ mod tests {
     use crate::circuit::test::*;
     use crate::compound_proof;
     use crate::drgporep;
-    use crate::drgraph::{graph_height, new_seed, BucketGraph};
+    use crate::drgraph::{graph_height, new_seed, BucketGraph, BASE_DEGREE};
     use crate::fr32::{bytes_into_fr, fr_into_bytes};
     use crate::hasher::{Blake2sHasher, Hasher, PedersenHasher};
     use crate::porep::PoRep;
@@ -544,7 +545,7 @@ mod tests {
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
         let nodes = 12;
-        let degree = 6;
+        let degree = BASE_DEGREE;
         let challenge = 2;
 
         let replica_id: Fr = rng.gen();
@@ -667,8 +668,8 @@ mod tests {
         }
 
         assert!(cs.is_satisfied(), "constraints not satisfied");
-        assert_eq!(cs.num_inputs(), 18, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 130957, "wrong number of constraints");
+        assert_eq!(cs.num_inputs(), 16, "wrong number of inputs");
+        assert_eq!(cs.num_constraints(), 103813, "wrong number of constraints");
 
         assert_eq!(cs.get_input(0, "ONE"), Fr::one());
 
@@ -689,7 +690,7 @@ mod tests {
 
         // 1 GB
         let n = (1 << 30) / 32;
-        let m = 6;
+        let m = BASE_DEGREE;
         let tree_depth = graph_height(n);
 
         let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -710,8 +711,8 @@ mod tests {
         )
         .expect("failed to synthesize circuit");
 
-        assert_eq!(cs.num_inputs(), 18, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 361789, "wrong number of constraints");
+        assert_eq!(cs.num_inputs(), 16, "wrong number of inputs");
+        assert_eq!(cs.num_constraints(), 305791, "wrong number of constraints");
     }
 
     #[test]
@@ -735,7 +736,7 @@ mod tests {
         let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
         let nodes = 5;
-        let degree = 2;
+        let degree = BASE_DEGREE;
         let challenges = vec![1, 3];
 
         let replica_id: Fr = rng.gen();

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -253,7 +253,7 @@ mod tests {
 
     use crate::circuit::test::*;
     use crate::compound_proof;
-    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::{bytes_into_fr, fr_into_bytes};
     use crate::hasher::{Blake2sHasher, Domain, Hasher, PedersenHasher};
     use crate::merklepor;
@@ -273,7 +273,7 @@ mod tests {
         let data: Vec<u8> = (0..leaves)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
-        let graph = BucketGraph::<PedersenHasher>::new(leaves, 16, 0, new_seed());
+        let graph = BucketGraph::<PedersenHasher>::new(leaves, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
         for i in 0..3 {
@@ -366,7 +366,7 @@ mod tests {
                 .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
                 .collect();
 
-            let graph = BucketGraph::<H>::new(leaves, 16, 0, new_seed());
+            let graph = BucketGraph::<H>::new(leaves, BASE_DEGREE, 0, new_seed());
             let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
             // -- MerklePoR
@@ -472,7 +472,7 @@ mod tests {
         let data: Vec<u8> = (0..leaves)
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
-        let graph = BucketGraph::<H>::new(leaves, 16, 0, new_seed());
+        let graph = BucketGraph::<H>::new(leaves, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
         for i in 0..3 {
@@ -554,7 +554,7 @@ mod tests {
                 .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
                 .collect();
 
-            let graph = BucketGraph::<PedersenHasher>::new(leaves, 16, 0, new_seed());
+            let graph = BucketGraph::<PedersenHasher>::new(leaves, BASE_DEGREE, 0, new_seed());
             let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
             // -- MerklePoR

--- a/storage-proofs/src/circuit/porc.rs
+++ b/storage-proofs/src/circuit/porc.rs
@@ -289,7 +289,7 @@ mod tests {
 
     use crate::circuit::test::*;
     use crate::compound_proof;
-    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::fr_into_bytes;
     use crate::hasher::pedersen::*;
     use crate::porc::{self, PoRC};
@@ -320,10 +320,10 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph1 = BucketGraph::<PedersenHasher>::new(32, 5, 0, new_seed());
+        let graph1 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed());
         let tree1 = graph1.merkle_tree(data1.as_slice()).unwrap();
 
-        let graph2 = BucketGraph::<PedersenHasher>::new(32, 5, 0, new_seed());
+        let graph2 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed());
         let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
 
         let challenges = vec![rng.gen_range(0, leaves), rng.gen_range(0, leaves)];
@@ -421,10 +421,10 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph1 = BucketGraph::<PedersenHasher>::new(32, 5, 0, new_seed());
+        let graph1 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed());
         let tree1 = graph1.merkle_tree(data1.as_slice()).unwrap();
 
-        let graph2 = BucketGraph::<PedersenHasher>::new(32, 5, 0, new_seed());
+        let graph2 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed());
         let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
 
         let pub_inputs = porc::PublicInputs {

--- a/storage-proofs/src/circuit/ppor/mod.rs
+++ b/storage-proofs/src/circuit/ppor/mod.rs
@@ -124,7 +124,7 @@ impl<'a, E: JubjubEngine> Circuit<E> for ParallelProofOfRetrievability<'a, E> {
 mod tests {
     use super::*;
     use crate::circuit::test::*;
-    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::{bytes_into_fr, fr_into_bytes};
     use crate::hasher::pedersen::*;
     use crate::merklepor;
@@ -156,7 +156,7 @@ mod tests {
                 .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
                 .collect();
 
-            let graph = BucketGraph::<PedersenHasher>::new(leaves, 6, 0, new_seed());
+            let graph = BucketGraph::<PedersenHasher>::new(leaves, BASE_DEGREE, 0, new_seed());
             let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
             let pub_inputs: Vec<_> = (0..leaves)

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -486,7 +486,7 @@ mod tests {
     use std::io::Write;
     use tempfile;
 
-    use crate::drgraph::{new_seed, BucketGraph};
+    use crate::drgraph::{new_seed, BucketGraph, BASE_DEGREE};
     use crate::fr32::fr_into_bytes;
     use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
     use crate::util::data_at_node;
@@ -515,7 +515,7 @@ mod tests {
         let sp = SetupParams {
             drg: DrgParams {
                 nodes: data.len() / 32,
-                degree: 5,
+                degree: BASE_DEGREE,
                 expansion_degree: 0,
                 seed: new_seed(),
             },
@@ -568,7 +568,7 @@ mod tests {
         let sp = SetupParams {
             drg: DrgParams {
                 nodes: data.len() / 32,
-                degree: 5,
+                degree: BASE_DEGREE,
                 expansion_degree: 0,
                 seed: new_seed(),
             },
@@ -625,7 +625,7 @@ mod tests {
         // The loop is here in case we need to retry because of an edge case in the test design.
         loop {
             let rng = &mut XorShiftRng::from_seed([0x3dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
-            let degree = 10;
+            let degree = BASE_DEGREE;
             let expansion_degree = 0;
             let seed = new_seed();
 

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -164,12 +164,11 @@ mod tests {
     use rand::{self, Rng};
     use std::io::Write;
 
-    use crate::drgraph::new_seed;
-    use crate::drgraph::{BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
 
     fn merklepath<H: Hasher>() {
-        let g = BucketGraph::<H>::new(10, 5, 0, new_seed());
+        let g = BucketGraph::<H>::new(10, BASE_DEGREE, 0, new_seed());
         let mut rng = rand::thread_rng();
         let node_size = 32;
         let mut data = Vec::new();

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -140,7 +140,7 @@ mod tests {
     use paired::bls12_381::Bls12;
     use rand::{Rng, SeedableRng, XorShiftRng};
 
-    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::fr_into_bytes;
     use crate::hasher::{Blake2sHasher, HashFunction, PedersenHasher, Sha256Hasher};
     use crate::merkle::make_proof_for_test;
@@ -158,7 +158,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {
@@ -230,7 +230,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {
@@ -274,7 +274,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {

--- a/storage-proofs/src/piece_inclusion_proof.rs
+++ b/storage-proofs/src/piece_inclusion_proof.rs
@@ -367,7 +367,7 @@ fn subtree_capacity(pos: usize, total: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
     use crate::util::NODE_SIZE;
     use rand::Rng;
@@ -441,7 +441,7 @@ mod tests {
     ) {
         assert_eq!(node_lengths.len(), 1); // For now.
         let size = nodes * NODE_SIZE;
-        let g = BucketGraph::<H>::new(nodes, 0, 0, new_seed());
+        let g = BucketGraph::<H>::new(nodes, BASE_DEGREE, 0, new_seed());
         let mut data = vec![0u8; size]; //Vec::<u8>::with_capacity(nodes);
 
         let data_size = node_lengths[0] * NODE_SIZE;

--- a/storage-proofs/src/porc.rs
+++ b/storage-proofs/src/porc.rs
@@ -202,7 +202,7 @@ mod tests {
     use paired::bls12_381::Bls12;
     use rand::{Rng, SeedableRng, XorShiftRng};
 
-    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::fr_into_bytes;
     use crate::hasher::{Blake2sHasher, HashFunction, PedersenHasher, Sha256Hasher};
     use crate::merkle::make_proof_for_test;
@@ -221,7 +221,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {
@@ -288,7 +288,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs::<H::Domain> {
@@ -339,7 +339,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {


### PR DESCRIPTION
This is the first step to pulling in optimizations from r2. 

Important changes:
- All graphs are now using the degrees 5 + 8, including all tests and exposed sector sizes.
- degrees are no inputs anymore for the circuits, need to validate this is okay
- This will require new params
- Adds compile-time feature `allow-small-degree` which allows graphs to be constructed with base and expansion degrees smaller than 5 and 8 respectively. This feature is enabled in the CI for the ignored `storage-proofs` tests.