### PR TITLE
fix(storage-proofs): double expansion parents using permutation inverse

### DIFF
--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -460,8 +460,8 @@ mod tests {
 
         // End copied section.
 
-        let expected_inputs = 36;
-        let expected_constraints = 432312;
+        let expected_inputs = 52;
+        let expected_constraints = 673496;
         {
             // Verify that MetricCS returns the same metrics as TestConstraintSystem.
             let mut cs = MetricCS::<Bls12>::new();


### PR DESCRIPTION
Closes https://github.com/filecoin-project/rust-fil-proofs/issues/827.
Closes https://github.com/filecoin-project/rust-fil-proofs/pull/859.
Closes https://github.com/filecoin-project/rust-fil-proofs/issues/857.


