### PR TITLE
embed parameters.json in paramfetch binary

### DIFF
--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -22,6 +22,8 @@ use storage_proofs::parameter_cache::{
 const ERROR_PARAMETER_FILE: &str = "failed to find file in cache";
 const ERROR_PARAMETER_ID: &str = "failed to find key in manifest";
 
+const DEFAULT_PARAMETERS: &str = include_str!("../../../parameters.json");
+
 struct FetchProgress<R> {
     inner: R,
     progress_bar: ProgressBar<Stdout>,
@@ -117,14 +119,12 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
     let retry = matches.is_present("retry");
     let gateway = matches.value_of("gateway").unwrap_or("https://ipfs.io");
 
-    if !json_path.exists() {
-        return Err(err_msg(format!(
-            "json file '{}' does not exist",
-            &json_path.to_str().unwrap_or("")
-        )));
-    }
+    let manifest = if json_path.exists() {
+        read_parameter_map_from_disk(&json_path)?
+    } else {
+        read_parameter_map_from_str(&DEFAULT_PARAMETERS)?
+    };
 
-    let manifest = read_parameter_map_from_disk(&json_path)?;
     let mut filenames = get_filenames_from_parameter_map(&manifest)?;
 
     println!("{} files in manifest...", filenames.len());

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -64,7 +64,7 @@ Set http_proxy/https_proxy environment variables to specify proxy for ipfs gatew
                 .takes_value(true)
                 .short("j")
                 .long("json")
-                .help("Use specific json file"),
+                .help("Use specific JSON file"),
         )
         .arg(
             Arg::with_name("gateway")
@@ -117,11 +117,11 @@ Set http_proxy/https_proxy environment variables to specify proxy for ipfs gatew
 fn fetch(matches: &ArgMatches) -> Result<()> {
     let manifest = if matches.is_present("json") {
         let json_path = PathBuf::from(matches.value_of("json").unwrap());
-        println!("using json file: {:?}", json_path);
+        println!("using JSON file: {:?}", json_path);
 
         if !json_path.exists() {
             return Err(err_msg(format!(
-                "json file '{}' does not exist",
+                "JSON file '{}' does not exist",
                 &json_path.to_str().unwrap_or("")
             )));
         }
@@ -131,7 +131,7 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
 
         serde_json::from_reader(reader).map_err(|err| {
             failure::format_err!(
-                "json file '{}' did not parse correctly: {}",
+                "JSON file '{}' did not parse correctly: {}",
                 &json_path.to_str().unwrap_or(""),
                 err,
             )

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -128,17 +128,14 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
 
         let file = File::open(&json_path)?;
         let reader = BufReader::new(file);
-        let result = serde_json::from_reader(reader);
 
-        if result.is_err() {
-            return Err(err_msg(format!(
+        serde_json::from_reader(reader).map_err(|err| {
+            failure::format_err!(
                 "json file '{}' did not parse correctly: {}",
                 &json_path.to_str().unwrap_or(""),
-                result.err().unwrap(),
-            )));
-        }
-
-        result.unwrap()
+                err,
+            )
+        })?
     } else {
         println!("using built-in manifest");
         serde_json::from_str(&DEFAULT_PARAMETERS)?

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -126,9 +126,19 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
             )));
         }
 
-        let file = File::open(json_path)?;
+        let file = File::open(&json_path)?;
         let reader = BufReader::new(file);
-        serde_json::from_reader(reader)?
+        let result = serde_json::from_reader(reader);
+
+        if result.is_err() {
+            return Err(err_msg(format!(
+                "json file '{}' did not parse correctly: {}",
+                &json_path.to_str().unwrap_or(""),
+                result.err().unwrap(),
+            )));
+        }
+
+        result.unwrap()
     } else {
         println!("using built-in manifest");
         serde_json::from_str(&DEFAULT_PARAMETERS)?

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -26,6 +26,13 @@ pub struct ParameterData {
 }
 
 // Deserializes bytes from the provided path into a ParameterMap
+pub fn read_parameter_map_from_str(string: &str) -> Result<ParameterMap> {
+    let parameter_map = serde_json::from_str(string)?;
+
+    Ok(parameter_map)
+}
+
+// Deserializes bytes from the provided path into a ParameterMap
 pub fn read_parameter_map_from_disk<P: AsRef<Path>>(source_path: P) -> Result<ParameterMap> {
     let file = File::open(source_path)?;
     let reader = BufReader::new(file);

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs::File;
-use std::io::{stdin, stdout, BufReader, Write};
+use std::io::{stdin, stdout, Write};
 use std::path::{Path, PathBuf};
 
 use blake2b_simd::State as Blake2b;
@@ -23,22 +23,6 @@ pub struct ParameterData {
     pub cid: String,
     pub digest: String,
     pub sector_size: u64,
-}
-
-// Deserializes bytes from the provided path into a ParameterMap
-pub fn read_parameter_map_from_str(string: &str) -> Result<ParameterMap> {
-    let parameter_map = serde_json::from_str(string)?;
-
-    Ok(parameter_map)
-}
-
-// Deserializes bytes from the provided path into a ParameterMap
-pub fn read_parameter_map_from_disk<P: AsRef<Path>>(source_path: P) -> Result<ParameterMap> {
-    let file = File::open(source_path)?;
-    let reader = BufReader::new(file);
-    let parameter_map = serde_json::from_reader(reader)?;
-
-    Ok(parameter_map)
 }
 
 // Produces an absolute path to a file within the cache

--- a/filecoin-proofs/tests/paramfetch/prompts_to_fetch.rs
+++ b/filecoin-proofs/tests/paramfetch/prompts_to_fetch.rs
@@ -1,7 +1,7 @@
 use std::collections::btree_map::BTreeMap;
-use std::path::PathBuf;
 use std::fs::File;
 use std::io::{BufReader, Write};
+use std::path::PathBuf;
 
 use failure::Error as FailureError;
 
@@ -178,7 +178,8 @@ fn invalid_json_produces_error() -> Result<(), FailureError> {
         .with_session_timeout_ms(1000)
         .build();
 
-    session.exp_string("fatal error: expected value at line 1 column 1")?;
+    session.exp_string("fatal error: json file")?;
+    session.exp_string("did not parse correctly: expected value at line 1 column 1")?;
 
     Ok(())
 }

--- a/filecoin-proofs/tests/paramfetch/prompts_to_fetch.rs
+++ b/filecoin-proofs/tests/paramfetch/prompts_to_fetch.rs
@@ -162,7 +162,7 @@ fn invalid_json_path_produces_error() -> Result<(), FailureError> {
         .with_session_timeout_ms(1000)
         .build();
 
-    session.exp_string("fatal error: json file '/invalid/path' does not exist")?;
+    session.exp_string("fatal error: JSON file '/invalid/path' does not exist")?;
 
     Ok(())
 }
@@ -178,7 +178,7 @@ fn invalid_json_produces_error() -> Result<(), FailureError> {
         .with_session_timeout_ms(1000)
         .build();
 
-    session.exp_string("fatal error: json file")?;
+    session.exp_string("fatal error: JSON file")?;
     session.exp_string("did not parse correctly: expected value at line 1 column 1")?;
 
     Ok(())

--- a/filecoin-proofs/tests/paramfetch/support/session.rs
+++ b/filecoin-proofs/tests/paramfetch/support/session.rs
@@ -16,12 +16,12 @@ pub struct ParamFetchSessionBuilder {
     cache_dir: TempDir,
     session_timeout_ms: u64,
     whitelisted_sector_sizes: Option<Vec<String>>,
-    manifest: PathBuf,
+    manifest: Option<PathBuf>,
     prompt_enabled: bool,
 }
 
 impl ParamFetchSessionBuilder {
-    pub fn new(manifest: PathBuf) -> ParamFetchSessionBuilder {
+    pub fn new(manifest: Option<PathBuf>) -> ParamFetchSessionBuilder {
         let temp_dir = tempfile::tempdir().expect("could not create temp dir");
 
         ParamFetchSessionBuilder {
@@ -82,13 +82,19 @@ impl ParamFetchSessionBuilder {
             })
             .unwrap_or("".to_string());
 
+        let json_argument = if self.manifest.is_some() {
+            format!("--json={:?}", self.manifest.unwrap())
+        } else {
+            "".to_string()
+        };
+
         let cmd = format!(
-            "{}={} {:?} {} --json={:?} {}",
+            "{}={} {:?} {} {} {}",
             PARAMETER_CACHE_ENV_VAR,
             cache_dir_path,
             paramfetch_path,
             if self.prompt_enabled { "" } else { "--all" },
-            self.manifest,
+            json_argument,
             whitelist
         );
 


### PR DESCRIPTION
# what's in this pr

- puts the raw `parameters.json` file as a string into the paramfetch binary

# why?

- in https://github.com/filecoin-project/rust-fil-sector-builder/issues/12, `cargo install` would be the simplest way to include `rfp` binaries in with a `rfsb` release, but `parameters.json` is not part of the files downloaded. by including it by default in `paramfetch`, we don't need to worry about packaging anything other than binaries