### PR TITLE
fix(storage-proofs): ensure unique topological ordering of base graph

### DIFF
--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -668,8 +668,8 @@ mod tests {
         }
 
         assert!(cs.is_satisfied(), "constraints not satisfied");
-        assert_eq!(cs.num_inputs(), 16, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 103813, "wrong number of constraints");
+        assert_eq!(cs.num_inputs(), 18, "wrong number of inputs");
+        assert_eq!(cs.num_constraints(), 130957, "wrong number of constraints");
 
         assert_eq!(cs.get_input(0, "ONE"), Fr::one());
 
@@ -711,8 +711,8 @@ mod tests {
         )
         .expect("failed to synthesize circuit");
 
-        assert_eq!(cs.num_inputs(), 16, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 305791, "wrong number of constraints");
+        assert_eq!(cs.num_inputs(), 18, "wrong number of inputs");
+        assert_eq!(cs.num_constraints(), 361789, "wrong number of constraints");
     }
 
     #[test]

--- a/storage-proofs/src/circuit/rational_post.rs
+++ b/storage-proofs/src/circuit/rational_post.rs
@@ -197,7 +197,7 @@ mod tests {
 
     use crate::circuit::test::*;
     use crate::compound_proof;
-    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::fr_into_bytes;
     use crate::hasher::pedersen::*;
     use crate::proof::{NoRequirements, ProofScheme};
@@ -225,10 +225,10 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph1 = BucketGraph::<PedersenHasher>::new(32, 5, 0, new_seed());
+        let graph1 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed());
         let tree1 = graph1.merkle_tree(data1.as_slice()).unwrap();
 
-        let graph2 = BucketGraph::<PedersenHasher>::new(32, 5, 0, new_seed());
+        let graph2 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed());
         let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
 
         let faults = OrderedSectorSet::new();
@@ -327,10 +327,10 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph1 = BucketGraph::<PedersenHasher>::new(32, 5, 0, new_seed());
+        let graph1 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed());
         let tree1 = graph1.merkle_tree(data1.as_slice()).unwrap();
 
