### PR TITLE
Feat/821 and 814 benchmark improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,18 +195,20 @@ jobs:
           command: apt-get install time jq -yqq
       - run:
           name: Run hash-constraints benchmarks on remote host
-          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" hash-constraints > hash-constraints.json
+          command: |
+            ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" hash-constraints > hash-constraints.json
+            cat hash-constraints.json
           no_output_timeout: 60m
       - run:
           name: Run micro benchmarks
           command: |
-            ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" -- hash-blake2s/non-circuit > micro-benchmarks.json
+            ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" > micro-benchmarks.json
             cat micro-benchmarks.json
           no_output_timeout: 60m
       - run:
           name: Run ZigZag benchmarks using 1GiB sectors
           command: |
-            ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=1 > zigzag-benchmarks.json
+            ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) > zigzag-benchmarks.json
             cat zigzag-benchmarks.json
           no_output_timeout: 60m
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,11 +199,11 @@ jobs:
           no_output_timeout: 60m
       - run:
           name: Run micro benchmarks
-          command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" > micro-benchmarks.json
+          command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" -- hash-blake2s/non-circuit > micro-benchmarks.json
           no_output_timeout: 60m
       - run:
           name: Run ZigZag benchmarks using 1GiB sectors
-          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) > zigzag-benchmarks.json
+          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=1 > zigzag-benchmarks.json
           no_output_timeout: 60m
       - run:
           name: Aggregate benchmarks into single JSON document
@@ -335,7 +335,7 @@ workflows:
             - cargo_fetch
           filters:
             branches:
-              only: master
+              only: feat/821-and-814-benchmark-improvements
       - build_linux_release:
           requires:
             - cargo_fetch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,11 +208,13 @@ jobs:
       - run:
           name: Aggregate benchmarks into single JSON document
           command: |
-            jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "zigzag-benchmarks": .[2], "micro-benchmarks": .[3] } }' \
-              <(jq 'del (.benchmarks)' micro-benchmarks.json) \
-              <(jq '.benchmarks' hash-constraints.json) \
-              <(jq '.benchmarks' zigzag-benchmarks.json) \
-              <(jq '.benchmarks' micro-benchmarks.json)
+            jq --sort-keys -s '{ benchmarks: { "zigzag-benchmarks": { outputs: { "max-resident-set-size-kb": .[0] } } } } * .[1]' \
+              <(jq '.["max-resident-set-size-kb"]' zigzag-benchmarks.json) \
+              <(jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "zigzag-benchmarks": .[2], "micro-benchmarks": .[3] } }' \
+                <(jq 'del (.benchmarks)' micro-benchmarks.json) \
+                <(jq '.benchmarks' hash-constraints.json) \
+                <(jq '.benchmarks' zigzag-benchmarks.json) \
+                <(jq '.benchmarks' micro-benchmarks.json))
 
   rustfmt:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,16 +195,24 @@ jobs:
           command: apt-get install time jq -yqq
       - run:
           name: Run hash-constraints benchmarks on remote host
-          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" hash-circuits
+          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" hash-constraints > hash-constraints.json
           no_output_timeout: 60m
       - run:
           name: Run micro benchmarks
-          command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}"
+          command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" > micro-benchmarks.json
           no_output_timeout: 60m
       - run:
           name: Run ZigZag benchmarks using 1GiB sectors
-          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024))
+          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) > zigzag-benchmarks.json
           no_output_timeout: 60m
+      - run:
+          name: Aggregate benchmarks into single JSON document
+          command: |
+            jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "zigzag-benchmarks": .[2], "micro-benchmarks": .[3] } }' \
+              <(jq 'del (.benchmarks)' micro-benchmarks.json) \
+              <(jq '.benchmarks' hash-constraints.json) \
+              <(jq '.benchmarks' zigzag-benchmarks.json) \
+              <(jq '.benchmarks' micro-benchmarks.json)
 
   rustfmt:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,14 +214,8 @@ jobs:
       - run:
           name: Aggregate benchmarks into single JSON document
           command: |
