### PR TITLE
feat(profile): add Dockerfile to profile CPU of zigzag example

### DIFF
--- a/Dockerfile-profile
+++ b/Dockerfile-profile
@@ -73,10 +73,9 @@ cargo build                                                                   \
     cpu-profile                                                               \
   -Z package-features                                                         \
 &&                                                                            \
-CPUPROFILE=zigzag.prof                                                        \
 RUST_BACKTRACE=full                                                           \
 RUST_LOG=trace                                                                \
 target/release/examples/zigzag                                                \
   --size 1024                                                                 \
 &&                                                                            \
-pprof target/release/examples/zigzag zigzag.prof
+pprof target/release/examples/zigzag replicate.profile || bash

--- a/Dockerfile-profile
+++ b/Dockerfile-profile
@@ -1,0 +1,82 @@
+# How to build and run this Dockerfile:
+#
+# ```
+# RUST_FIL_PROOFS=`pwd` # path to `rust-fil-proofs`
+# docker --log-level debug build --progress tty --file Dockerfile-profile --tag rust-cpu-profile .
+# docker run -it -v $RUST_FIL_PROOFS:/code/ rust-cpu-profile
+# ```
+
+FROM rust
+
+# Get all the dependencies
+# ------------------------
+
+# Copied from: github.com/filecoin-project/rust-fil-proofs/blob/master/Dockerfile-ci
+RUN apt-get update && \
+    apt-get install -y curl file gcc g++ git make openssh-client \
+    autoconf automake cmake libtool libcurl4-openssl-dev libssl-dev \
+    libelf-dev libdw-dev binutils-dev zlib1g-dev libiberty-dev wget \
+    xz-utils pkg-config python clang
+
+# `gperftools` and dependencies (`libunwind`)
+# -------------------------------------------
+
+ENV GPERFTOOLS_VERSION="2.7"
+ENV LIBUNWIND_VERSION="0.99-beta"
+
+ENV HOME="/root"
+ENV DOWNLOADS=${HOME}/downloads
+RUN mkdir -p ${DOWNLOADS}
+RUN echo ${DOWNLOADS} 
+WORKDIR ${DOWNLOADS}
+
+RUN wget http://download.savannah.gnu.org/releases/libunwind/libunwind-${LIBUNWIND_VERSION}.tar.gz --output-document ${DOWNLOADS}/libunwind-${LIBUNWIND_VERSION}.tar.gz
+RUN tar -xvf ${DOWNLOADS}/libunwind-${LIBUNWIND_VERSION}.tar.gz
+WORKDIR ${DOWNLOADS}/libunwind-${LIBUNWIND_VERSION}
+RUN ./configure
+RUN make
+RUN make install
+WORKDIR ${DOWNLOADS}
+
+RUN wget https://github.com/gperftools/gperftools/releases/download/gperftools-${GPERFTOOLS_VERSION}/gperftools-${GPERFTOOLS_VERSION}.tar.gz  --output-document ${DOWNLOADS}/gperftools-${GPERFTOOLS_VERSION}.tar.gz
+RUN tar -xvf ${DOWNLOADS}/gperftools-${GPERFTOOLS_VERSION}.tar.gz
+WORKDIR ${DOWNLOADS}/gperftools-${GPERFTOOLS_VERSION}
+RUN ./configure
+RUN make install
+WORKDIR ${DOWNLOADS}
+
+ENV LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/usr/local/lib
+# FIXME: `gperftools` installs the library (`make install`) in
+# `/usr/local/lib` by default but Debian/Ubuntu don't look there
+# now, the correct `--prefix` should be added to the command.
+
+# Install latest toolchain used by `rust-fil-proofs`
+# --------------------------------------------------
+
+RUN rustup default nightly-2019-07-15
+# FIXME: The lastest version used should be dynamically obtained form the `rust-fil-proofs` repo
+# and not hard-coded here.
+
+# Ready to run
+# ------------
+
+WORKDIR /code
+
+CMD                                                                           \
+cargo update                                                                  \
+&&                                                                            \
+cargo build                                                                   \
+  -p filecoin-proofs                                                          \
+  --release                                                                   \
+  --example zigzag                                                            \
+  --features                                                                  \
+    cpu-profile                                                               \
+  -Z package-features                                                         \
+&&                                                                            \
+CPUPROFILE=zigzag.prof                                                        \
+RUST_BACKTRACE=full                                                           \
+RUST_LOG=trace                                                                \
+target/release/examples/zigzag                                                \
+  --size 1024                                                                 \
+&&                                                                            \
+pprof target/release/examples/zigzag zigzag.prof

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The results are written into the `.bencher` directory, as JSON files. The benchm
 
 Note: On macOS you need `gtime` (`brew install gnu-time`), as the built in `time` command is not enough.
 
+## Profiling
+
+For development purposes we have an (experimental) support for CPU and memory profiling in Rust through a [`gperftools`](https://github.com/dignifiedquire/rust-gperftools) binding library. These can be enabled though the `cpu-profile` and `heap-profile` features in `filecoin-proofs`. An example setup can be found in this [`Dockerfile`](./Dockerfile-profile) to profile CPU usage for the [`zigzag`](https://github.com/filecoin-project/rust-fil-proofs/blob/e6fa4232404641bb4be1ffc42944d2e734ab9748/filecoin-proofs/examples/zigzag.rs#L40-L61) example.
+
 ## Logging
 
 For better logging with backtraces on errors, developers should use `expects` rather than `expect` on `Result<T, E>` and `Option<T>`.


### PR DESCRIPTION
We need to provide an _easy_ setup to profile CPU (and memory, if needed) usage.