### PR TITLE
better remote benchmarking debug-output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,15 +195,15 @@ jobs:
           command: apt-get install time jq -yqq
       - run:
           name: Run hash-constraints benchmarks on remote host
-          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" hash-circuits | jq '.'
+          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" hash-circuits
           no_output_timeout: 60m
       - run:
           name: Run micro benchmarks
-          command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" | jq '.'
+          command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}"
           no_output_timeout: 60m
       - run:
           name: Run ZigZag benchmarks using 1GiB sectors
-          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) | jq '.'
+          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024))
           no_output_timeout: 60m
 
   rustfmt:

--- a/fil-proofs-tooling/scripts/benchy.sh
+++ b/fil-proofs-tooling/scripts/benchy.sh
@@ -2,11 +2,12 @@
 
 which jq >/dev/null || { printf '%s\n' "error: jq" >&2; exit 1; }
 
-BENCHY_OUT=$(mktemp)
-TIME_OUT=$(mktemp)
+BENCHY_STDOUT=$(mktemp)
+GTIME_STDERR=$(mktemp)
+JQ_STDERR=$(mktemp)
 
-BIN="env time"
-CMD="-f '{ \"outputs\": { \"max-resident-set-size-kb\": %M } }' cargo run --quiet --bin benchy --release -- ${@} > ${BENCHY_OUT} 2> ${TIME_OUT}"
+GTIME_BIN="env time"
+CMD="-f '{ \"outputs\": { \"max-resident-set-size-kb\": %M } }' cargo run --quiet --bin benchy --release -- ${@} > ${BENCHY_STDOUT} 2> ${GTIME_STDERR}"
 
 if [[ $(env time --version 2>&1) != *"GNU"* ]]; then
     if [[ $(/usr/bin/time --version 2>&1) != *"GNU"* ]]; then
@@ -14,14 +15,35 @@ if [[ $(env time --version 2>&1) != *"GNU"* ]]; then
             printf '%s\n' "error: GNU time not installed" >&2
             exit 1
         else
-            BIN="gtime"
+            GTIME_BIN="gtime"
         fi
     else
-        BIN="/usr/bin/time"
+        GTIME_BIN="/usr/bin/time"
     fi
 fi
 
+eval "RUSTFLAGS=\"-Awarnings -C target-cpu=native\" ${GTIME_BIN} ${CMD}"
 
-eval "RUSTFLAGS=\"-Awarnings -C target-cpu=native\" ${BIN} ${CMD}"
+jq -s '.[0] * .[1]' $BENCHY_STDOUT $GTIME_STDERR 2> $JQ_STDERR
 
-jq -s '.[0] * .[1]' "${BENCHY_OUT}" "${TIME_OUT}"
+if [[ ! $? -eq 0 ]]; then
+    >&2 echo "*********************************************"
+    >&2 echo "* benchy failed - dumping debug information *"
+    >&2 echo "*********************************************"
+    >&2 echo ""
+    >&2 echo "<COMMAND>"
+    >&2 echo "${GTIME_BIN} ${CMD}"
+    >&2 echo "</COMMAND>"
+    >&2 echo ""
+    >&2 echo "<GTIME_STDERR>"
+    >&2 echo "$(cat $GTIME_STDERR)"
+    >&2 echo "</GTIME_STDERR>"
+    >&2 echo ""
+    >&2 echo "<BENCHY_STDOUT>"
+    >&2 echo "$(cat $BENCHY_STDOUT)"
+    >&2 echo "</BENCHY_STDOUT>"
+    >&2 echo ""
+    >&2 echo "<JQ_STDERR>"
+    >&2 echo "$(cat $JQ_STDERR)"
+    >&2 echo "</JQ_STDERR>"
+fi

--- a/fil-proofs-tooling/scripts/benchy.sh
+++ b/fil-proofs-tooling/scripts/benchy.sh
@@ -26,9 +26,13 @@ CMD="${GTIME_BIN} ${GTIME_ARG}"
 
 eval "RUST_BACKTRACE=1 RUSTFLAGS=\"-Awarnings -C target-cpu=native\" ${CMD}" > $BENCHY_STDOUT 2> $GTIME_STDERR
 
+GTIME_EXIT_CODE=$?
+
 jq -s '.[0] * .[1]' $BENCHY_STDOUT $GTIME_STDERR 2> $JQ_STDERR
 
-if [[ ! $? -eq 0 ]]; then
+JQ_EXIT_CODE=$?
+
+if [[ ! $GTIME_EXIT_CODE -eq 0 || ! $JQ_EXIT_CODE -eq 0 ]]; then
     >&2 echo "*********************************************"
     >&2 echo "* benchy failed - dumping debug information *"
     >&2 echo "*********************************************"

