### PR TITLE
Feat/787 serialized benchmark runs

### DIFF
--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -13,4 +13,4 @@ git checkout -q master
 EOF
 )
 
-ssh -q $1 "$CMDS"
+ssh -t -q $1 "$CMDS"

--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -7,7 +7,9 @@ cd \$(mktemp -d)
 git clone -q https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
 git checkout -q master
-./fil-proofs-tooling/scripts/benchy.sh ${@:2}
+./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
+    ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
+    ./fil-proofs-tooling/scripts/benchy.sh ${@:2}
 EOF
 )
 

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -13,4 +13,4 @@ git checkout -q master
 EOF
 )
 
-ssh -q $1 "$CMDS"
+ssh -t -q $1 "$CMDS"

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -7,7 +7,9 @@ cd \$(mktemp -d)
 git clone -q https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
 git checkout -q master
-./fil-proofs-tooling/scripts/micro.sh ${@:2}
+./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
+    ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
+    ./fil-proofs-tooling/scripts/micro.sh ${@:2}
 EOF
 )
 

--- a/fil-proofs-tooling/scripts/retry.sh
+++ b/fil-proofs-tooling/scripts/retry.sh
@@ -16,8 +16,8 @@ set -o pipefail
 # exit_code: The exit code to retry on.
 # attempts: The number of attempts to make.
 # sleep_millis: Multiplier for sleep between attempts. Examples:
-#     If multiplier is 1000, sleep intervals are 1, 2, 4, 8, 16, etc. seconds.
-#     If multiplier is 5000, sleep intervals are 5, 10, 20, 40, 80, etc. seconds.
+#     If multiplier is 1000, sleep intervals are 1, 4, 9, 16, etc. seconds.
+#     If multiplier is 5000, sleep intervals are 5, 20, 45, 80, 125, etc. seconds.
 
 exit_code=$1
 attempts=$2

--- a/fil-proofs-tooling/scripts/retry.sh
+++ b/fil-proofs-tooling/scripts/retry.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# This software is freely available under the Apache 2.0 license.
-# Full license available here: https://www.apache.org/licenses/LICENSE-2.0.txt
-
 # Inspired by https://gist.github.com/reacocard/28611bfaa2395072119464521d48729a
 
 set -o errexit

--- a/fil-proofs-tooling/scripts/retry.sh
+++ b/fil-proofs-tooling/scripts/retry.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# This software is freely available under the Apache 2.0 license.
+# Full license available here: https://www.apache.org/licenses/LICENSE-2.0.txt
+
+# Inspired by https://gist.github.com/reacocard/28611bfaa2395072119464521d48729a
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Retry a command on a particular exit code, up to a max number of attempts,
+# with exponential backoff.
+# Invocation:
+#   err_retry exit_code attempts sleep_multiplier <command>
+# exit_code: The exit code to retry on.
+# attempts: The number of attempts to make.
+# sleep_millis: Multiplier for sleep between attempts. Examples:
+#     If multiplier is 1000, sleep intervals are 1, 2, 4, 8, 16, etc. seconds.
+#     If multiplier is 5000, sleep intervals are 5, 10, 20, 40, 80, etc. seconds.
+
+exit_code=$1
+attempts=$2
+sleep_millis=$3
+shift 3
+for attempt in `seq 1 $attempts`; do
+    # This weird construction lets us capture return codes under -o errexit
+    "$@" && rc=$? || rc=$?
+
+    if [[ ! $rc -eq $exit_code ]]; then
+        exit $rc
+    fi
+
+    if [[ $attempt -eq $attempts ]]; then
+        exit $rc
+    fi
+
+    sleep_ms="$(($attempt * $attempt * $sleep_millis))"
+
+    echo >&2 "sleeping ${sleep_ms:0:-3}.${sleep_ms: -3}s and then retrying ($((attempt + 1))/${attempts})"
+
+    sleep "${sleep_ms:0:-3}.${sleep_ms: -3}"
+done

--- a/fil-proofs-tooling/scripts/retry.sh
+++ b/fil-proofs-tooling/scripts/retry.sh
@@ -23,6 +23,7 @@ exit_code=$1
 attempts=$2
 sleep_millis=$3
 shift 3
+
 for attempt in `seq 1 $attempts`; do
     # This weird construction lets us capture return codes under -o errexit
     "$@" && rc=$? || rc=$?

--- a/fil-proofs-tooling/scripts/with-lock.sh
+++ b/fil-proofs-tooling/scripts/with-lock.sh
@@ -9,7 +9,7 @@ then
     echo >&2 "successfully acquired lock (${lockdir})"
 
     # Unlock (by removing dir) when the script finishes
-    trap 'rm -rf "$lockdir"' EXIT
+    trap 'echo >&2 "relinquishing lock (${lockdir})"; rm -rf "$lockdir"' EXIT
 
     eval "${@:3}"
 else

--- a/fil-proofs-tooling/scripts/with-lock.sh
+++ b/fil-proofs-tooling/scripts/with-lock.sh
@@ -9,7 +9,7 @@ then
     echo >&2 "successfully acquired lock (${lockdir})"
 
     # Unlock (by removing dir) when the script finishes
-    trap 'rm -rf "$lockdir"' 0
+    trap 'rm -rf "$lockdir"' EXIT
 
     eval "${@:3}"
 else

--- a/fil-proofs-tooling/scripts/with-lock.sh
+++ b/fil-proofs-tooling/scripts/with-lock.sh
@@ -4,6 +4,8 @@
 
 failure_code=$1
 lockdir=$2
+shift 2
+
 if mkdir "$lockdir" > /dev/null 2>&1
 then
     echo >&2 "successfully acquired lock (${lockdir})"
@@ -11,7 +13,8 @@ then
     # Unlock (by removing dir) when the script finishes
     trap 'echo >&2 "relinquishing lock (${lockdir})"; rm -rf "$lockdir"' EXIT
 
-    eval "${@:3}"
+    # Execute command
+    "$@"
 else
     echo >&2 "failed to acquire lock (${lockdir})"
     exit $failure_code

--- a/fil-proofs-tooling/scripts/with-lock.sh
+++ b/fil-proofs-tooling/scripts/with-lock.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Inspired by http://mywiki.wooledge.org/BashFAQ/045
+
+failure_code=$1
+lockdir=$2
+if mkdir "$lockdir" > /dev/null 2>&1
+then
+    echo >&2 "successfully acquired lock (${lockdir})"
+
+    # Unlock (by removing dir) when the script finishes
+    trap 'rm -rf "$lockdir"' 0
+
+    eval "${@:3}"
+else
+    echo >&2 "failed to acquire lock (${lockdir})"
+    exit $failure_code
+fi


### PR DESCRIPTION
## Why does this PR exist?

We need to ensure that benchmarks are run sequentially; we can't have more than one running at a time or they'll steal resources from each other.

## What's in this PR?

This PR adds a new script `retry.sh`, which retries a command after sleeping (with exponential backoff) if it exits with a given exit code.

This PR adds a new script `with-lock.sh`, which runs a command only after acquiring an exclusive lock. This script uses `mkdir`, which is an atomic operation, to emulate a mutex.

Together, these two scripts can be used to acquire an exclusive (system-wide) lock before running benchmarks.