### PR TITLE
feat(add SectorId type and transforms)

### DIFF
--- a/filecoin-proofs/src/api.rs
+++ b/filecoin-proofs/src/api.rs
@@ -167,7 +167,7 @@ pub fn generate_post(
                 Ok(replica)
             } else {
                 Err(format_err!(
-                    "Invalid challenge generated: {:?}, only {} sectors are being proven",
+                    "Invalid challenge generated: {}, only {} sectors are being proven",
                     c.sector_id,
                     sector_count
                 ))
@@ -264,7 +264,7 @@ pub fn verify_post(
                 Ok(*comm)
             } else {
                 Err(format_err!(
-                    "Invalid challenge generated: {:?}, only {} sectors are being proven",
+                    "Invalid challenge generated: {}, only {} sectors are being proven",
                     c.sector_id,
                     sector_count
                 ))

--- a/filecoin-proofs/src/api.rs
+++ b/filecoin-proofs/src/api.rs
@@ -163,12 +163,12 @@ pub fn generate_post(
     let challenged_replicas: Vec<_> = challenges
         .iter()
         .map(|c| {
-            if let Some(replica) = replicas.get(u64::from(c.sector_id) as usize) {
+            if let Some(replica) = replicas.get(u64::from(c.sector) as usize) {
                 Ok(replica)
             } else {
                 Err(format_err!(
                     "Invalid challenge generated: {}, only {} sectors are being proven",
-                    c.sector_id,
+                    c.sector,
                     sector_count
                 ))
             }
@@ -260,12 +260,12 @@ pub fn verify_post(
     let commitments: Vec<_> = challenges
         .iter()
         .map(|c| {
-            if let Some(comm) = commitments_all.get(u64::from(c.sector_id) as usize) {
+            if let Some(comm) = commitments_all.get(u64::from(c.sector) as usize) {
                 Ok(*comm)
             } else {
                 Err(format_err!(
                     "Invalid challenge generated: {}, only {} sectors are being proven",
-                    c.sector_id,
+                    c.sector,
                     sector_count
                 ))
             }

--- a/storage-proofs/src/circuit/rational_post.rs
+++ b/storage-proofs/src/circuit/rational_post.rs
@@ -234,7 +234,7 @@ mod tests {
         let commitments_raw = vec![tree1.root(), tree2.root()];
         let commitments: Vec<_> = challenges
             .iter()
-            .map(|c| commitments_raw[u64::from(c.sector_id) as usize])
+            .map(|c| commitments_raw[u64::from(c.sector) as usize])
             .collect();
 
         let pub_inputs = rational_post::PublicInputs {
@@ -329,7 +329,7 @@ mod tests {
         let commitments_raw = vec![tree1.root(), tree2.root()];
         let commitments: Vec<_> = challenges
             .iter()
-            .map(|c| commitments_raw[u64::from(c.sector_id) as usize].into())
+            .map(|c| commitments_raw[u64::from(c.sector) as usize].into())
             .collect();
 
         let pub_inputs = rational_post::PublicInputs {

--- a/storage-proofs/src/circuit/rational_post.rs
+++ b/storage-proofs/src/circuit/rational_post.rs
@@ -234,7 +234,7 @@ mod tests {
         let commitments_raw = vec![tree1.root(), tree2.root()];
         let commitments: Vec<_> = challenges
             .iter()
-            .map(|c| commitments_raw[c.sector as usize])
+            .map(|c| commitments_raw[u64::from(c.sector_id) as usize])
             .collect();
 
         let pub_inputs = rational_post::PublicInputs {
@@ -329,7 +329,7 @@ mod tests {
         let commitments_raw = vec![tree1.root(), tree2.root()];
         let commitments: Vec<_> = challenges
             .iter()
-            .map(|c| commitments_raw[c.sector as usize].into())
+            .map(|c| commitments_raw[u64::from(c.sector_id) as usize].into())
             .collect();
 
         let pub_inputs = rational_post::PublicInputs {

--- a/storage-proofs/src/lib.rs
+++ b/storage-proofs/src/lib.rs
@@ -44,6 +44,7 @@ pub mod porc;
 pub mod porep;
 pub mod proof;
 pub mod rational_post;
+pub mod sector_id;
 pub mod settings;
 pub mod util;
 pub mod zigzag_drgporep;

--- a/storage-proofs/src/rational_post.rs
+++ b/storage-proofs/src/rational_post.rs
@@ -129,7 +129,7 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for RationalPoSt<'a, H> {
             .iter()
             .zip(pub_inputs.commitments.iter())
             .map(|(challenge, commitment)| {
-                let challenged_sector = u64::from(challenge.sector_id);
+                let challenged_sector = u64::from(challenge.sector);
                 let challenged_leaf = challenge.leaf;
 
                 let tree = priv_inputs.trees[challenged_sector as usize];
@@ -197,7 +197,7 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for RationalPoSt<'a, H> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Challenge {
     // The ID of the sector this challenge points at.
-    pub sector_id: SectorId,
+    pub sector: SectorId,
     // The leaf index this challenge points at.
     pub leaf: u64,
 }
@@ -218,7 +218,7 @@ pub fn derive_challenges(
                 let c = derive_challenge(seed, n as u64, attempt, sector_size, sector_count);
 
                 // check for faulty sector
-                if faults.binary_search(&c.sector_id).is_err() {
+                if faults.binary_search(&c.sector).is_err() {
                     // valid challenge, not found
                     return c;
                 }
@@ -245,7 +245,7 @@ fn derive_challenge(
     let leaf_challenge = LittleEndian::read_u64(&challenge_bytes[8..16]);
 
     Challenge {
-        sector_id: SectorId::from(sector_challenge % sector_count),
+        sector: SectorId::from(sector_challenge % sector_count),
         leaf: leaf_challenge % (sector_size / NODE_SIZE as u64),
     }
 }
@@ -291,7 +291,7 @@ mod tests {
         let commitments = challenges
             .iter()
             .map(|c| {
-                if u64::from(c.sector_id) % 2 == 0 {
+                if u64::from(c.sector) % 2 == 0 {
                     tree1.root()
                 } else {
                     tree2.root()

--- a/storage-proofs/src/rational_post.rs
+++ b/storage-proofs/src/rational_post.rs
@@ -10,6 +10,7 @@ use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::proof::{NoRequirements, ProofScheme};
+use crate::sector_id::SectorId;
 use crate::util::NODE_SIZE;
 
 #[derive(Debug, Clone)]
@@ -47,7 +48,7 @@ impl ParameterSetMetadata for PublicParams {
 pub struct PublicInputs<'a, T: 'a + Domain> {
     /// The challenges, which leafs to prove.
     pub challenges: &'a [Challenge],
-    pub faults: &'a [u64],
+    pub faults: &'a [SectorId],
     /// The root hashes of the underlying merkle trees.
     pub commitments: &'a [T],
 }
@@ -128,7 +129,7 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for RationalPoSt<'a, H> {
             .iter()
             .zip(pub_inputs.commitments.iter())
             .map(|(challenge, commitment)| {
-                let challenged_sector = challenge.sector;
+                let challenged_sector = u64::from(challenge.sector_id);
                 let challenged_leaf = challenge.leaf;
 
                 let tree = priv_inputs.trees[challenged_sector as usize];
@@ -196,7 +197,7 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for RationalPoSt<'a, H> {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Challenge {
     // The ID of the sector this challenge points at.
-    pub sector: u64,
+    pub sector_id: SectorId,
     // The leaf index this challenge points at.
     pub leaf: u64,
 }
@@ -207,7 +208,7 @@ pub fn derive_challenges(
     sector_size: u64,
     sector_count: u64,
     seed: &[u8],
-    faults: &[u64],
+    faults: &[SectorId],
 ) -> Vec<Challenge> {
     // TODO: ensure sorting of faults
     (0..challenge_count)
@@ -217,7 +218,7 @@ pub fn derive_challenges(
                 let c = derive_challenge(seed, n as u64, attempt, sector_size, sector_count);
 
                 // check for faulty sector
-                if faults.binary_search(&c.sector).is_err() {
+                if faults.binary_search(&c.sector_id).is_err() {
                     // valid challenge, not found
                     return c;
                 }
@@ -244,7 +245,7 @@ fn derive_challenge(
     let leaf_challenge = LittleEndian::read_u64(&challenge_bytes[8..16]);
 
     Challenge {
-        sector: sector_challenge % sector_count,
+        sector_id: SectorId::from(sector_challenge % sector_count),
         leaf: leaf_challenge % (sector_size / NODE_SIZE as u64),
     }
 }
@@ -285,12 +286,12 @@ mod tests {
         let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
 
         let seed = (0..32).map(|_| rng.gen()).collect::<Vec<u8>>();
-        let faults = vec![1];
+        let faults = vec![SectorId::from(1)];
         let challenges = derive_challenges(challenges_count, sector_size, 2, &seed, &faults);
         let commitments = challenges
             .iter()
             .map(|c| {
-                if c.sector % 2 == 0 {
+                if u64::from(c.sector_id) % 2 == 0 {
                     tree1.root()
                 } else {
                     tree2.root()
@@ -427,7 +428,7 @@ mod tests {
         let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
         let seed = (0..32).map(|_| rng.gen()).collect::<Vec<u8>>();
-        let faults = vec![1];
+        let faults = vec![SectorId::from(1)];
         let challenges = derive_challenges(challenges_count, sector_size, 2, &seed, &faults);
         let commitments = challenges.iter().map(|_c| tree.root()).collect::<Vec<_>>();
 

--- a/storage-proofs/src/sector_id.rs
+++ b/storage-proofs/src/sector_id.rs
@@ -1,7 +1,7 @@
 use byteorder::ByteOrder;
 use std::fmt;
 
-#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
 pub struct SectorId(u64);
 
 impl From<u64> for SectorId {
@@ -13,12 +13,6 @@ impl From<u64> for SectorId {
 impl From<SectorId> for u64 {
     fn from(n: SectorId) -> Self {
         n.0
-    }
-}
-
-impl std::cmp::Ord for SectorId {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.cmp(&other.0)
     }
 }
 

--- a/storage-proofs/src/sector_id.rs
+++ b/storage-proofs/src/sector_id.rs
@@ -1,0 +1,30 @@
+use byteorder::ByteOrder;
+
+#[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq)]
+pub struct SectorId(u64);
+
+impl From<u64> for SectorId {
+    fn from(n: u64) -> Self {
+        SectorId(n)
+    }
+}
+
+impl From<SectorId> for u64 {
+    fn from(n: SectorId) -> Self {
+        n.0
+    }
+}
+
+impl std::cmp::Ord for SectorId {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl SectorId {
+    pub fn as_fr_safe(&self) -> [u8; 31] {
+        let mut buf: [u8; 31] = [0; 31];
+        byteorder::LittleEndian::write_u64(&mut buf[0..8], self.0);
+        buf
+    }
+}

--- a/storage-proofs/src/sector_id.rs
+++ b/storage-proofs/src/sector_id.rs
@@ -1,4 +1,5 @@
 use byteorder::ByteOrder;
+use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialOrd, PartialEq, Eq)]
 pub struct SectorId(u64);
@@ -18,6 +19,12 @@ impl From<SectorId> for u64 {
 impl std::cmp::Ord for SectorId {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.cmp(&other.0)
+    }
+}
+
+impl fmt::Display for SectorId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SectorId({})", self.0)
     }
 }
 

--- a/storage-proofs/src/sector_id.rs
+++ b/storage-proofs/src/sector_id.rs
@@ -22,7 +22,7 @@ impl std::cmp::Ord for SectorId {
 }
 
 impl SectorId {
-    pub fn as_fr_safe(&self) -> [u8; 31] {
+    pub fn as_fr_safe(self) -> [u8; 31] {
         let mut buf: [u8; 31] = [0; 31];
         byteorder::LittleEndian::write_u64(&mut buf[0..8], self.0);
         buf


### PR DESCRIPTION
## Why does this PR exist?

`u64` doesn't tell us much about what values of this type represent (in our domain).

## What's in this PR?

This changeset uses [the newtype pattern](https://doc.rust-lang.org/1.0.0/style/features/types/newtype.html) to wrap `u64` up into a `SectorId` type.