### PR TITLE
feat(filecoin-proofs): Use ipget to download params

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -37,6 +37,8 @@ pretty_env_logger = "0.3.0"
 env_proxy = "0.3"
 array-macro = "1.0.4"
 os_type = "2.2.0"
+flate2 = { version = "1.0.9", features = ["rust_backend"]}
+tar = "0.4.26"
 
 [dependencies.reqwest]
 version = "0.9"

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -36,6 +36,7 @@ log = "0.4.7"
 pretty_env_logger = "0.3.0"
 env_proxy = "0.3"
 array-macro = "1.0.4"
+os_type = "2.2.0"
 
 [dependencies.reqwest]
 version = "0.9"

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -242,13 +242,15 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
 /// Check if ipget is available, dowwnload it otherwise.
 fn ensure_ipget(is_verbose: bool) -> Result<()> {
     if Path::new(IPGET_BIN).exists() {
-        if is_verbose {
-            println!("{} already exists", IPGET_BIN);
-        }
-        return Ok(());
+        Ok(())
+    } else {
+        download_ipget(is_verbose)
     }
-
-    download_ipget(is_verbose)
+    .map(|_| {
+        if is_verbose {
+            println!("ipget installed: {}", IPGET_BIN);
+        }
+    })
 }
 
 /// Download a version of ipget.

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -25,8 +25,8 @@ use storage_proofs::parameter_cache::{
 const ERROR_PARAMETER_FILE: &str = "failed to find file in cache";
 const ERROR_PARAMETER_ID: &str = "failed to find key in manifest";
 
-const IPGET_PATH: &'static str = "/var/tmp/ipget";
-const IPGET_BIN: &'static str = "/var/tmp/ipget/ipget";
+const IPGET_PATH: &str = "/var/tmp/ipget";
+const IPGET_BIN: &str = "/var/tmp/ipget/ipget";
 const DEFAULT_PARAMETERS: &str = include_str!("../../../parameters.json");
 
 struct FetchProgress<R> {

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -53,11 +53,6 @@ pub fn main() {
                 "
 Set {} to specify Groth parameter and verifying key-cache directory.
 Defaults to '{}'
-
-Use -g,--gateway to specify ipfs gateway.
-Defaults to 'https://ipfs.io'
-
-Set http_proxy/https_proxy environment variables to specify proxy for ipfs gateway.
 ",
                 PARAMETER_CACHE_ENV_VAR,
                 PARAMETER_CACHE_DIR
@@ -70,14 +65,6 @@ Set http_proxy/https_proxy environment variables to specify proxy for ipfs gatew
                 .short("j")
                 .long("json")
                 .help("Use specific JSON file"),
-        )
-        .arg(
-            Arg::with_name("gateway")
-                .value_name("URL")
-                .takes_value(true)
-                .short("g")
-                .long("gateway")
-                .help("Use specific ipfs gateway"),
         )
         .arg(
             Arg::with_name("retry")
@@ -154,7 +141,6 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
     };
 
     let retry = matches.is_present("retry");
-    let gateway = matches.value_of("gateway").unwrap_or("https://ipfs.io");
 
     let mut filenames = get_filenames_from_parameter_map(&manifest)?;
 
@@ -224,7 +210,6 @@ fn fetch(matches: &ArgMatches) -> Result<()> {
                 is_verbose,
                 &manifest,
                 &filename,
-                &gateway,
                 PathBuf::from(ipget_bin_path.unwrap_or(IPGET_BIN)),
             ) {
                 Ok(_) => println!("ok\n"),
@@ -352,7 +337,6 @@ fn fetch_parameter_file(
     is_verbose: bool,
     parameter_map: &ParameterMap,
     filename: &str,
-    _gateway: &str,
     ipget_bin_path: impl AsRef<Path>,
 ) -> Result<()> {
     let parameter_data = parameter_map_lookup(parameter_map, filename)?;

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -254,6 +254,7 @@ fn ensure_ipget(is_verbose: bool) -> Result<()> {
 /// Download a version of ipget.
 fn download_ipget(is_verbose: bool) -> Result<()> {
     let version = "v0.3.1";
+
     let (os, extension) = if cfg!(target_os = "macos") {
         ("darwin", "tar.gz")
     } else if cfg!(target_os = "windows") {
@@ -261,13 +262,14 @@ fn download_ipget(is_verbose: bool) -> Result<()> {
     } else {
         ("linux", "tar.gz")
     };
+
     let url = Url::parse(&format!(
         "https://dist.ipfs.io/ipget/{}/ipget_{}_{}-amd64.{}",
         version, version, os, extension
     ))?;
 
     if is_verbose {
-        println!("Downloading ipget@{}-{}...", version, os);
+        println!("downloading ipget@{}-{}...", version, os);
     }
 
     // download file
@@ -282,7 +284,7 @@ fn download_ipget(is_verbose: bool) -> Result<()> {
         archive.unpack("/var/tmp/")?;
     } else {
         // TODO: handle zip archives on windows
-        unimplemented!("unzip is not yet supported");
+        unimplemented!("failed to install ipget: unzip is not yet supported");
     }
 
     Ok(())

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -3,7 +3,7 @@ use std::fs::{create_dir_all, rename, File};
 use std::io::copy;
 use std::io::prelude::*;
 use std::io::{BufReader, Stdout};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::process::Command;
 use std::{fs, io};

--- a/filecoin-proofs/tests/paramfetch/support/session.rs
+++ b/filecoin-proofs/tests/paramfetch/support/session.rs
@@ -89,13 +89,14 @@ impl ParamFetchSessionBuilder {
         };
 
         let cmd = format!(
-            "{}={} {:?} {} {} {}",
+            "{}={} {:?} {} {} {} --ipget-bin={:?}",
             PARAMETER_CACHE_ENV_VAR,
             cache_dir_path,
             paramfetch_path,
             if self.prompt_enabled { "" } else { "--all" },
             json_argument,
-            whitelist
+            whitelist,
+            "true"
         );
 
         p.execute(&cmd, ".*").expect("could not execute paramfetch");


### PR DESCRIPTION
This downloads and uses `igpet` to download params, instead of going through the gateway, which has been pretty flaky for us. 

We loose progress bars, as `ipget` doesn't support this atm. 