-            jq --sort-keys -s '{ benchmarks: { "zigzag-benchmarks": { outputs: { "max-resident-set-size-kb": .[0] } } } } * .[1]' \
-              <(jq '.["max-resident-set-size-kb"]' zigzag-benchmarks.json) \
-              <(jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "zigzag-benchmarks": .[2], "micro-benchmarks": .[3] } }' \
-                <(jq 'del (.benchmarks)' micro-benchmarks.json) \
-                <(jq '.benchmarks' hash-constraints.json) \
-                <(jq '.benchmarks' zigzag-benchmarks.json) \
-                <(jq '.benchmarks' micro-benchmarks.json)) > combined-benchmarks.json
-            cat combined-benchmarks.json
+            ./fil-proofs-tooling/scripts/aggregate-benchmarks.sh zigzag-benchmarks.json micro-benchmarks.json hash-constraints.json > aggregated-benchmarks.json
+            cat aggregated-benchmarks.json
       - store_artifacts:
           path: zigzag-benchmarks.json
       - store_artifacts:
@@ -229,7 +223,7 @@ jobs:
       - store_artifacts:
           path: micro-benchmarks.json
       - store_artifacts:
-          path: combined-benchmarks.json
+          path: aggregated-benchmarks.json
 
   rustfmt:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,11 +199,15 @@ jobs:
           no_output_timeout: 60m
       - run:
           name: Run micro benchmarks
-          command: ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" -- hash-blake2s/non-circuit > micro-benchmarks.json
+          command: |
+            ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" -- hash-blake2s/non-circuit > micro-benchmarks.json
+            cat micro-benchmarks.json
           no_output_timeout: 60m
       - run:
           name: Run ZigZag benchmarks using 1GiB sectors
-          command: ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=1 > zigzag-benchmarks.json
+          command: |
+            ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=1 > zigzag-benchmarks.json
+            cat zigzag-benchmarks.json
           no_output_timeout: 60m
       - run:
           name: Aggregate benchmarks into single JSON document
@@ -214,7 +218,16 @@ jobs:
                 <(jq 'del (.benchmarks)' micro-benchmarks.json) \
                 <(jq '.benchmarks' hash-constraints.json) \
                 <(jq '.benchmarks' zigzag-benchmarks.json) \
-                <(jq '.benchmarks' micro-benchmarks.json))
+                <(jq '.benchmarks' micro-benchmarks.json)) > combined-benchmarks.json
+            cat combined-benchmarks.json
+      - store_artifacts:
+          path: zigzag-benchmarks.json
+      - store_artifacts:
+          path: hash-constraints.json
+      - store_artifacts:
+          path: micro-benchmarks.json
+      - store_artifacts:
+          path: combined-benchmarks.json
 
   rustfmt:
     docker:
@@ -337,7 +350,7 @@ workflows:
             - cargo_fetch
           filters:
             branches:
-              only: feat/821-and-814-benchmark-improvements
+              only: master
       - build_linux_release:
           requires:
             - cargo_fetch

--- a/fil-proofs-tooling/scripts/aggregate-benchmarks.sh
+++ b/fil-proofs-tooling/scripts/aggregate-benchmarks.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+zigzag_path=$1
+micro_path=$2
+hash_constraints_path=$3
+
+jq --sort-keys -s '{ benchmarks: { "zigzag-benchmarks": { outputs: { "max-resident-set-size-kb": .[0] } } } } * .[1]' \
+  <(jq '.["max-resident-set-size-kb"]' $zigzag_path) \
+  <(jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "zigzag-benchmarks": .[2], "micro-benchmarks": .[3] } }' \
+    <(jq 'del (.benchmarks)' $micro_path) \
+    <(jq '.benchmarks' $hash_constraints_path) \
+    <(jq '.benchmarks' $zigzag_path) \
+    <(jq '.benchmarks' $micro_path))

