### PR TITLE
fix(storage-proofs): always use temporary files for MTs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ To check that it's working you can inspect the replication log to find `using pa
 
 ### Memory
 
-We try to generate the MTs in parallel to speed up the process but that takes 2 sector sizes per each layer (e.g., a 1 GiB sector may require, in the worst case scenario, up to 20 GiB of memory to hold the MTs alone). To reduce that (at the cost of speed) we have the (experimental) `disk-trees` feature to offload the MTs to disk when we don't use them. For example, to run the `zigzag` example with this feature you'd need to indicate so to `cargo` *and* then indicate to the example (or any other code doing the replication) where they should be stored using the `FIL_PROOFS_REPLICATED_TREES_DIR` environmental variable (if set to a relative path, it will be relative  to the current working directory of the process in which the replication happens, see [`create_dir`](https://doc.rust-lang.org/std/fs/fn.create_dir.html#platform-specific-behavior)),
+We try to generate the MTs in parallel to speed up the process but that takes 2 sector sizes per each layer (e.g., a 1 GiB sector may require, in the worst case scenario, up to 20 GiB of memory to hold the MTs alone). To reduce that (at the cost of speed) we have the (experimental) `disk-trees` feature to offload the MTs to disk when we don't use them. For example, to run the `zigzag` example with this feature you'd need to indicate so to `cargo`,
 
 ```
 # From inside the `storage-proofs` directory, where this feature
@@ -172,14 +172,9 @@ cargo build                                                                   \
   --example zigzag                                                            \
   --features                                                                  \
     disk-trees                                                               &&
-FIL_PROOFS_REPLICATED_TREES_DIR="<tree-dir>"                                  \
 ../target/release/examples/zigzag                                             \
     --size 1048576
 ```
-
-To check if the feature is indeed working you can inspect the replication log to find the text `creating leaves tree mmap-file` indicating the path where each MT file is saved.
-
-Note that at the moment we do *not* clean up `<tree-dir>` so you'll need to **remove old MT files** yourself (otherwise the disk will start to fill up pretty fast). To avoid collisions in the directory we append a random hexadecimal value to each file, to check which files belong to the latest replication run you can (besides checking modification times) inspect the replication log to find out the actual file names generated.
 
 To optimize even more for memory there's another option (used in addition to the `disk-trees` feature) to generate all MTs in sequential order, to make sure we can offload them to disk before we start buildding the next one,
 

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,8 @@ bench = false
 bitvec = "0.5"
 rand = "0.4"
 libc = "0.2"
-merkletree = "=0.8"
+# merkletree = "=0.8"
+merkletree = { git = "https://github.com/filecoin-project/merkle_light", branch = "fix/use-only-temp-files" }
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,8 +15,7 @@ bench = false
 bitvec = "0.5"
 rand = "0.4"
 libc = "0.2"
-# merkletree = "=0.8"
-merkletree = { git = "https://github.com/filecoin-project/merkle_light", branch = "fix/use-only-temp-files" }
+merkletree = "=0.9"
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -10,6 +10,7 @@ use crate::hasher::{Domain, Hasher};
 use crate::merkle::MerkleTree;
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node, NODE_SIZE};
+use merkletree::merkle::FromIndexedParallelIterator;
 
 /// The default hasher currently in use.
 pub type DefaultTreeHasher = PedersenHasher;


### PR DESCRIPTION
To avoid managing them for now. Towards making disk-MTs the default (#831).

This removes the `FIL_PROOFS_REPLICATED_TREES_DIR` option (updated documentation).

Blockers:
* [x] Fix `from_par_iter` in `MerkleTree` to avoid `collect`ing and allocating the entire store (defeating the disk-store purpose).

* [x] Fix `merkletree` dependency (currently pointing to WIP branch, https://github.com/filecoin-project/merkle_light/pull/30).

--------------------------------------------------

Benchmark:

```
# in storage-proofs/
cargo build                                                                   \
  -p filecoin-proofs                                                          \
  --release                                                                   \
  --example zigzag                                                            \
  --features                                                                  \
    disk-trees                                                               &&
RUST_BACKTRACE=1                                                              \
CARGO_INCREMENTAL=1                                                           \
RUST_LOG=trace                                                                \
nohup /usr/bin/time -v ../target/release/examples/zigzag                      \
    --size 1048576                                                            \
    --hasher blake2s                                                          \
    --m 1  --expansion 0 --layers 5                                           \
     > zigzag-1gib-disk-only.out &
```
```
	User time (seconds): 303.02
	System time (seconds): 32.03
	Percent of CPU this job got: 149%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 3:44.12

	Maximum resident set size (kbytes): 2135616
```

Compared with https://github.com/filecoin-project/rust-fil-proofs/pull/796#issue-305565394:

```
	User time (seconds): 306.70
	System time (seconds): 28.66
	Percent of CPU this job got: 147%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 3:46.74
	Maximum resident set size (kbytes): 2138624
```