### PR TITLE
backport hotfix branch into master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,10 +333,14 @@ workflows:
             - cargo_fetch
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - /hotfix.*/
       - build_darwin_release:
           requires:
             - cargo_fetch
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - /hotfix.*/

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "filecoin-proofs"
 description = "The Filecoin specific aspects of storage-proofs, including a C based FFI, to generate and verify proofs."
-version = "0.6.3"
+version = "0.6.4"
 authors = ["dignifiedquire <dignifiedquire@gmail.com>", "laser <l@s3r.com>", "porcuquine <porcuquine@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "filecoin-proofs"
 description = "The Filecoin specific aspects of storage-proofs, including a C based FFI, to generate and verify proofs."
-version = "0.6.2"
+version = "0.6.3"
 authors = ["dignifiedquire <dignifiedquire@gmail.com>", "laser <l@s3r.com>", "porcuquine <porcuquine@users.noreply.github.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"

--- a/filecoin-proofs/parameters.json
+++ b/filecoin-proofs/parameters.json
@@ -1,20 +1,20 @@
 {
-  "v11-vdf-post-7734b138d16b609af122a44c8105ec323810a40eb743479f7127a14630ae407f.params": {
+  "v11-vdf-post-6142c5095dcab8adf8698aaea24eac78035e3fefe6503b3e2f80758e4c948639.params": {
     "cid": "QmYS9NmkfVtZCtQPF18uQBeWfajF5YRKKkDPXpVR6pzzP4",
     "digest": "43008a8c945076a08aa2e7c4785241de",
     "sector_size": 1024
   },
-  "v11-vdf-post-7734b138d16b609af122a44c8105ec323810a40eb743479f7127a14630ae407f.vk": {
+  "v11-vdf-post-6142c5095dcab8adf8698aaea24eac78035e3fefe6503b3e2f80758e4c948639.vk": {
     "cid": "QmTXenYSVvEz2yEJ1deCobfQBVgykkigBuvWJCzTM5tmC2",
     "digest": "73b49d9cf0ba983b3e861da0e0ee2e2a",
     "sector_size": 1024
   },
-  "v11-vdf-post-fcc91dc272c9e6dfc906ff56cf65c412340b02fdef60b8132610bbe1dce61b20.params": {
+  "v11-vdf-post-71ca99ebb6212e45b2affa16eb6e1f671c37986e84ee8b9edbf924ab45b5fdfe.params": {
     "cid": "Qmc3R5xmapcSGKGR9zRC2fyPo3QuAuChtsKwswE6NZ6QMQ",
     "digest": "8091b735d254982b0b62e712bab82139",
     "sector_size": 268435456
   },
-  "v11-vdf-post-fcc91dc272c9e6dfc906ff56cf65c412340b02fdef60b8132610bbe1dce61b20.vk": {
+  "v11-vdf-post-71ca99ebb6212e45b2affa16eb6e1f671c37986e84ee8b9edbf924ab45b5fdfe.vk": {
     "cid": "QmeD4mdJFPjsWouBPPwvm6iVFYG8bpqNYetd2Ux7PoZawz",
     "digest": "32784464acc85a662ea16ecf5aba931d",
     "sector_size": 268435456

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -1,6 +1,6 @@
 use storage_proofs::util::NODE_SIZE;
 
-pub const POST_SECTORS_COUNT: usize = 512;
+pub const POST_SECTORS_COUNT: usize = 4;
 pub const POREP_MINIMUM_CHALLENGES: usize = 12; // FIXME: 8,000
 pub const SINGLE_PARTITION_PROOF_LEN: usize = 192;
 


### PR DESCRIPTION
## Why does this PR exist?

I cut a release branch last week in which we decreased POST_SECTORS_COUNT from 512 to 4 and modified the parameters manifest to point at the new Groth parameters. We need to backport those changes into rust-fil-proofs master.