### PR TITLE
refactor(storage-proofs): streamline expander parents cache

### DIFF
--- a/fil-proofs-tooling/src/metadata.rs
+++ b/fil-proofs-tooling/src/metadata.rs
@@ -32,7 +32,11 @@ pub struct GitMetadata {
 
 impl GitMetadata {
     pub fn new() -> Result<Self, Error> {
-        let repo_path = std::env::var("CARGO_MANIFEST_DIR")?;
+        let repo_path = if let Ok(mdir) = std::env::var("CARGO_MANIFEST_DIR") {
+            std::path::Path::new(&mdir).into()
+        } else {
+            std::env::current_dir()?
+        };
         let repo = Repository::discover(&repo_path)?;
         let head = repo.head()?;
         let commit = head.peel_to_commit()?;


### PR DESCRIPTION
Switches the cache structure to something towards what is described in #847. This still keeps everything in memory though. 
This also removes the cloning of the cache, when cloning the graph.

For 128MiB sectors the following memory usage changes can be seen 

**with `disk-trees`**

| state  | max res memory   |
|--------|------------------|
| master |  1_714_648 bytes |
| 02718b6 | 1_285_292 bytes |
| beeee94  | 1_285_232 bytes |


**without `disk-trees`**

| state  | max res memory   |
|--------|------------------|
| master  | 4_532_592 bytes |
| 02718b6 | 4_167_780 bytes |
| beeee94  | 4_068_068 bytes |