### PR TITLE
bug(use SectorId type in API instead of 31-byte array)

### DIFF
--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -408,13 +408,13 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>>(
     sealed_path: T,
     output_path: T,
     prover_id_in: &FrSafe,
-    sector_id_in: &FrSafe,
+    sector_id: SectorId,
     offset: UnpaddedByteIndex,
     num_bytes: UnpaddedBytesAmount,
 ) -> error::Result<(UnpaddedBytesAmount)> {
+    let sector_id_as_safe_fr = pad_safe_fr(&sector_id.as_fr_safe());
     let prover_id = pad_safe_fr(prover_id_in);
-    let sector_id = pad_safe_fr(sector_id_in);
-    let replica_id = replica_id::<DefaultTreeHasher>(prover_id, sector_id);
+    let replica_id = replica_id::<DefaultTreeHasher>(prover_id, sector_id_as_safe_fr);
 
     let f_in = File::open(sealed_path)?;
     let mut data = Vec::new();

--- a/storage-proofs/src/sector.rs
+++ b/storage-proofs/src/sector.rs
@@ -7,7 +7,9 @@ use byteorder::ByteOrder;
 pub type OrderedSectorSet = BTreeSet<SectorId>;
 
 /// Identifier for a single sector.
-#[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
+#[derive(
+    Default, Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash, Serialize, Deserialize,
+)]
 pub struct SectorId(u64);
 
 impl From<u64> for SectorId {


### PR DESCRIPTION
## Why does this PR exist?

The Rational PoSt changeset moved us from representing sector id as a 31-byte array (at the API boundary) to a unsigned, 64-bit integer. We forgot to update one of the functions to conform to this new convention.