### PR TITLE
Remove extra `data` allocation used for MT generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,7 @@ cargo build                                                                   \
     --size 1048576
 ```
 
-To optimize even more for memory there's another option (used in addition to the `disk-trees` feature) to generate all MTs in sequential order, to make sure we can offload them to disk before we start buildding the next one,
-
-```
-FIL_PROOFS_GENERATE_MERKLE_TREES_IN_PARALLEL=0
-```
-
-You can inspect that it's working also in the replication log, where you'll see that the MTs are all generated in order without any layer index out of place.
-
-All these optimizations (`disk-trees` with a directory to offload MTs plus sequential generation) should reduce the maximum RSS, in the `zigzag` example, to 3 times the sector size used (so in the above command that tested ZigZag with a 1 GiB sector the maximum RSS reported by commands like `/usr/bin/time -v` should not exceed 3 GiB, please submit an issue if you observe otherwise).
+This optimization should reduce the maximum RSS, in the `zigzag` example, to 1-2 times the sector size used (so in the above command that tested ZigZag with a 1 GiB sector the maximum RSS reported by commands like `/usr/bin/time -v` should not exceed 2 GiB, please submit an issue if you observe otherwise).
 
 ## Generate Documentation
 

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,8 @@ bench = false
 bitvec = "0.5"
 rand = "0.4"
 libc = "0.2"
-merkletree = "=0.9"
+# merkletree = "=0.9"
+merkletree = {git = "https://github.com/filecoin-project/merkle_light", branch = "feat/create-mt-from-leaves-store"}
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,8 +15,7 @@ bench = false
 bitvec = "0.5"
 rand = "0.4"
 libc = "0.2"
-# merkletree = "=0.9"
-merkletree = {git = "https://github.com/filecoin-project/merkle_light", branch = "feat/create-mt-from-leaves-store"}
+merkletree = "=0.10"
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 use crate::error::*;
 use crate::hasher::pedersen::PedersenHasher;
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::MerkleTree;
+use crate::merkle::{MerkleTree, MerkleStore};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node, NODE_SIZE};
 use merkletree::merkle::FromIndexedParallelIterator;
@@ -60,6 +60,12 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
         } else {
             Ok(MerkleTree::new((0..self.size()).map(f)))
         }
+    }
+
+    /// Builds a merkle tree based on the given leaves store.
+    // FIXME: Add the parallel case (if it's worth it).
+    fn merkle_tree_from_leaves<'a>(&self, leaves: MerkleStore<H::Domain>, leafs_number: usize) -> Result<MerkleTree<H::Domain, H::Function>> {
+        Ok(MerkleTree::from_leaves_store(leaves, leafs_number))
     }
 
     /// Returns the merkle tree depth.

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -64,7 +64,7 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
 
     /// Builds a merkle tree based on the given leaves store.
     // FIXME: Add the parallel case (if it's worth it).
-    fn merkle_tree_from_leaves<'a>(&self, leaves: MerkleStore<H::Domain>, leafs_number: usize) -> Result<MerkleTree<H::Domain, H::Function>> {
+    fn merkle_tree_from_leaves(&self, leaves: MerkleStore<H::Domain>, leafs_number: usize) -> Result<MerkleTree<H::Domain, H::Function>> {
         Ok(MerkleTree::from_leaves_store(leaves, leafs_number))
     }
 

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 use crate::error::*;
 use crate::hasher::pedersen::PedersenHasher;
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::{MerkleTree, MerkleStore};
+use crate::merkle::{MerkleStore, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node, NODE_SIZE};
 use merkletree::merkle::FromIndexedParallelIterator;
@@ -64,7 +64,11 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
 
     /// Builds a merkle tree based on the given leaves store.
     // FIXME: Add the parallel case (if it's worth it).
-    fn merkle_tree_from_leaves(&self, leaves: MerkleStore<H::Domain>, leafs_number: usize) -> Result<MerkleTree<H::Domain, H::Function>> {
+    fn merkle_tree_from_leaves(
+        &self,
+        leaves: MerkleStore<H::Domain>,
+        leafs_number: usize,
+    ) -> Result<MerkleTree<H::Domain, H::Function>> {
         Ok(MerkleTree::from_leaves_store(leaves, leafs_number))
     }
 

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -319,7 +319,7 @@ mod tests {
 
     use merkletree::hash::Hashable;
 
-    use crate::merkle::{MerkleTree, VecMerkleTree};
+    use crate::merkle::MerkleTree;
 
     #[test]
     fn test_path() {
@@ -335,8 +335,7 @@ mod tests {
     fn test_pedersen_hasher() {
         let values = ["hello", "world", "you", "two"];
 
-        let t = VecMerkleTree::<PedersenDomain, PedersenFunction>::from_data(values.iter());
-        // Using `VecMerkleTree` since the `MmapStore` of `MerkleTree` doesn't support `Deref` (`as_slice`).
+        let t = MerkleTree::<PedersenDomain, PedersenFunction>::from_data(values.iter());
 
         assert_eq!(t.leafs(), 4);
 

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -17,7 +17,7 @@ mod tests {
     use std::fmt;
     use std::iter::FromIterator;
 
-    use crate::merkle::VecMerkleTree;
+    use crate::merkle::MerkleTree;
     use merkletree::hash::{Algorithm, Hashable};
 
     use super::super::{DigestDomain, Hasher};
@@ -109,8 +109,8 @@ mod tests {
 
         let v: Vec<DigestDomain> = vec![h1.into(), h2.into(), h3.into()];
         let v2: Vec<DigestDomain> = vec![h1.into(), h2.into()];
-        let t = VecMerkleTree::<<Sha256Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Function>::from_iter(v);
-        let t2 = VecMerkleTree::<
+        let t = MerkleTree::<<Sha256Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Function>::from_iter(v);
+        let t2 = MerkleTree::<
             <Sha256Hasher as Hasher>::Domain,
             <Sha256Hasher as Hasher>::Function,
         >::from_iter(v2);

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -16,7 +16,6 @@ use crate::merkle::{next_pow2, populate_leaves, MerkleStore, MerkleTree, Store};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::porep::{self, PoRep};
 use crate::proof::ProofScheme;
-use crate::settings;
 use crate::util::{data_at_node, NODE_SIZE};
 use crate::vde;
 
@@ -364,158 +363,112 @@ pub trait Layers {
         let mut taus = Vec::with_capacity(layers);
         let mut auxs: Vec<Tree<Self::Hasher>> = Vec::with_capacity(layers);
 
-        if !&settings::SETTINGS
-            .lock()
-            .unwrap()
-            .generate_merkle_trees_in_parallel
-        {
-            let mut sorted_trees: Vec<_> = Vec::new();
+        // We need to create a scope which encloses all the work, spawning threads
+        // for merkle tree generation and sending the results back to a channel.
+        // The received results need to be sorted by layer because ordering of the completed results
+        // is not guaranteed. Misordered results will be seen in practice when trees are small.
 
-            (0..=layers).fold(graph.clone(), |current_graph, layer| {
-                let tree_d = current_graph.merkle_tree(&data).unwrap();
+        // The outer scope ensure that `tx` is dropped and closed before we read from `outer_rx`.
+        // Otherwise, the read loop will block forever waiting for more input.
+        let outer_rx = {
+            let (tx, rx) = channel();
 
-                info!("returning tree (layer: {})", layer);
-
-                sorted_trees.push(tree_d);
-
-                if layer < layers {
-                    info!("encoding (layer: {})", layer);
-                    vde::encode(&current_graph, replica_id, data)
-                        .expect("encoding failed in thread");
-                }
-
-                Self::transform(&current_graph)
-            });
-
-            sorted_trees
-                .into_iter()
-                .fold(None, |previous_comm_r: Option<_>, replica_tree| {
-                    let comm_r = replica_tree.root();
-                    // Each iteration's replica_tree becomes the next iteration's previous_tree (data_tree).
-                    // The first iteration has no previous_tree.
-                    if let Some(comm_d) = previous_comm_r {
-                        let tau = porep::Tau { comm_r, comm_d };
-                        // info!("setting tau/aux (layer: {})", i - 1);
-                        // FIXME: Use `enumerate` if this log is worth it.
-                        taus.push(tau);
-                    };
-
-                    auxs.push(replica_tree);
-
-                    Some(comm_r)
-                });
-        } else {
-            // The parallel case is more complicated but should produce the same results as the
-            // serial case. Note that to make lifetimes work out, we have to inline and tease apart
-            // the definition of DrgPoRep::replicate. This is because as implemented, it entangles
-            // encoding and merkle tree generation too tightly to be used as a subcomponent.
-            // Instead, we need to create a scope which encloses all the work, spawning threads
-            // for merkle tree generation and sending the results back to a channel.
-            // The received results need to be sorted by layer because ordering of the completed results
-            // is not guaranteed. Misordered results will be seen in practice when trees are small.
-
-            // The outer scope ensure that `tx` is dropped and closed before we read from `outer_rx`.
-            // Otherwise, the read loop will block forever waiting for more input.
-            let outer_rx = {
-                let (tx, rx) = channel();
-
-                let errf = |e| {
-                    let err_string = format!("{:?}", e);
-                    error!(
-                        "MerkleTreeGenerationError: {} - {:?}",
-                        &err_string,
-                        failure::Backtrace::new()
-                    );
-                    Error::MerkleTreeGenerationError(err_string)
-                };
-
-                let _ = thread::scope(|scope| -> Result<()> {
-                    let mut threads = Vec::with_capacity(layers + 1);
-                    (0..=layers).fold(graph.clone(), |current_graph, layer| {
-                        let leafs = data.len() / NODE_SIZE;
-                        assert_eq!(data.len() % NODE_SIZE, 0);
-                        let pow = next_pow2(leafs);
-                        // FIXME: Who's actually responsible for ensuring power of 2
-                        //  sector sizes?
-
-                        let mut leaves_store = MerkleStore::new(pow);
-                        // FIXME: Horrible iterator coming, not sure how to elegantly do this:
-                        let f = |i| {
-                            let d = data_at_node(&data, i).expect("data_at_node math failed");
-                            <Self::Hasher as Hasher>::Domain::try_from_bytes(d)
-                                .expect("failed to convert node data to domain element")
-                        };
-
-                        populate_leaves::<
-                            _,
-                            <Self::Hasher as Hasher>::Function,
-                            _,
-                            std::iter::Map<_, _>,
-                        >(&mut leaves_store, (0..leafs).map(f));
-                        let return_channel = tx.clone();
-                        let (transfer_tx, transfer_rx) = channel::<Self::Graph>();
-
-                        transfer_tx
-                            .send(current_graph.clone())
-                            .expect("Failed to send value through channel");
-
-                        let thread = scope.spawn(move |_| {
-                            // If we panic anywhere in this closure, thread.join() below will receive an error —
-                            // so it is safe to unwrap.
-                            let graph = transfer_rx
-                                .recv()
-                                .expect("Failed to receive value through channel");
-
-                            let tree_d =
-                                graph.merkle_tree_from_leaves(leaves_store, leafs).unwrap();
-
-                            info!("returning tree (layer: {})", layer);
-                            return_channel
-                                .send((layer, tree_d))
-                                .expect("Failed to send value through channel");
-                        });
-
-                        threads.push(thread);
-
-                        if layer < layers {
-                            info!("encoding (layer: {})", layer);
-                            vde::encode(&current_graph, replica_id, data)
-                                .expect("encoding failed in thread");
-                        }
-                        Self::transform(&current_graph)
-                    });
-
-                    for thread in threads {
-                        thread.join().map_err(errf)?;
-                    }
-
-                    Ok(())
-                })
-                .map_err(errf)?;
-
-                rx
+            let errf = |e| {
+                let err_string = format!("{:?}", e);
+                error!(
+                    "MerkleTreeGenerationError: {} - {:?}",
+                    &err_string,
+                    failure::Backtrace::new()
+                );
+                Error::MerkleTreeGenerationError(err_string)
             };
 
-            let mut sorted_trees = outer_rx.iter().collect::<Vec<_>>();
-            sorted_trees.sort_unstable_by_key(|k| k.0);
+            let _ = thread::scope(|scope| -> Result<()> {
+                let mut threads = Vec::with_capacity(layers + 1);
+                (0..=layers).fold(graph.clone(), |current_graph, layer| {
+                    let leafs = data.len() / NODE_SIZE;
+                    assert_eq!(data.len() % NODE_SIZE, 0);
+                    let pow = next_pow2(leafs);
+                    // FIXME: Who's actually responsible for ensuring power of 2
+                    //  sector sizes?
 
-            sorted_trees
-                .into_iter()
-                .fold(None, |previous_comm_r: Option<_>, (i, replica_tree)| {
-                    let comm_r = replica_tree.root();
-                    // Each iteration's replica_tree becomes the next iteration's previous_tree (data_tree).
-                    // The first iteration has no previous_tree.
-                    if let Some(comm_d) = previous_comm_r {
-                        let tau = porep::Tau { comm_r, comm_d };
-                        info!("setting tau/aux (layer: {})", i - 1);
-                        taus.push(tau);
+                    let mut leaves_store = MerkleStore::new(pow);
+                    // FIXME: Horrible iterator coming, not sure how to elegantly do this:
+                    let f = |i| {
+                        let d = data_at_node(&data, i).expect("data_at_node math failed");
+                        <Self::Hasher as Hasher>::Domain::try_from_bytes(d)
+                            .expect("failed to convert node data to domain element")
                     };
 
-                    auxs.push(replica_tree);
+                    populate_leaves::<
+                        _,
+                        <Self::Hasher as Hasher>::Function,
+                        _,
+                        std::iter::Map<_, _>,
+                    >(&mut leaves_store, (0..leafs).map(f));
+                    let return_channel = tx.clone();
+                    let (transfer_tx, transfer_rx) = channel::<Self::Graph>();
 
-                    Some(comm_r)
+                    transfer_tx
+                        .send(current_graph.clone())
+                        .expect("Failed to send value through channel");
+
+                    let thread = scope.spawn(move |_| {
+                        // If we panic anywhere in this closure, thread.join() below will receive an error —
+                        // so it is safe to unwrap.
+                        let graph = transfer_rx
+                            .recv()
+                            .expect("Failed to receive value through channel");
+
+                        let tree_d =
+                            graph.merkle_tree_from_leaves(leaves_store, leafs).unwrap();
+
+                        info!("returning tree (layer: {})", layer);
+                        return_channel
+                            .send((layer, tree_d))
+                            .expect("Failed to send value through channel");
+                    });
+
+                    threads.push(thread);
+
+                    if layer < layers {
+                        info!("encoding (layer: {})", layer);
+                        vde::encode(&current_graph, replica_id, data)
+                            .expect("encoding failed in thread");
+                    }
+                    Self::transform(&current_graph)
                 });
-        }
+
+                for thread in threads {
+                    thread.join().map_err(errf)?;
+                }
+
+                Ok(())
+            })
+            .map_err(errf)?;
+
+            rx
+        };
+
+        let mut sorted_trees = outer_rx.iter().collect::<Vec<_>>();
+        sorted_trees.sort_unstable_by_key(|k| k.0);
+
+        sorted_trees
+            .into_iter()
+            .fold(None, |previous_comm_r: Option<_>, (i, replica_tree)| {
+                let comm_r = replica_tree.root();
+                // Each iteration's replica_tree becomes the next iteration's previous_tree (data_tree).
+                // The first iteration has no previous_tree.
+                if let Some(comm_d) = previous_comm_r {
+                    let tau = porep::Tau { comm_r, comm_d };
+                    info!("setting tau/aux (layer: {})", i - 1);
+                    taus.push(tau);
+                };
+
+                auxs.push(replica_tree);
+
+                Some(comm_r)
+            });
 
         Ok((taus, auxs))
     }

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -14,7 +14,9 @@ use crate::drgporep::{self, DrgPoRep};
 use crate::drgraph::Graph;
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, HashFunction, Hasher};
-use crate::merkle::{next_pow2, MerkleStore, MerkleTree, Store, BUILD_LEAVES_BLOCK_SIZE, Algorithm};
+use crate::merkle::{
+    next_pow2, Algorithm, MerkleStore, MerkleTree, Store, BUILD_LEAVES_BLOCK_SIZE,
+};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::porep::{self, PoRep};
 use crate::proof::ProofScheme;
@@ -716,7 +718,7 @@ fn comm_r_star<H: Hasher>(replica_id: &H::Domain, comm_rs: &[H::Domain]) -> Resu
         comm_r.write_bytes(&mut bytes[(i + 1) * 32..(i + 2) * 32])?;
     }
 
-    Ok(HashFunction::<H::Domain>::hash(&bytes))
+    Ok(<H::Function as HashFunction<H::Domain>>::hash(&bytes))
 }
 
 impl<'a, 'c, L: Layers> PoRep<'a, L::Hasher> for L {

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -640,7 +640,7 @@ fn comm_r_star<H: Hasher>(replica_id: &H::Domain, comm_rs: &[H::Domain]) -> Resu
         comm_r.write_bytes(&mut bytes[(i + 1) * 32..(i + 2) * 32])?;
     }
 
-    Ok(<H::Function as HashFunction<H::Domain>>::hash(&bytes))
+    Ok(H::Function::hash(&bytes))
 }
 
 impl<'a, 'c, L: Layers> PoRep<'a, L::Hasher> for L {

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -393,19 +393,17 @@ pub trait Layers {
                     //  sector sizes?
 
                     let mut leaves_store = MerkleStore::new(pow);
-                    // FIXME: Horrible iterator coming, not sure how to elegantly do this:
-                    let f = |i| {
-                        let d = data_at_node(&data, i).expect("data_at_node math failed");
-                        <Self::Hasher as Hasher>::Domain::try_from_bytes(d)
-                            .expect("failed to convert node data to domain element")
-                    };
 
                     populate_leaves::<
                         _,
                         <Self::Hasher as Hasher>::Function,
                         _,
                         std::iter::Map<_, _>,
-                    >(&mut leaves_store, (0..leafs).map(f));
+                    >(&mut leaves_store, (0..leafs).map(|i| {
+                        let d = data_at_node(&data, i).expect("data_at_node math failed");
+                        <Self::Hasher as Hasher>::Domain::try_from_bytes(d)
+                            .expect("failed to convert node data to domain element")
+                    }));
                     let return_channel = tx.clone();
                     let (transfer_tx, transfer_rx) = channel::<Self::Graph>();
 

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -5,8 +5,8 @@ use std::marker::PhantomData;
 // Reexport here, so we don't depend on merkletree directly in other places.
 pub use merkletree::hash::Algorithm;
 use merkletree::merkle;
-#[cfg(not(feature = "disk-trees"))]
-use merkletree::merkle::MmapStore;
+// #[cfg(not(feature = "disk-trees"))]
+// use merkletree::merkle::MmapStore;
 use merkletree::merkle::VecStore;
 use merkletree::proof;
 use paired::bls12_381::Fr;
@@ -16,8 +16,8 @@ use crate::hasher::{Domain, Hasher};
 // `mmap`ed `MerkleTree` (replacing the previously `Vec`-backed
 // `MerkleTree`, now encapsulated in `merkle::VecStore` and exposed
 // as `VecMerkleTree`).
-pub use merkletree::merkle::Store;
 pub use merkletree::merkle::next_pow2;
+pub use merkletree::merkle::Store;
 pub use merkletree::merkle::BUILD_LEAVES_BLOCK_SIZE;
 pub type DiskStore<E> = merkletree::merkle::DiskStore<E>;
 pub type MmapStore<E> = merkletree::merkle::MmapStore<E>;

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -7,21 +7,16 @@ pub use merkletree::hash::Algorithm;
 use merkletree::merkle;
 // #[cfg(not(feature = "disk-trees"))]
 // use merkletree::merkle::MmapStore;
-use merkletree::merkle::VecStore;
 use merkletree::proof;
 use paired::bls12_381::Fr;
 
 use crate::hasher::{Domain, Hasher};
 
-// `mmap`ed `MerkleTree` (replacing the previously `Vec`-backed
-// `MerkleTree`, now encapsulated in `merkle::VecStore` and exposed
-// as `VecMerkleTree`).
 pub use merkletree::merkle::next_pow2;
 pub use merkletree::merkle::populate_leaves;
 pub use merkletree::merkle::Store;
 pub type DiskStore<E> = merkletree::merkle::DiskStore<E>;
 pub type MmapStore<E> = merkletree::merkle::MmapStore<E>;
-pub type VecMerkleTree<T, A> = merkle::MerkleTree<T, A, VecStore<T>>;
 #[cfg(feature = "disk-trees")]
 pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, DiskStore<T>>;
 #[cfg(not(feature = "disk-trees"))]

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -17,8 +17,8 @@ use crate::hasher::{Domain, Hasher};
 // `MerkleTree`, now encapsulated in `merkle::VecStore` and exposed
 // as `VecMerkleTree`).
 pub use merkletree::merkle::next_pow2;
+pub use merkletree::merkle::populate_leaves;
 pub use merkletree::merkle::Store;
-pub use merkletree::merkle::BUILD_LEAVES_BLOCK_SIZE;
 pub type DiskStore<E> = merkletree::merkle::DiskStore<E>;
 pub type MmapStore<E> = merkletree::merkle::MmapStore<E>;
 pub type VecMerkleTree<T, A> = merkle::MerkleTree<T, A, VecStore<T>>;

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 // Reexport here, so we don't depend on merkletree directly in other places.
-use merkletree::hash::Algorithm;
+pub use merkletree::hash::Algorithm;
 use merkletree::merkle;
 #[cfg(not(feature = "disk-trees"))]
 use merkletree::merkle::MmapStore;
@@ -16,13 +16,20 @@ use crate::hasher::{Domain, Hasher};
 // `mmap`ed `MerkleTree` (replacing the previously `Vec`-backed
 // `MerkleTree`, now encapsulated in `merkle::VecStore` and exposed
 // as `VecMerkleTree`).
+pub use merkletree::merkle::Store;
+pub use merkletree::merkle::next_pow2;
+pub use merkletree::merkle::BUILD_LEAVES_BLOCK_SIZE;
 pub type DiskStore<E> = merkletree::merkle::DiskStore<E>;
+pub type MmapStore<E> = merkletree::merkle::MmapStore<E>;
 pub type VecMerkleTree<T, A> = merkle::MerkleTree<T, A, VecStore<T>>;
 #[cfg(feature = "disk-trees")]
 pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, DiskStore<T>>;
 #[cfg(not(feature = "disk-trees"))]
 pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, MmapStore<T>>;
-
+#[cfg(feature = "disk-trees")]
+pub type MerkleStore<T> = DiskStore<T>;
+#[cfg(not(feature = "disk-trees"))]
+pub type MerkleStore<T> = MmapStore<T>;
 /// Representation of a merkle proof.
 /// Each element in the `path` vector consists of a tuple `(hash, is_right)`, with `hash` being the the hash of the node at the current level and `is_right` a boolean indicating if the path is taking the right path.
 /// The first element is the hash of leaf itself, and the last is the root hash.

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -3,20 +3,16 @@
 use std::marker::PhantomData;
 
 // Reexport here, so we don't depend on merkletree directly in other places.
-pub use merkletree::hash::Algorithm;
+use merkletree::hash::Algorithm;
 use merkletree::merkle;
-// #[cfg(not(feature = "disk-trees"))]
-// use merkletree::merkle::MmapStore;
 use merkletree::proof;
 use paired::bls12_381::Fr;
 
 use crate::hasher::{Domain, Hasher};
 
-pub use merkletree::merkle::next_pow2;
-pub use merkletree::merkle::populate_leaves;
-pub use merkletree::merkle::Store;
-pub type DiskStore<E> = merkletree::merkle::DiskStore<E>;
+pub use merkletree::merkle::{next_pow2, populate_leaves, Store};
 pub type MmapStore<E> = merkletree::merkle::MmapStore<E>;
+pub type DiskStore<E> = merkletree::merkle::DiskStore<E>;
 #[cfg(feature = "disk-trees")]
 pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, DiskStore<T>>;
 #[cfg(not(feature = "disk-trees"))]
@@ -25,6 +21,7 @@ pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, MmapStore<T>>;
 pub type MerkleStore<T> = DiskStore<T>;
 #[cfg(not(feature = "disk-trees"))]
 pub type MerkleStore<T> = MmapStore<T>;
+
 /// Representation of a merkle proof.
 /// Each element in the `path` vector consists of a tuple `(hash, is_right)`, with `hash` being the the hash of the node at the current level and `is_right` a boolean indicating if the path is taking the right path.
 /// The first element is the hash of leaf itself, and the last is the root hash.

--- a/storage-proofs/src/settings.rs
+++ b/storage-proofs/src/settings.rs
@@ -16,7 +16,6 @@ pub struct Settings {
     pub merkle_tree_path: String,
     pub num_proving_threads: usize,
     pub replicated_trees_dir: String,
-    pub generate_merkle_trees_in_parallel: bool,
     pub pedersen_hash_exp_window_size: u32,
     // Generating MTs in parallel optimizes for speed while generating them
     // in sequence (`false`) optimizes for memory.
@@ -29,7 +28,6 @@ impl Default for Settings {
             merkle_tree_path: "/tmp/merkle-trees".into(),
             num_proving_threads: 1,
             replicated_trees_dir: "".into(),
-            generate_merkle_trees_in_parallel: true,
             pedersen_hash_exp_window_size: 16,
         }
     }
@@ -42,15 +40,6 @@ impl Settings {
         s.merge(File::with_name(SETTINGS_PATH).required(false))?;
         s.merge(Environment::with_prefix("FIL_PROOFS"))?;
 
-        let settings: Result<Settings, ConfigError> = s.try_into();
-
-        #[cfg(not(feature = "disk-trees"))]
-        {
-            if settings.is_ok() && !settings.as_ref().unwrap().generate_merkle_trees_in_parallel {
-                warn!("Setting GENERATE_MERKLE_TREES_IN_PARALLEL to false (sequiental generation) doesn't add any value if the `disk-trees` feature is not set (no offload possible)");
-            }
-        }
-
-        settings
+        s.try_into()
     }
 }


### PR DESCRIPTION
Towards making disk-MTs default (https://github.com/filecoin-project/rust-fil-proofs/issues/831), a suboptimal solution to https://github.com/filecoin-project/rust-fil-proofs/issues/826. (Using new features from MT repo in https://github.com/filecoin-project/merkle_light/pull/31).

* [x] Update `merkletree` to (future) `0.10` release.

* [x] Remove FIL_PROOFS_GENERATE_MERKLE_TREES_IN_PARALLEL, that case would no longer be needed, it's too extreme compared to this new architecture.

* [x] Call `populate_leaves` directly instead of copying its code (should remove `Algorithm` then and the ambiguities introduced there).

* [x] Remove `VecStore` if not used, we use `MmapStore` by default.

-------------------------------------------

For speed we both build MT and encode in parallel, the price to pay in an entire sector size duplication to decouple the two process so the modification of the encoding of the new layer doesn't affect the MT being build off the current one. For memory we do both processes sequentially, so we don't need the extra allocation to decouple them, greatly slowing down replication as a whole.

In the middle of these two extremes there seems to be an acceptable scenario that removes the duplication by adding a negligible (compared to encoding) subpart of the process in sequence. What actually needs to be preserved from encoding modification for the MT is just the leaves store creation, once the MT has its bottom store populated all its other work depends on that, independently of what the encoding does. So encoding only needs to wait for the MT to populate its leaves store (from the original `data`) before proceeding (and both processes continue in parallel from there). This sequential part I think (benchmarking to be sure) is negligible because populating the leaves store *does not involve hashing*, just (in the most expensive case of the `DiskStore`) writing the sector to disk, which is not minor, but still compared to the actual encoding process seems like a small price to pay to bring the RAM requirements from 2x to 1x sector size.

This is just an intermediary solution, a much better alternative could be implemented so the encoding phase doesn't have to wait for the MT to copy the _entire_ store before beginning (by partitioning it so both process work on `data` simultaneously, see https://github.com/filecoin-project/rust-fil-proofs/issues/826).

-------------------------------------------

Benchmark:

```
# in storage-proofs/
cargo build                                                                   \
  -p filecoin-proofs                                                          \
  --release                                                                   \
  --example zigzag                                                            \
  --features                                                                  \
    disk-trees                                                               &&
RUST_BACKTRACE=1                                                              \
CARGO_INCREMENTAL=1                                                           \
RUST_LOG=trace                                                                \
nohup /usr/bin/time -v ../target/release/examples/zigzag                      \
    --size 1048576                                                            \
    --hasher blake2s                                                          \
    --m 1  --expansion 0 --layers 5                                           \
     > zigzag-1gib-disk-only.out &
```

```
MASTER:

	User time (seconds): 301.13
	System time (seconds): 31.36
	Percent of CPU this job got: 149%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 3:42.88

	Maximum resident set size (kbytes): 2135512

PR:
	User time (seconds): 297.50
	System time (seconds): 25.88
	Percent of CPU this job got: 135%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 3:58.06

	Maximum resident set size (kbytes): 1057256             <-- 1x sector size
```

Why does this PR has more wall clock time than `master` even though user/system times are less than it? Because it got less percentage of CPU since we are de-parallelizing part of it, however, this is noticeable here only because we are basically doing no hashing (`--m 1  --expansion 0`), a normal replication of a sector of 1 GiB takes 2 hours and this is done in 3 minutes, we should benchmark the full example to test this.