--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -6,7 +6,7 @@ CMDS=$(cat <<EOF
 cd \$(mktemp -d)
 git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
-git checkout -q feat/821-and-814-benchmark-improvements
+git checkout -q master
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/with-dots.sh \

--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -6,7 +6,7 @@ CMDS=$(cat <<EOF
 cd \$(mktemp -d)
 git clone -q https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
-git checkout -q master
+git checkout -q feat/821-and-814-benchmark-improvements
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/benchy.sh ${@:2}

--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -4,7 +4,7 @@ set -e
 
 CMDS=$(cat <<EOF
 cd \$(mktemp -d)
-git clone -q https://github.com/filecoin-project/rust-fil-proofs.git
+git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
 git checkout -q feat/821-and-814-benchmark-improvements
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \

--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -9,6 +9,7 @@ cd rust-fil-proofs
 git checkout -q feat/821-and-814-benchmark-improvements
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
+    ./fil-proofs-tooling/scripts/with-dots.sh \
     ./fil-proofs-tooling/scripts/benchy.sh ${@:2}
 EOF
 )

--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -13,4 +13,4 @@ git checkout -q master
 EOF
 )
 
-ssh -t -q $1 "$CMDS"
+ssh -q $1 "$CMDS"

--- a/fil-proofs-tooling/scripts/benchy.sh
+++ b/fil-proofs-tooling/scripts/benchy.sh
@@ -7,7 +7,7 @@ GTIME_STDERR=$(mktemp)
 JQ_STDERR=$(mktemp)
 
 GTIME_BIN="env time"
-GTIME_ARG="-f '{ \"benchmarks\": { \"outputs\": { \"max-resident-set-size-kb\": %M } } }' cargo run --quiet --bin benchy --release -- ${@}"
+GTIME_ARG="-f '{ \"max-resident-set-size-kb\": %M }' cargo run --quiet --bin benchy --release -- ${@}"
 
 if [[ $(env time --version 2>&1) != *"GNU"* ]]; then
     if [[ $(/usr/bin/time --version 2>&1) != *"GNU"* ]]; then

--- a/fil-proofs-tooling/scripts/benchy.sh
+++ b/fil-proofs-tooling/scripts/benchy.sh
@@ -7,7 +7,7 @@ GTIME_STDERR=$(mktemp)
 JQ_STDERR=$(mktemp)
 
 GTIME_BIN="env time"
-GTIME_ARG="-f '{ \"outputs\": { \"max-resident-set-size-kb\": %M } }' cargo run --quiet --bin benchy --release -- ${@}"
+GTIME_ARG="-f '{ \"benchmarks\": { \"outputs\": { \"max-resident-set-size-kb\": %M } } }' cargo run --quiet --bin benchy --release -- ${@}"
 
 if [[ $(env time --version 2>&1) != *"GNU"* ]]; then
     if [[ $(/usr/bin/time --version 2>&1) != *"GNU"* ]]; then

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -6,7 +6,7 @@ CMDS=$(cat <<EOF
 cd \$(mktemp -d)
 git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
-git checkout -q feat/821-and-814-benchmark-improvements
+git checkout -q master
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/with-dots.sh \

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -6,7 +6,7 @@ CMDS=$(cat <<EOF
 cd \$(mktemp -d)
 git clone -q https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
-git checkout -q master
+git checkout -q feat/821-and-814-benchmark-improvements
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/micro.sh ${@:2}

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -9,6 +9,7 @@ cd rust-fil-proofs
 git checkout -q feat/821-and-814-benchmark-improvements
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
+    ./fil-proofs-tooling/scripts/with-dots.sh \
     ./fil-proofs-tooling/scripts/micro.sh ${@:2}
 EOF
 )

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -4,7 +4,7 @@ set -e
 
 CMDS=$(cat <<EOF
 cd \$(mktemp -d)
-git clone -q https://github.com/filecoin-project/rust-fil-proofs.git
+git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
 git checkout -q feat/821-and-814-benchmark-improvements
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -13,4 +13,4 @@ git checkout -q master
 EOF
 )
 
-ssh -t -q $1 "$CMDS"
+ssh -q $1 "$CMDS"

--- a/fil-proofs-tooling/scripts/micro.sh
+++ b/fil-proofs-tooling/scripts/micro.sh
@@ -4,7 +4,7 @@ MICRO_SDERR=$(mktemp)
 MICRO_SDOUT=$(mktemp)
 JQ_STDERR=$(mktemp)
 
-CMD="cargo run --quiet --bin micro --release ${@}"
+CMD="cargo run --bin micro --release ${@}"
 
 eval "RUST_BACKTRACE=1 RUSTFLAGS=\"-Awarnings -C target-cpu=native\" ${CMD}" 1> $MICRO_SDOUT 2> $MICRO_SDERR
 

--- a/fil-proofs-tooling/scripts/retry.sh
+++ b/fil-proofs-tooling/scripts/retry.sh
@@ -35,7 +35,9 @@ for attempt in `seq 1 $attempts`; do
 
     sleep_ms="$(($attempt * $attempt * $sleep_millis))"
 
-    echo >&2 "sleeping ${sleep_ms:0:-3}.${sleep_ms: -3}s and then retrying ($((attempt + 1))/${attempts})"
+    sleep_seconds=$(echo "scale=2; ${sleep_ms}/1000" | bc)
 
-    sleep "${sleep_ms:0:-3}.${sleep_ms: -3}"
+    echo >&2 "sleeping ${sleep_seconds}s and then retrying ($((attempt + 1))/${attempts})"
+
+    sleep "${sleep_seconds}"
 done

--- a/fil-proofs-tooling/scripts/with-dots.sh
+++ b/fil-proofs-tooling/scripts/with-dots.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+trap cleanup EXIT
+
+cleanup() {
+  kill $DOT_PID
+}
+
+(
+  sleep 1
+  while true; do
+    (printf "." >&2)
+    sleep 1
+  done
+) &
+DOT_PID=$!
+
+$@

--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -112,8 +112,8 @@ fn main() {
                         .takes_value(true)
                 );
 
-    let hash_cmd =
-        SubCommand::with_name("hash-circuits").about("Benchmark hash function inside of a circuit");
+    let hash_cmd = SubCommand::with_name("hash-constraints")
+        .about("Benchmark hash function inside of a circuit");
 
     let matches = App::new("benchy")
         .version("0.1")

--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -149,8 +149,8 @@ fn main() {
                 })
                 .expect("zigzag failed");
         }