--- a/fil-proofs-tooling/scripts/micro.sh
+++ b/fil-proofs-tooling/scripts/micro.sh
@@ -1,3 +1,33 @@
 #!/usr/bin/env bash
 
-RUSTFLAGS="-Awarnings -C target-cpu=native" cargo run --quiet --bin micro --release ${@}
+MICRO_SDERR=$(mktemp)
+MICRO_SDOUT=$(mktemp)
+JQ_STDERR=$(mktemp)
+
+CMD="cargo run --quiet --bin micro --release ${@}"
+
+eval "RUSTFLAGS=\"-Awarnings -C target-cpu=native\" ${CMD}" 1> $MICRO_SDOUT 2> $MICRO_SDERR
+
+cat $MICRO_SDOUT | jq '.' 2> $JQ_STDERR
+
+if [[ ! $? -eq 0 ]]; then
+    >&2 echo "********************************************"
+    >&2 echo "* micro failed - dumping debug information *"
+    >&2 echo "********************************************"
+    >&2 echo ""
+    >&2 echo "<COMMAND>"
+    >&2 echo "${CMD}"
+    >&2 echo "</COMMAND>"
+    >&2 echo ""
+    >&2 echo "<MICRO_SDERR>"
+    >&2 echo "$(cat $MICRO_SDERR)"
+    >&2 echo "</MICRO_SDERR>"
+    >&2 echo ""
+    >&2 echo "<MICRO_SDOUT>"
+    >&2 echo "$(cat $MICRO_SDOUT)"
+    >&2 echo "</MICRO_SDOUT>"
+    >&2 echo ""
+    >&2 echo "<JQ_STDERR>"
+    >&2 echo "$(cat $JQ_STDERR)"
+    >&2 echo "</JQ_STDERR>"
+fi

--- a/fil-proofs-tooling/scripts/micro.sh
+++ b/fil-proofs-tooling/scripts/micro.sh
@@ -8,9 +8,13 @@ CMD="cargo run --quiet --bin micro --release ${@}"
 
 eval "RUST_BACKTRACE=1 RUSTFLAGS=\"-Awarnings -C target-cpu=native\" ${CMD}" 1> $MICRO_SDOUT 2> $MICRO_SDERR
 
+MICRO_EXIT_CODE=$?
+
 cat $MICRO_SDOUT | jq '.' 2> $JQ_STDERR
 
-if [[ ! $? -eq 0 ]]; then
+JQ_EXIT_CODE=$?
+
+if [[ ! $MICRO_EXIT_CODE -eq 0 || ! $JQ_EXIT_CODE -eq 0 ]]; then
     >&2 echo "********************************************"
     >&2 echo "* micro failed - dumping debug information *"
     >&2 echo "********************************************"

--- a/fil-proofs-tooling/scripts/micro.sh
+++ b/fil-proofs-tooling/scripts/micro.sh
@@ -6,7 +6,7 @@ JQ_STDERR=$(mktemp)
 
 CMD="cargo run --quiet --bin micro --release ${@}"
 
-eval "RUSTFLAGS=\"-Awarnings -C target-cpu=native\" ${CMD}" 1> $MICRO_SDOUT 2> $MICRO_SDERR
+eval "RUST_BACKTRACE=1 RUSTFLAGS=\"-Awarnings -C target-cpu=native\" ${CMD}" 1> $MICRO_SDOUT 2> $MICRO_SDERR
 
 cat $MICRO_SDOUT | jq '.' 2> $JQ_STDERR
 


### PR DESCRIPTION
## Why does this PR exist?

If and when the remote benchmarking fails, we need a way to inspect the state of the system in order to characterize the failure.

## What's in this PR?

This PR prints as much debug output to CircleCI stdout (or whomever runs the remote debug script) as possible.

An example:

```
*********************************************
* benchy failed - dumping debug information *
*********************************************

<COMMAND>
gtime -f '{ "outputs": { "max-resident-set-size-kb": %M } }' cargo run --quiet --bin benchy --release -- hash-constraints > /var/folders/8h/gmmbhq1s5tb8sk9011sy2wkw0000gn/T/tmp.XuhiQMcK 2> /var/folders/8h/gmmbhq1s5tb8sk9011sy2wkw0000gn/T/tmp.OxwswshO
</COMMAND>

<GTIME_STDERR>
error: The subcommand 'hash-constraints' wasn't recognized
	Did you mean 'hash-circuits'?

If you believe you received this message in error, try re-running with 'benchy -- hash-constraints'

USAGE:
    benchy [SUBCOMMAND]

For more information try --help
Command exited with non-zero status 1
{ "outputs": { "max-resident-set-size-kb": 5444 } }
</GTIME_STDERR>

<BENCHY_STDOUT>

</BENCHY_STDOUT>

<JQ_STDERR>
parse error: Invalid numeric literal at line 1, column 6
</JQ_STDERR>
```