### PR TITLE
fix(storage-proofs): increase expansion parents from 8 to 16

### DIFF
--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -415,7 +415,7 @@ fn main() {
             Arg::with_name("exp")
                 .help("Expansion degree")
                 .long("expansion")
-                .default_value("8")
+                .default_value("16")
                 .takes_value(true),
         )
         .arg(

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -9,7 +9,7 @@ use crate::layered_drgporep::Layerable;
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::settings;
 
-pub const DEFAULT_EXPANSION_DEGREE: usize = 8;
+pub const DEFAULT_EXPANSION_DEGREE: usize = 16;
 
 // Cache of node's parents.
 pub type ParentCache = HashMap<usize, Vec<usize>>;


### PR DESCRIPTION
* What benchmarks should be run? (At least one with the cache turned on.)

* Is there another place where this value is hardcoded?

Towards #827.
Closes https://github.com/filecoin-project/rust-fil-proofs/issues/857.