### PR TITLE
wrap err log-command in parens to ensure echo goes to stderr and not stdout

### DIFF
--- a/fil-proofs-tooling/scripts/retry.sh
+++ b/fil-proofs-tooling/scripts/retry.sh
@@ -37,7 +37,7 @@ for attempt in `seq 1 $attempts`; do
 
     sleep_seconds=$(echo "scale=2; ${sleep_ms}/1000" | bc)
 
-    echo >&2 "sleeping ${sleep_seconds}s and then retrying ($((attempt + 1))/${attempts})"
+    (>&2 echo "sleeping ${sleep_seconds}s and then retrying ($((attempt + 1))/${attempts})")
 
     sleep "${sleep_seconds}"
 done

--- a/fil-proofs-tooling/scripts/with-lock.sh
+++ b/fil-proofs-tooling/scripts/with-lock.sh
@@ -8,14 +8,14 @@ shift 2
 
 if mkdir "$lockdir" > /dev/null 2>&1
 then
-    echo >&2 "successfully acquired lock (${lockdir})"
+    (>&2 echo "successfully acquired lock (${lockdir})")
 
     # Unlock (by removing dir) when the script finishes
-    trap 'echo >&2 "relinquishing lock (${lockdir})"; rm -rf "$lockdir"' EXIT
+    trap '(>&2 echo "relinquishing lock (${lockdir})"); rm -rf "$lockdir"' EXIT
 
     # Execute command
     "$@"
 else
-    echo >&2 "failed to acquire lock (${lockdir})"
+    (>&2 echo "failed to acquire lock (${lockdir})")
     exit $failure_code
 fi


### PR DESCRIPTION
@sidke noticed that I had incorrect sent stderr to stdout. This PR fixes that.