### PR TITLE
add composable with-dots.sh script

### DIFF
--- a/fil-proofs-tooling/scripts/with-dots.sh
+++ b/fil-proofs-tooling/scripts/with-dots.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+trap cleanup EXIT
+
+cleanup() {
+  kill $DOT_PID
+}
+
+(
+  sleep 1
+  while true; do
+    (printf "." >&2)
+    sleep 1
+  done
+) &
+DOT_PID=$!
+
+$@


### PR DESCRIPTION

with a basic sleep:

```sh
$ ./with-dots.sh sleep 5
....%
```

a script that prints 'A', sleeps 5 seconds, then prints 'B':

```sh
$ ./with-dots.sh /tmp/some-long-command.sh
A
....B
```
