### PR TITLE
[zexe] refactor: use bytes instead of bits for hashing in and outputs

### DIFF
--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -660,7 +660,7 @@ mod tests {
         assert!(cs.is_satisfied(), "constraints not satisfied");
         assert_eq!(cs.num_inputs(), 18, "wrong number of inputs");
         //        assert_eq!(cs.num_constraints(), 131216, "wrong number of constraints");
-        assert_eq!(cs.num_constraints(), 362619, "wrong number of constraints");
+        assert_eq!(cs.num_constraints(), 235707, "wrong number of constraints");
 
         assert_eq!(cs.get_input(0, "ONE"), Fr::one());
 
@@ -699,7 +699,7 @@ mod tests {
 
         assert_eq!(cs.num_inputs(), 18, "wrong number of inputs");
         //        assert_eq!(cs.num_constraints(), 363392, "wrong number of constraints");
-        assert_eq!(cs.num_constraints(), 1803891, "wrong number of constraints");
+        assert_eq!(cs.num_constraints(), 1010691, "wrong number of constraints");
     }
 
     #[test]

--- a/storage-proofs/src/circuit/pedersen.rs
+++ b/storage-proofs/src/circuit/pedersen.rs
@@ -1,8 +1,5 @@
 use algebra::curves::bls12_381::Bls12_381 as Bls12;
 use algebra::curves::jubjub::JubJubProjective as JubJub;
-use algebra::curves::ProjectiveCurve;
-use algebra::fields::PrimeField;
-
 use dpc::{
     crypto_primitives::crh::{pedersen::PedersenCRH, pedersen::PedersenParameters},
     gadgets::crh::{pedersen::PedersenCRHGadget, FixedLengthCRHGadget},
@@ -84,12 +81,7 @@ pub fn pedersen_compression<CS: ConstraintSystem<Bls12>>(
     params: &PedersenParameters<JubJub>,
 ) -> Result<Vec<UInt8>, SynthesisError> {
     let h = pedersen_compression_num(cs.ns(|| "compression"), bytes, params)?;
-    let mut out = h.to_bytes(cs.ns(|| "h into bits"))?;
-
-    // to_bits convert the value to a big-endian number, we need it to be little-endian
-    out.reverse();
-
-    Ok(out)
+    h.to_bytes(cs.ns(|| "h into bits"))
 }
 
 #[cfg(test)]
@@ -97,6 +89,7 @@ mod tests {
 
     use super::*;
 
+    use algebra::curves::ProjectiveCurve;
     use rand::{Rng, SeedableRng, XorShiftRng};
 
     use crate::circuit::test::TestConstraintSystem;
@@ -141,8 +134,8 @@ mod tests {
         let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
         let cases = [
-            (64, 8576),  // 64 bytes
-            (128, 9088), // 128 bytes
+            (64, 4608),  // 64 bytes
+            (128, 5120), // 128 bytes
         ];
 
         for (bytes, constraints) in &cases {

--- a/storage-proofs/src/circuit/pedersen.rs
+++ b/storage-proofs/src/circuit/pedersen.rs
@@ -1,15 +1,17 @@
 use algebra::curves::bls12_381::Bls12_381 as Bls12;
 use algebra::curves::jubjub::JubJubProjective as JubJub;
+use algebra::curves::ProjectiveCurve;
+use algebra::fields::PrimeField;
 
 use dpc::{
     crypto_primitives::crh::{pedersen::PedersenCRH, pedersen::PedersenParameters},
     gadgets::crh::{pedersen::PedersenCRHGadget, FixedLengthCRHGadget},
 };
 use snark::{ConstraintSystem, SynthesisError};
-use snark_gadgets::bits::{boolean::Boolean, uint8::UInt8};
+use snark_gadgets::bits::uint8::UInt8;
 use snark_gadgets::fields::fp::FpGadget;
 use snark_gadgets::groups::curves::twisted_edwards::jubjub::JubJubGadget;
-use snark_gadgets::utils::{AllocGadget, ToBitsGadget};
+use snark_gadgets::utils::{AllocGadget, ToBytesGadget};
 
 use crate::crypto::pedersen::{BigWindow, PEDERSEN_BLOCK_SIZE};
 
@@ -19,22 +21,22 @@ type CRH = PedersenCRH<JubJub, BigWindow>;
 /// Pedersen hashing for inputs with length multiple of the block size. Based on a Merkle-Damgard construction.
 pub fn pedersen_md_no_padding<CS: ConstraintSystem<Bls12>>(
     mut cs: CS,
-    bits: &[Boolean],
+    bytes: &[UInt8],
     params: &PedersenParameters<JubJub>,
 ) -> Result<FpGadget<Bls12>, SynthesisError> {
     assert!(
-        bits.len() >= 2 * PEDERSEN_BLOCK_SIZE,
+        (bytes.len() * 8) >= 2 * PEDERSEN_BLOCK_SIZE,
         "must be at least 2 block sizes long"
     );
 
     assert_eq!(
-        bits.len() % PEDERSEN_BLOCK_SIZE,
+        (bytes.len() * 8) % PEDERSEN_BLOCK_SIZE,
         0,
         "must be a multiple of the block size"
     );
 
-    let mut chunks = bits.chunks(PEDERSEN_BLOCK_SIZE);
-    let mut cur: Vec<Boolean> = chunks.nth(0).unwrap().to_vec();
+    let mut chunks = bytes.chunks(PEDERSEN_BLOCK_SIZE / 8);
+    let mut cur: Vec<UInt8> = chunks.nth(0).unwrap().to_vec();
     let chunks_len = chunks.len();
 
     for (i, block) in chunks.enumerate() {
@@ -56,7 +58,7 @@ pub fn pedersen_md_no_padding<CS: ConstraintSystem<Bls12>>(
 
 pub fn pedersen_compression_num<CS: ConstraintSystem<Bls12>>(
     mut cs: CS,
-    bits: &[Boolean],
+    bytes: &[UInt8],
     params: &PedersenParameters<JubJub>,
 ) -> Result<FpGadget<Bls12>, SynthesisError> {
     let gadget_parameters =
@@ -66,20 +68,10 @@ pub fn pedersen_compression_num<CS: ConstraintSystem<Bls12>>(
         )
         .unwrap();
 
-    let mut bits = bits.to_vec();
-    while bits.len() % 8 != 0 {
-        bits.push(Boolean::Constant(false));
-    }
-
-    let input_bytes = bits
-        .chunks(8)
-        .map(|v| UInt8::from_bits_le(v))
-        .collect::<Vec<UInt8>>();
-
     let gadget_result = <CRHGadget as FixedLengthCRHGadget<CRH, Bls12>>::check_evaluation_gadget(
         &mut cs.ns(|| "gadget_evaluation"),
         &gadget_parameters,
-        &input_bytes,
+        &bytes,
     )
     .unwrap();
 
@@ -88,19 +80,14 @@ pub fn pedersen_compression_num<CS: ConstraintSystem<Bls12>>(
 
 pub fn pedersen_compression<CS: ConstraintSystem<Bls12>>(
     mut cs: CS,
-    bits: &[Boolean],
+    bytes: &[UInt8],
     params: &PedersenParameters<JubJub>,
-) -> Result<Vec<Boolean>, SynthesisError> {
-    let h = pedersen_compression_num(cs.ns(|| "compression"), bits, params)?;
-    let mut out = h.to_bits(cs.ns(|| "h into bits"))?;
+) -> Result<Vec<UInt8>, SynthesisError> {
+    let h = pedersen_compression_num(cs.ns(|| "compression"), bytes, params)?;
+    let mut out = h.to_bytes(cs.ns(|| "h into bits"))?;
 
     // to_bits convert the value to a big-endian number, we need it to be little-endian
     out.reverse();
-
-    // Needs padding, because x does not always translate to exactly 256 bits
-    while out.len() < PEDERSEN_BLOCK_SIZE {
-        out.push(Boolean::Constant(false));
-    }
 
     Ok(out)
 }
@@ -115,7 +102,6 @@ mod tests {
     use crate::circuit::test::TestConstraintSystem;
     use crate::crypto;
     use crate::singletons::PEDERSEN_PARAMS;
-    use crate::util::bytes_into_boolean_vec;
 
     #[test]
     fn test_pedersen_input_circuit() {
@@ -125,17 +111,19 @@ mod tests {
             let mut cs = TestConstraintSystem::<Bls12>::new();
             let data: Vec<u8> = (0..i * 32).map(|_| rng.gen()).collect();
 
-            let data_bits: Vec<Boolean> = {
+            let data_bytes: Vec<UInt8> = {
                 let mut cs = cs.ns(|| "data");
-                bytes_into_boolean_vec(&mut cs, Some(data.as_slice()), data.len()).unwrap()
+                data.iter()
+                    .enumerate()
+                    .map(|(byte_i, input_byte)| {
+                        let cs = cs.ns(|| format!("input_byte_{}", byte_i));
+                        UInt8::alloc(cs, || Ok(*input_byte)).unwrap()
+                    })
+                    .collect()
             };
-
-            let out = pedersen_md_no_padding(
-                cs.ns(|| "pedersen"),
-                data_bits.as_slice(),
-                &PEDERSEN_PARAMS,
-            )
-            .expect("pedersen hashing failed");
+            let out =
+                pedersen_md_no_padding(cs.ns(|| "pedersen"), &data_bytes[..], &PEDERSEN_PARAMS)
+                    .expect("pedersen hashing failed");
 
             assert!(cs.is_satisfied(), "constraints not satisfied");
 
@@ -153,24 +141,27 @@ mod tests {
         let mut rng = XorShiftRng::from_seed([0x5dbe6259, 0x8d313d76, 0x3237db17, 0xe5bc0654]);
 
         let cases = [
-            (64, 8576),    // 64 bytes
-            (96, 17152),   // 96 bytes
-            (128, 25728),  // 128 bytes
-            (160, 34304),  // 160 bytes
-            (512, 128640), // 512 bytes
+            (64, 8576),  // 64 bytes
+            (128, 9088), // 128 bytes
         ];
 
         for (bytes, constraints) in &cases {
             let mut cs = TestConstraintSystem::<Bls12>::new();
             let data: Vec<u8> = (0..*bytes).map(|_| rng.gen()).collect();
 
-            let data_bits: Vec<Boolean> = {
+            let data_bytes: Vec<UInt8> = {
                 let mut cs = cs.ns(|| "data");
-                bytes_into_boolean_vec(&mut cs, Some(data.as_slice()), data.len()).unwrap()
+                data.iter()
+                    .enumerate()
+                    .map(|(byte_i, input_byte)| {
+                        let cs = cs.ns(|| format!("input_byte_{}", byte_i));
+                        UInt8::alloc(cs, || Ok(*input_byte)).unwrap()
+                    })
+                    .collect()
             };
-            let out = pedersen_md_no_padding(
+            let out = pedersen_compression_num(
                 cs.ns(|| "pedersen"),
-                data_bits.as_slice(),
+                data_bytes.as_slice(),
                 &PEDERSEN_PARAMS,
             )
             .expect("pedersen hashing failed");
@@ -183,8 +174,7 @@ mod tests {
                 bytes
             );
 
-            let expected = crypto::pedersen::pedersen_md_no_padding(data.as_slice());
-
+            let expected = crypto::pedersen::pedersen(data.as_slice()).into_affine().x;
             assert_eq!(
                 expected,
                 out.value.unwrap(),

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -180,11 +180,8 @@ impl<'a, H: Hasher> Circuit<Bls12> for PoRCircuit<'a, H> {
                     &path_element,
                 )?;
 
-                let mut xl_bytes = xl.to_bytes(cs.ns(|| "xl into bytes"))?;
-                let mut xr_bytes = xr.to_bytes(cs.ns(|| "xr into bytes"))?;
-
-                // xl_bytes.reverse();
-                // xr_bytes.reverse();
+                let xl_bytes = xl.to_bytes(cs.ns(|| "xl into bytes"))?;
+                let xr_bytes = xr.to_bytes(cs.ns(|| "xr into bytes"))?;
 
                 // Compute the new subtree value
                 cur = H::Function::hash_leaf_circuit(
@@ -331,7 +328,7 @@ mod tests {
 
     #[test]
     fn test_por_input_circuit_with_bls12_381_pedersen() {
-        test_por_input_circuit_with_bls12_381::<PedersenHasher>(25746);
+        test_por_input_circuit_with_bls12_381::<PedersenHasher>(13842);
     }
 
     #[test]
@@ -578,7 +575,7 @@ mod tests {
             assert!(cs.is_satisfied(), "constraints not satisfied");
 
             assert_eq!(cs.num_inputs(), 2, "wrong number of inputs");
-            assert_eq!(cs.num_constraints(), 25739, "wrong number of constraints");
+            assert_eq!(cs.num_constraints(), 13841, "wrong number of constraints");
 
             let auth_path_bits: Vec<bool> = proof
                 .proof

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -7,7 +7,7 @@ use snark::{Circuit, ConstraintSystem, SynthesisError};
 use snark_gadgets::{
     boolean,
     fields::fp::FpGadget,
-    utils::{AllocGadget, CondReverseGadget, ToBitsGadget},
+    utils::{AllocGadget, CondReverseGadget, ToBytesGadget},
 };
 
 use crate::circuit::{constraint, multipack, variables::Root};
@@ -180,17 +180,17 @@ impl<'a, H: Hasher> Circuit<Bls12> for PoRCircuit<'a, H> {
                     &path_element,
                 )?;
 
-                let mut xl_bits = xl.to_bits(cs.ns(|| "xl into bits"))?;
-                let mut xr_bits = xr.to_bits(cs.ns(|| "xr into bits"))?;
+                let mut xl_bytes = xl.to_bytes(cs.ns(|| "xl into bytes"))?;
+                let mut xr_bytes = xr.to_bytes(cs.ns(|| "xr into bytes"))?;
 
-                xl_bits.reverse();
-                xr_bits.reverse();
+                // xl_bytes.reverse();
+                // xr_bytes.reverse();
 
                 // Compute the new subtree value
                 cur = H::Function::hash_leaf_circuit(
                     cs.ns(|| "computation of pedersen hash"),
-                    &xl_bits,
-                    &xr_bits,
+                    &xl_bytes[..],
+                    &xr_bytes[..],
                     i,
                     params,
                 )?;
@@ -331,12 +331,12 @@ mod tests {
 
     #[test]
     fn test_por_input_circuit_with_bls12_381_pedersen() {
-        test_por_input_circuit_with_bls12_381::<PedersenHasher>(25740);
+        test_por_input_circuit_with_bls12_381::<PedersenHasher>(25746);
     }
 
     #[test]
     fn test_por_input_circuit_with_bls12_381_blake2s() {
-        test_por_input_circuit_with_bls12_381::<Blake2sHasher>(65388);
+        test_por_input_circuit_with_bls12_381::<Blake2sHasher>(65394);
     }
 
     fn test_por_input_circuit_with_bls12_381<H: Hasher>(num_constraints: usize) {

--- a/storage-proofs/src/circuit/porc.rs
+++ b/storage-proofs/src/circuit/porc.rs
@@ -192,11 +192,9 @@ impl<'a> Circuit<Bls12> for PoRCCircuit<'a> {
                 )?;
 
                 let mut preimage = vec![];
-                let mut xl_bytes = xl.to_bytes(cs.ns(|| "xl into bytes"))?;
-                let mut xr_bytes = xr.to_bytes(cs.ns(|| "xr into bytes"))?;
+                let xl_bytes = xl.to_bytes(cs.ns(|| "xl into bytes"))?;
+                let xr_bytes = xr.to_bytes(cs.ns(|| "xr into bytes"))?;
 
-                xl_bytes.reverse();
-                xr_bytes.reverse();
                 preimage.extend(xl_bytes);
                 preimage.extend(xr_bytes);
 
@@ -354,7 +352,7 @@ mod tests {
         assert!(cs.is_satisfied(), "constraints not satisfied");
 
         assert_eq!(cs.num_inputs(), 1, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 85796, "wrong number of constraints");
+        assert_eq!(cs.num_constraints(), 46136, "wrong number of constraints");
         assert_eq!(cs.get_input(0, "ONE"), Fr::one());
     }
 

--- a/storage-proofs/src/circuit/porc.rs
+++ b/storage-proofs/src/circuit/porc.rs
@@ -7,7 +7,7 @@ use snark::{Circuit, ConstraintSystem, SynthesisError};
 use snark_gadgets::{
     boolean,
     fields::fp::FpGadget,
-    utils::{AllocGadget, CondReverseGadget, ToBitsGadget},
+    utils::{AllocGadget, CondReverseGadget, ToBytesGadget},
     Assignment,
 };
 
@@ -192,18 +192,18 @@ impl<'a> Circuit<Bls12> for PoRCCircuit<'a> {
                 )?;
 
                 let mut preimage = vec![];
-                let mut xl_bits = xl.to_bits(cs.ns(|| "xl into bits"))?;
-                let mut xr_bits = xr.to_bits(cs.ns(|| "xr into bits"))?;
+                let mut xl_bytes = xl.to_bytes(cs.ns(|| "xl into bytes"))?;
+                let mut xr_bytes = xr.to_bytes(cs.ns(|| "xr into bytes"))?;
 
-                xl_bits.reverse();
-                xr_bits.reverse();
-                preimage.extend(xl_bits);
-                preimage.extend(xr_bits);
+                xl_bytes.reverse();
+                xr_bytes.reverse();
+                preimage.extend(xl_bytes);
+                preimage.extend(xr_bytes);
 
                 // Compute the new subtree value
                 cur = pedersen::pedersen_compression_num(
                     cs.ns(|| "computation of pedersen hash"),
-                    &preimage,
+                    &preimage[..],
                     params,
                 )?
                 .clone(); // Injective encoding

--- a/storage-proofs/src/circuit/vdf_post.rs
+++ b/storage-proofs/src/circuit/vdf_post.rs
@@ -506,7 +506,7 @@ mod tests {
         assert!(cs.is_satisfied(), "constraints not satisfied");
 
         assert_eq!(cs.num_inputs(), 3, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 1801684, "wrong number of constraints");
+        assert_eq!(cs.num_constraints(), 968824, "wrong number of constraints");
         assert_eq!(cs.get_input(0, "ONE"), Fr::one());
     }
 

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -3,9 +3,9 @@ use std::marker::PhantomData;
 use algebra::curves::bls12_381::Bls12_381 as Bls12;
 use algebra::fields::bls12_381::Fr;
 use snark::{Circuit, ConstraintSystem, SynthesisError};
-use snark_gadgets::boolean;
 use snark_gadgets::fields::fp::FpGadget;
-use snark_gadgets::utils::{AllocGadget, ToBitsGadget};
+use snark_gadgets::uint8::UInt8;
+use snark_gadgets::utils::{AllocGadget, ToBytesGadget};
 
 use crate::circuit::constraint;
 use crate::circuit::drgporep::{ComponentPrivateInputs, DrgPoRepCompound};
@@ -201,29 +201,29 @@ impl<'a, H: Hasher> Circuit<Bls12> for ZigZagCircuit<'a, H> {
         // Compute CommRStar = Hash(replica_id | comm_r_0 | ... | comm_r_l).
         {
             // Collect the bits to be hashed into crs_boolean.
-            let mut crs_boolean = replica_id_num.to_bits(cs.ns(|| "replica_id_bits"))?;
+            let mut crs_bytes = replica_id_num.to_bytes(cs.ns(|| "replica_id_bytes"))?;
 
-            crs_boolean.reverse();
+            crs_bytes.reverse();
 
             // sad padding is sad
-            while crs_boolean.len() % 256 != 0 {
-                crs_boolean.push(boolean::Boolean::Constant(false));
+            while crs_bytes.len() % 256 != 0 {
+                crs_bytes.push(UInt8::constant(8));
             }
 
             for (i, comm_r) in comm_rs.into_iter().enumerate() {
-                let mut comm_r_bits = comm_r.to_bits(cs.ns(|| format!("comm_r-bits-{}", i)))?;
-                comm_r_bits.reverse();
-                crs_boolean.extend(comm_r_bits);
+                let mut comm_r_bytes = comm_r.to_bytes(cs.ns(|| format!("comm_r-bits-{}", i)))?;
+                comm_r_bytes.reverse();
+                crs_bytes.extend(comm_r_bytes);
                 // sad padding is sad
-                while crs_boolean.len() % 256 != 0 {
-                    crs_boolean.push(boolean::Boolean::Constant(false));
+                while crs_bytes.len() % 256 != 0 {
+                    crs_bytes.push(UInt8::constant(0));
                 }
             }
 
             // Calculate the pedersen hash.
             let computed_comm_r_star = H::Function::hash_circuit(
                 cs.ns(|| "comm_r_star"),
-                &crs_boolean[..],
+                &crs_bytes[..],
                 &PEDERSEN_PARAMS,
             )?;
 

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -4,7 +4,6 @@ use algebra::curves::bls12_381::Bls12_381 as Bls12;
 use algebra::fields::bls12_381::Fr;
 use snark::{Circuit, ConstraintSystem, SynthesisError};
 use snark_gadgets::fields::fp::FpGadget;
-use snark_gadgets::uint8::UInt8;
 use snark_gadgets::utils::{AllocGadget, ToBytesGadget};
 
 use crate::circuit::constraint;
@@ -203,21 +202,9 @@ impl<'a, H: Hasher> Circuit<Bls12> for ZigZagCircuit<'a, H> {
             // Collect the bits to be hashed into crs_boolean.
             let mut crs_bytes = replica_id_num.to_bytes(cs.ns(|| "replica_id_bytes"))?;
 
-            crs_bytes.reverse();
-
-            // sad padding is sad
-            while crs_bytes.len() % 256 != 0 {
-                crs_bytes.push(UInt8::constant(8));
-            }
-
             for (i, comm_r) in comm_rs.into_iter().enumerate() {
-                let mut comm_r_bytes = comm_r.to_bytes(cs.ns(|| format!("comm_r-bits-{}", i)))?;
-                comm_r_bytes.reverse();
+                let comm_r_bytes = comm_r.to_bytes(cs.ns(|| format!("comm_r-bits-{}", i)))?;
                 crs_bytes.extend(comm_r_bytes);
-                // sad padding is sad
-                while crs_bytes.len() % 256 != 0 {
-                    crs_bytes.push(UInt8::constant(0));
-                }
             }
 
             // Calculate the pedersen hash.
@@ -437,7 +424,7 @@ mod tests {
         // End copied section.
 
         let expected_inputs = 16;
-        let expected_constraints = 362488;
+        let expected_constraints = 235576;
         {
             // Verify that MetricCS returns the same metrics as TestConstraintSystem.
             let mut cs = MetricCS::<Bls12>::new();

--- a/storage-proofs/src/crypto/pedersen.rs
+++ b/storage-proofs/src/crypto/pedersen.rs
@@ -47,31 +47,15 @@ impl Personalization {
     }
 }
 
-pub fn pedersen_hash<I>(
+pub fn pedersen_hash(
     personalization: Personalization,
-    bits: I,
-) -> GroupProjective<JubJubParameters>
-where
-    I: IntoIterator<Item = bool>,
-{
-    let mut bits: Vec<bool> = personalization
-        .get_bits()
-        .into_iter()
-        .chain(bits.into_iter())
-        .collect();
-
-    while bits.len() % 8 != 0 {
-        bits.push(false);
-    }
-
-    let bytes = BitVec::<bitvec::LittleEndian, _>::from(&bits[..]);
-
-    PedersenCRH::<JubJub, BigWindow>::evaluate(&PEDERSEN_PARAMS, bytes.as_ref()).unwrap()
+    bytes: &[u8],
+) -> GroupProjective<JubJubParameters> {
+    PedersenCRH::<JubJub, BigWindow>::evaluate(&PEDERSEN_PARAMS, bytes).unwrap()
 }
 
 pub fn pedersen(data: &[u8]) -> GroupProjective<JubJubParameters> {
-    let bits = BitVec::<bitvec::LittleEndian, u8>::from(data);
-    pedersen_hash(Personalization::None, bits)
+    pedersen_hash(Personalization::None, data)
 }
 
 /// Pedersen hashing for inputs that have length multiple of the block size `256`. Based on pedersen hashes and a Merkle-Damgard construction.

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -22,7 +22,7 @@ use snark_gadgets::groups::curves::twisted_edwards::jubjub::JubJubGadget;
 use snark_gadgets::utils::AllocGadget;
 
 use crate::circuit::pedersen::pedersen_md_no_padding;
-use crate::crypto::pedersen::{pedersen_hash, BigWindow, Personalization};
+use crate::crypto::pedersen::BigWindow;
 use crate::crypto::{kdf, pedersen, sloth};
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, HashFunction, Hasher};
@@ -280,48 +280,6 @@ impl LightAlgorithm<PedersenDomain> for PedersenFunction {
             .into_affine()
             .x
             .into()
-    }
-}
-
-/// Helper to iterate over a pair of `Fr`.
-struct NodeBits<'a> {
-    // 256 bits
-    lhs: &'a [u64],
-    // 256 bits
-    rhs: &'a [u64],
-    index: usize,
-}
-
-impl<'a> NodeBits<'a> {
-    pub fn new(lhs: &'a [u64], rhs: &'a [u64]) -> Self {
-        NodeBits { lhs, rhs, index: 0 }
-    }
-}
-
-impl<'a> Iterator for NodeBits<'a> {
-    type Item = bool;
-
-    #[inline]
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.index < 255 {
-            // return lhs
-            let a = self.index / 64;
-            let b = self.index % 64;
-            let res = (self.lhs[a] & (1 << b)) != 0;
-            self.index += 1;
-            return Some(res);
-        }
-
-        if self.index < 2 * 255 {
-            // return rhs
-            let a = (self.index - 255) / 64;
-            let b = (self.index - 255) % 64;
-            let res = (self.rhs[a] & (1 << b)) != 0;
-            self.index += 1;
-            return Some(res);
-        }
-
-        None
     }
 }
 

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -3,34 +3,30 @@ use std::hash::Hasher as StdHasher;
 use std::io::Read;
 use std::io::Write;
 
-use snark::{ConstraintSystem, SynthesisError};
-
 use algebra::biginteger::BigInteger;
 use algebra::biginteger::BigInteger256 as FrRepr;
 use algebra::curves::ProjectiveCurve;
 use algebra::curves::{bls12_381::Bls12_381 as Bls12, jubjub::JubJubProjective as JubJub};
 use algebra::fields::{bls12_381::Fr, PrimeField};
-
-use snark_gadgets::bits::uint8::UInt8;
-use snark_gadgets::boolean::Boolean;
-use snark_gadgets::fields::fp::FpGadget;
-use snark_gadgets::groups::curves::twisted_edwards::jubjub::JubJubGadget;
-
-use snark_gadgets::utils::AllocGadget;
-
+use dpc::crypto_primitives::crh::FixedLengthCRH;
 use dpc::{
     crypto_primitives::crh::pedersen::{PedersenCRH, PedersenParameters},
     gadgets::crh::{pedersen::PedersenCRHGadget, FixedLengthCRHGadget},
 };
-
 use merkletree::hash::{Algorithm as LightAlgorithm, Hashable};
 use merkletree::merkle::Element;
+use snark::{ConstraintSystem, SynthesisError};
+use snark_gadgets::bits::uint8::UInt8;
+use snark_gadgets::fields::fp::FpGadget;
+use snark_gadgets::groups::curves::twisted_edwards::jubjub::JubJubGadget;
+use snark_gadgets::utils::AllocGadget;
 
 use crate::circuit::pedersen::pedersen_md_no_padding;
 use crate::crypto::pedersen::{pedersen_hash, BigWindow, Personalization};
 use crate::crypto::{kdf, pedersen, sloth};
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, HashFunction, Hasher};
+use crate::singletons::PEDERSEN_PARAMS;
 
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq)]
 pub struct PedersenHasher {}
@@ -212,12 +208,12 @@ impl HashFunction<PedersenDomain> for PedersenFunction {
 
     fn hash_leaf_circuit<CS: ConstraintSystem<Bls12>>(
         mut cs: CS,
-        left: &[Boolean],
-        right: &[Boolean],
+        left: &[UInt8],
+        right: &[UInt8],
         _height: usize,
         params: &PedersenParameters<JubJub>,
     ) -> std::result::Result<FpGadget<Bls12>, SynthesisError> {
-        let mut preimage: Vec<Boolean> = vec![];
+        let mut preimage: Vec<UInt8> = vec![];
         preimage.extend_from_slice(left);
         preimage.extend_from_slice(right);
 
@@ -231,20 +227,11 @@ impl HashFunction<PedersenDomain> for PedersenFunction {
             )
             .unwrap();
 
-        while preimage.len() % 8 != 0 {
-            preimage.push(Boolean::Constant(false));
-        }
-
-        let input_bytes = preimage
-            .chunks(8)
-            .map(|v| UInt8::from_bits_le(v))
-            .collect::<Vec<UInt8>>();
-
         let gadget_result =
             <CRHGadget as FixedLengthCRHGadget<CRH, Bls12>>::check_evaluation_gadget(
                 &mut cs.ns(|| "gadget_evaluation"),
                 &gadget_parameters,
-                &input_bytes,
+                &preimage,
             )
             .unwrap();
 
@@ -253,10 +240,10 @@ impl HashFunction<PedersenDomain> for PedersenFunction {
 
     fn hash_circuit<CS: ConstraintSystem<Bls12>>(
         cs: CS,
-        bits: &[Boolean],
+        bytes: &[UInt8],
         params: &PedersenParameters<JubJub>,
     ) -> std::result::Result<FpGadget<Bls12>, SynthesisError> {
-        pedersen_md_no_padding(cs, bits, params)
+        pedersen_md_no_padding(cs, bytes, params)
     }
 }
 
@@ -281,9 +268,15 @@ impl LightAlgorithm<PedersenDomain> for PedersenFunction {
         right: PedersenDomain,
         _height: usize,
     ) -> PedersenDomain {
-        let node_bits = NodeBits::new(&(left.0).0[..], &(right.0).0[..]);
+        let left: &[u8] = left.as_ref();
+        let right: &[u8] = right.as_ref();
 
-        pedersen_hash::<_>(Personalization::None, node_bits)
+        let mut bytes = Vec::with_capacity(left.len() + right.len());
+        bytes.extend_from_slice(left);
+        bytes.extend_from_slice(right);
+
+        PedersenCRH::<JubJub, BigWindow>::evaluate(&PEDERSEN_PARAMS, &bytes[..])
+            .unwrap()
             .into_affine()
             .x
             .into()

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -10,7 +10,7 @@ use algebra::curves::jubjub::JubJubProjective as JubJub;
 use algebra::fields::bls12_381::Fr;
 use dpc::crypto_primitives::crh::pedersen::PedersenParameters;
 use snark::{ConstraintSystem, SynthesisError};
-use snark_gadgets::bits::boolean;
+use snark_gadgets::bits::uint8::UInt8;
 use snark_gadgets::fields::fp::FpGadget;
 
 use crate::error::Result;
@@ -60,15 +60,15 @@ pub trait HashFunction<T: Domain>:
 
     fn hash_leaf_circuit<CS: ConstraintSystem<Bls12_381>>(
         cs: CS,
-        left: &[boolean::Boolean],
-        right: &[boolean::Boolean],
+        left: &[UInt8],
+        right: &[UInt8],
         height: usize,
         params: &PedersenParameters<JubJub>,
     ) -> std::result::Result<FpGadget<Bls12_381>, SynthesisError>;
 
     fn hash_circuit<CS: ConstraintSystem<Bls12_381>>(
         cs: CS,
-        bits: &[boolean::Boolean],
+        bits: &[UInt8],
         params: &PedersenParameters<JubJub>,
     ) -> std::result::Result<FpGadget<Bls12_381>, SynthesisError>;
 }

--- a/storage-proofs/src/test_helper.rs
+++ b/storage-proofs/src/test_helper.rs
@@ -1,11 +1,11 @@
 use algebra::biginteger::BigInteger;
 use algebra::curves::bls12_381::Bls12_381 as Bls12;
-use algebra::fields::{bls12_381::Fr, BitIterator, FpParameters, PrimeField};
+use algebra::fields::{bls12_381::Fr, PrimeField};
 use algebra::ToBytes;
 use rand::Rng;
 
 use crate::crypto;
-use crate::crypto::pedersen::{pedersen_hash, Personalization};
+use crate::crypto::pedersen::pedersen;
 use crate::error;
 use crate::fr32::{bytes_into_fr, fr_into_bytes};
 use crate::hasher::pedersen::{PedersenDomain, PedersenFunction, PedersenHasher};
@@ -161,7 +161,7 @@ pub fn random_merkle_path_with_value<R: Rng>(
         lhs.into_repr().write(&mut bytes).unwrap();
         rhs.into_repr().write(&mut bytes).unwrap();
 
-        cur = pedersen_hash(Personalization::None, &bytes).x
+        cur = pedersen(&bytes).x
     }
 
     (auth_path, cur)


### PR DESCRIPTION
Investigating how to make this work, to avoid explosion in constraints

Issues solved:

- use `UInt8` instead of `Boolean` to avoid double constraints for conversions
- use appropriate pedersen window size, to avoid padding
- use bigendian for some encodings as that is what zexe uses