-        ("hash-circuits", Some(_m)) => {
-            hash_fns::run().expect("hash-circuits failed");
+        ("hash-constraints", Some(_m)) => {
+            hash_fns::run().expect("hash-constraints failed");
         }
         _ => panic!("carnation"),
     }

--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -137,7 +137,7 @@ fn main() {
                         extract: m.is_present("extract"),
                         groth: m.is_present("groth"),
                         hasher: value_t!(m, "hasher", String)?,
-                        layers: value_t!(m, "layers", usize)?,
+                        layers,
                         m: value_t!(m, "m", usize)?,
                         no_bench: m.is_present("no-bench"),
                         no_tmp: m.is_present("no-tmp"),

--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -74,6 +74,8 @@ struct Params {
     dump_proofs: bool,
     bench_only: bool,
     hasher: String,
+    taper: f64,
+    taper_layers: usize,
 }
 
 impl From<Params> for Inputs {
@@ -88,6 +90,9 @@ impl From<Params> for Inputs {
             layers: p.layer_challenges.layers(),
             partition_challenges: p.layer_challenges.total_challenges(),
             total_challenges: p.layer_challenges.total_challenges() * p.partitions,
+            layer_challenges: p.layer_challenges,
+            taper: p.taper,
+            taper_layers: p.taper_layers,
         }
     }
 }
@@ -446,6 +451,9 @@ struct Inputs {
     layers: usize,
     partition_challenges: usize,
     total_challenges: usize,
+    taper: f64,
+    taper_layers: usize,
+    layer_challenges: LayerChallenges,
 }
 
 #[derive(Serialize, Default)]
@@ -530,6 +538,8 @@ pub fn run(opts: RunOpts) -> Result<(), failure::Error> {
         extract: opts.extract,
         hasher: opts.hasher,
         samples: 5,
+        taper: opts.taper,
+        taper_layers: opts.taper_layers,
     };
 
     let report = match params.hasher.as_ref() {

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -39,7 +39,7 @@ fn anonymous_mmap(len: usize) -> MmapMut {
         .expect("Failed to create memory map")
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub enum LayerChallenges {
     Fixed {
         layers: usize,


### PR DESCRIPTION
Fixes #821. Fixes #814.

## What's in this PR?

This changeset adds a few new keys to benchmarking output (taper, taper-layers, layer-challenges). It also combines all three benchmarks into a single JSON document, and persists individual and combined JSON documents as CircleCI artifacts.

## Aggregated JSON

An example of the aggregated JSON can be found [here](https://26876-135468185-gh.circle-artifacts.com/0/mnt/crate/combined-benchmarks.json).

## Before Merging

- remove references to topic branch in PR (replace with `master`)