-        let graph2 = BucketGraph::<PedersenHasher>::new(32, 5, 0, new_seed());
+        let graph2 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed());
         let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
 
         let faults = OrderedSectorSet::new();

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -460,8 +460,8 @@ mod tests {
 
         // End copied section.
 
-        let expected_inputs = 36;
-        let expected_constraints = 432312;
+        let expected_inputs = 38;
+        let expected_constraints = 483850;
         {
             // Verify that MetricCS returns the same metrics as TestConstraintSystem.
             let mut cs = MetricCS::<Bls12>::new();

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -17,8 +17,10 @@ pub type DefaultTreeHasher = PedersenHasher;
 
 pub const PARALLEL_MERKLE: bool = true;
 
-/// The base degree used for all drg graphs.
-pub const BASE_DEGREE: usize = 5;
+/// The base degree used for all DRG graphs. One degree from this value is used to ensure that a
+/// given node always has its immediate predecessor as a parent, thus ensuring unique topological
+/// ordering of the graph nodes.
+pub const BASE_DEGREE: usize = 6;
 
 /// A depth robust graph.
 pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
@@ -124,7 +126,7 @@ impl<H: Hasher> ParameterSetMetadata for BucketGraph<H> {
         format!(
             "drgraph::BucketGraph{{size: {}; degree: {}; hasher: {}}}",
             self.nodes,
-            self.base_degree,
+            self.degree(),
             H::name(),
         )
     }
@@ -137,34 +139,37 @@ impl<H: Hasher> ParameterSetMetadata for BucketGraph<H> {
 impl<H: Hasher> Graph<H> for BucketGraph<H> {
     #[inline]
     fn parents(&self, node: usize, parents: &mut [usize]) {
-        let m = self.base_degree;
+        let m = self.degree();
 
         match node {
-            // Special case for the first node, it self references.
-            // Special case for the second node, it references only the first one.
+            // There are special cases for the first and second node: the first node self
+            // references, the second node only references the first node.
             0 | 1 => {
-                // Use the degree of the curren graph (`m`), as parents.len() might be bigger
-                // than that (that's the case for ZigZag Graph)
+                // Use the degree of the current graph (`m`) as `parents.len()` might be bigger than
+                // that (that's the case for ZigZag Graph).
                 for parent in parents.iter_mut().take(m) {
                     *parent = 0;
                 }
             }
             _ => {
+                // The degree `m` minus 1; the degree without the immediate predecessor node.
+                let m_prime = m - 1;
+
                 // seed = self.seed | node
                 let mut seed = [0u32; 8];
                 seed[0..7].copy_from_slice(&self.seed);
                 seed[7] = node as u32;
                 let mut rng = ChaChaRng::from_seed(&seed);
 
-                for (k, parent) in parents.iter_mut().take(m).enumerate() {
-                    // iterate over m meta nodes of the ith real node
-                    // simulate the edges that we would add from previous graph nodes
-                    // if any edge is added from a meta node of jth real node then add edge (j,i)
-                    let logi = ((node * m) as f32).log2().floor() as usize;
+                for (k, parent) in parents.iter_mut().take(m_prime).enumerate() {
+                    // Iterate over `m_prime` number of meta nodes for the i-th real node. Simulate
+                    // the edges that we would add from previous graph nodes. If any edge is added
+                    // from a meta node of j-th real node then add edge (j,i).
+                    let logi = ((node * m_prime) as f32).log2().floor() as usize;
                     let j = rng.gen::<usize>() % logi;
-                    let jj = cmp::min(node * m + k, 1 << (j + 1));
+                    let jj = cmp::min(node * m_prime + k, 1 << (j + 1));
                     let back_dist = rng.gen_range(cmp::max(jj >> 1, 2), jj + 1);
-                    let out = (node * m + k - back_dist) / m;
+                    let out = (node * m_prime + k - back_dist) / m_prime;
 
                     // remove self references and replace with reference to previous node
                     if out == node {
@@ -175,8 +180,11 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
                     }
                 }
 
-                // Use the degree of the curren graph (`m`), as parents.len() might be bigger
-                // than that (that's the case for ZigZag Graph)
+                // Add the immediate predecessor as a parent to ensure unique topological ordering.
+                parents[m_prime] = node - 1;
+
+                // Use the degree of the current graph (`m`) as `parents.len()` might be bigger than
+                // that (that's the case for ZigZag Graph).
                 parents[0..m].sort_unstable();
             }
         }
@@ -187,6 +195,7 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
         self.nodes
     }
 
+    /// Returns the degree of the graph.
     #[inline]
     fn degree(&self) -> usize {
         self.base_degree

--- a/storage-proofs/src/rational_post.rs
+++ b/storage-proofs/src/rational_post.rs
@@ -272,7 +272,7 @@ mod tests {
     use paired::bls12_381::Bls12;
     use rand::{Rng, SeedableRng, XorShiftRng};
 
-    use crate::drgraph::{new_seed, BucketGraph, Graph};
+    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::fr_into_bytes;
     use crate::hasher::{Blake2sHasher, HashFunction, PedersenHasher, Sha256Hasher};
     use crate::merkle::make_proof_for_test;
@@ -296,8 +296,8 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph1 = BucketGraph::<H>::new(32, 5, 0, new_seed());
-        let graph2 = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph1 = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
+        let graph2 = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree1 = graph1.merkle_tree(data1.as_slice()).unwrap();
         let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
 
@@ -397,7 +397,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
         let seed = (0..32).map(|_| rng.gen()).collect::<Vec<u8>>();
 
@@ -461,7 +461,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&rng.gen()))
             .collect();
 
-        let graph = BucketGraph::<H>::new(32, 5, 0, new_seed());
+        let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed());
         let tree = graph.merkle_tree(data.as_slice()).unwrap();
         let seed = (0..32).map(|_| rng.gen()).collect::<Vec<u8>>();
         let mut faults = OrderedSectorSet::new();


### PR DESCRIPTION
BREAKING CHANGE: adding one more parent to the base graph.

Option 1 of https://github.com/filecoin-project/rust-fil-proofs/issues/744#issuecomment-519643859.

Fixes #744.