### PR TITLE
Disk-only MT

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 bitvec = "0.5"
 rand = "0.4"
 libc = "0.2"
-merkletree = "0.7.1"
+merkletree = { git = "https://github.com/filecoin-project/merkle_light", branch = "feat/store/add-disk-only-version"}
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 bitvec = "0.5"
 rand = "0.4"
 libc = "0.2"
-merkletree = { git = "https://github.com/filecoin-project/merkle_light", branch = "feat/store/add-disk-only-version"}
+merkletree = "=0.8"
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -12,7 +12,7 @@ use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node, NODE_SIZE};
 
 #[cfg(feature = "disk-trees")]
-use crate::merkle::DiskMmapStore;
+use crate::merkle::DiskStore;
 #[cfg(feature = "disk-trees")]
 use merkletree::merkle::next_pow2;
 #[cfg(feature = "disk-trees")]
@@ -122,10 +122,9 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
                 top_half_path.to_str()
             );
 
-            let leaves_disk_mmap =
-                DiskMmapStore::new_with_path(next_pow2(self.size()), leaves_path);
+            let leaves_disk_mmap = DiskStore::new_with_path(next_pow2(self.size()), leaves_path);
             let top_half_disk_mmap =
-                DiskMmapStore::new_with_path(next_pow2(self.size()), top_half_path);
+                DiskStore::new_with_path(next_pow2(self.size()), top_half_path);
 
             // FIXME: `new_with_path` is using the `from_iter` implementation,
             //  instead the `parallel` flag should be passed also as argument
@@ -138,7 +137,7 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
                 top_half_disk_mmap,
             ))
         // If path is `None` use the existing code that will eventually
-        // call the default `DiskMmapStore::new` creating a temporary
+        // call the default `DiskStore::new` creating a temporary
         // file.
         } else if parallel {
             Ok(MerkleTree::from_par_iter(

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -337,14 +337,6 @@ pub trait Layers {
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                // Offload the data tree, we won't use it in the next iteration,
-                // only `tree_r` is reused (as the new `tree_d`).
-                aux[layer].try_offload_store();
-                // Only if this is the last iteration also offload `tree_r`.
-                if layer == layers - 1 {
-                    aux[layer + 1].try_offload_store();
-                }
-
                 Ok(partition_proofs)
             })
             .collect::<Result<Vec<_>>>()
@@ -569,7 +561,6 @@ pub trait Layers {
                 // replications many times in the same run so they may end up
                 // reusing the same files with invalid (old) data and failing.
 
-                tree_d.try_offload_store();
                 return tree_d;
             }
         }

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -16,10 +16,10 @@ use crate::hasher::{Domain, Hasher};
 // `mmap`ed `MerkleTree` (replacing the previously `Vec`-backed
 // `MerkleTree`, now encapsulated in `merkle::VecStore` and exposed
 // as `VecMerkleTree`).
-pub type DiskMmapStore<E> = merkletree::merkle::DiskMmapStore<E>;
+pub type DiskStore<E> = merkletree::merkle::DiskStore<E>;
 pub type VecMerkleTree<T, A> = merkle::MerkleTree<T, A, VecStore<T>>;
 #[cfg(feature = "disk-trees")]
-pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, DiskMmapStore<T>>;
+pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, DiskStore<T>>;
 #[cfg(not(feature = "disk-trees"))]
 pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, MmapStore<T>>;
 


### PR DESCRIPTION
Use new `DiskStore` from https://github.com/filecoin-project/merkle_light/pull/27 instead of the file-`mmap` version, remove the `try_offload` logic since we work _always_ on offloaded (disk-only) stores now (when the `disk-trees` feature is set).

```
# in storage-proofs/
cargo build                                                                   \
  -p filecoin-proofs                                                          \
  --release                                                                   \
  --example zigzag                                                            \
  --features                                                                  \
    disk-trees                                                               &&
export TREES_DIR=rust-fil-proofs-trees-dir                                   &&
FIL_PROOFS_REPLICATED_TREES_DIR="$TREES_DIR"                                  \
RUST_BACKTRACE=1                                                              \
CARGO_INCREMENTAL=1                                                           \
RUST_LOG=trace                                                                \
nohup /usr/bin/time -v ../target/release/examples/zigzag                      \
    --size 1048576                                                            \
    --hasher blake2s                                                          \
    --m 1  --expansion 0 --layers 5                                           \
     > zigzag-1gib-disk-only.out &
```
```
MASTER
	User time (seconds): 333.93
	System time (seconds): 24.50
	Percent of CPU this job got: 154%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 3:52.39
	Maximum resident set size (kbytes): 4201012

DISK-ONLY PR
	User time (seconds): 306.70
	System time (seconds): 28.66                           <--- (similar disk time)
	Percent of CPU this job got: 147%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 3:46.74
	Maximum resident set size (kbytes): 2138624            <--- (half memory used)
```