### PR TITLE
feat(fil-proofs-tooling): add rational-post subcommand to benchy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -215,9 +215,15 @@ jobs:
             cat zigzag-benchmarks.json
           no_output_timeout: 60m
       - run:
+          name: Run Rational PoST benchmarks using a 1GiB sector
+          command: |
+            ./fil-proofs-tooling/scripts/benchy-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" rational-post --size=$((1024*1024)) > rational-post-benchmarks.json
+            cat rational-post-benchmarks.json
+          no_output_timeout: 60m
+      - run:
           name: Aggregate benchmarks into single JSON document
           command: |
-            ./fil-proofs-tooling/scripts/aggregate-benchmarks.sh zigzag-benchmarks.json micro-benchmarks.json hash-constraints.json > aggregated-benchmarks.json
+            ./fil-proofs-tooling/scripts/aggregate-benchmarks.sh zigzag-benchmarks.json micro-benchmarks.json hash-constraints.json rational-post-benchmarks.json > aggregated-benchmarks.json
             cat aggregated-benchmarks.json
       - store_artifacts:
           path: zigzag-benchmarks.json

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -29,6 +29,7 @@ memmap = "0.7.0"
 paired = "0.15.0"
 rand = "0.4"
 storage-proofs = { path = "../storage-proofs"}
+filecoin-proofs = { path = "../filecoin-proofs"}
 tempfile = "3.0.8"
 cpu-time = "0.1.0"
 git2 = "0.9.2"

--- a/fil-proofs-tooling/scripts/aggregate-benchmarks.sh
+++ b/fil-proofs-tooling/scripts/aggregate-benchmarks.sh
@@ -5,11 +5,13 @@ set -e
 zigzag_path=$1
 micro_path=$2
 hash_constraints_path=$3
+rational_post_path=$4
 
 jq --sort-keys -s '{ benchmarks: { "zigzag-benchmarks": { outputs: { "max-resident-set-size-kb": .[0] } } } } * .[1]' \
   <(jq '.["max-resident-set-size-kb"]' $zigzag_path) \
-  <(jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "zigzag-benchmarks": .[2], "micro-benchmarks": .[3] } }' \
+  <(jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "zigzag-benchmarks": .[2], "micro-benchmarks": .[3], "rational-post-benchmarks": .[4] } }' \
     <(jq 'del (.benchmarks)' $micro_path) \
     <(jq '.benchmarks' $hash_constraints_path) \
     <(jq '.benchmarks' $zigzag_path) \
-    <(jq '.benchmarks' $micro_path))
+    <(jq '.benchmarks' $micro_path) \
+    <(jq '.benchmarks' $rational_post_path))

--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -4,6 +4,7 @@ extern crate serde;
 use clap::{value_t, App, Arg, SubCommand};
 
 mod hash_fns;
+mod rational_post;
 mod zigzag;
 
 fn main() {
@@ -100,12 +101,23 @@ fn main() {
                         .takes_value(true)
                 );
 
+    let rational_post_cmd = SubCommand::with_name("rational-post")
+        .about("Benchmark Rational PoST")
+        .arg(
+            Arg::with_name("size")
+                .long("size")
+                .required(true)
+                .help("The data size in KiB")
+                .takes_value(true),
+        );
+
     let hash_cmd = SubCommand::with_name("hash-constraints")
         .about("Benchmark hash function inside of a circuit");
 
     let matches = App::new("benchy")
         .version("0.1")
         .subcommand(zigzag_cmd)
+        .subcommand(rational_post_cmd)
         .subcommand(hash_cmd)
         .get_matches();
 
@@ -133,6 +145,12 @@ fn main() {
                     })
                 })
                 .expect("zigzag failed");
+        }
+        ("rational-post", Some(m)) => {
+            let sector_size_kibs = value_t!(m, "size", usize)
+                .expect("could not convert `size` CLI argument to `usize`");
+            let sector_size = sector_size_kibs * 1024;
+            rational_post::run(sector_size).expect("rational-post failed");
         }
         ("hash-constraints", Some(_m)) => {
             hash_fns::run().expect("hash-constraints failed");

--- a/fil-proofs-tooling/src/bin/benchy/rational_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/rational_post.rs
@@ -1,0 +1,135 @@
+use std::collections::BTreeMap;
+use std::io::stdout;
+
+use fil_proofs_tooling::{measure, Metadata};
+use filecoin_proofs::fr32::write_padded;
+use filecoin_proofs::pieces::get_aligned_source;
+use filecoin_proofs::types::{
+    PaddedBytesAmount, PoRepConfig, PoRepProofPartitions, PoStConfig, SectorSize,
+    UnpaddedBytesAmount,
+};
+use filecoin_proofs::{generate_post, seal, verify_post, PrivateReplicaInfo, PublicReplicaInfo};
+use log::info;
+use rand::random;
+use storage_proofs::sector::SectorId;
+use tempfile::NamedTempFile;
+
+// The seed for the rng used to generate which sectors to challenge.
+const CHALLENGE_SEED: [u8; 32] = [0; 32];
+
+const PROVER_ID: [u8; 31] = [0; 31];
+const SECTOR_ID: u64 = 0;
+const N_PARTITIONS: PoRepProofPartitions = PoRepProofPartitions(1);
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct Inputs {
+    sector_size: usize,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct Outputs {
+    proving_cpu_time_ms: u64,
+    proving_wall_time_ms: u64,
+    verifying_wall_time_ms: u64,
+    verifying_cpu_time_ms: u64,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "kebab-case")]
+struct Report {
+    inputs: Inputs,
+    outputs: Outputs,
+}
+
+impl Report {
+    /// Print all results to stdout
+    pub fn print(&self) {
+        let wrapped = Metadata::wrap(&self).expect("failed to retrieve metadata");
+        serde_json::to_writer(stdout(), &wrapped).expect("cannot write report JSON to stdout");
+    }
+}
+
+pub fn run(sector_size: usize) -> Result<(), failure::Error> {
+    info!("Benchy Rational PoSt: sector-size={}", sector_size);
+
+    let sector_size_unpadded_bytes_ammount =
+        UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size as u64));
+
+    // Create files for the staged and sealed sectors.
+    let mut staged_file =
+        NamedTempFile::new().expect("could not create temp file for staged sector");
+
+    let sealed_file = NamedTempFile::new().expect("could not create temp file for sealed sector");
+
+    let sealed_path_string = sealed_file
+        .path()
+        .to_str()
+        .expect("file name is not a UTF-8 string")
+        .to_string();
+
+    // Generate the data from which we will create a replica, we will then prove the continued
+    // storage of that replica using the PoSt.
+    let data: Vec<u8> = (0..sector_size).map(|_| random()).collect();
+
+    // Write the aligned data to the staged sector file.
+    let (_, mut aligned_data) =
+        get_aligned_source(&data[..], &[], sector_size_unpadded_bytes_ammount);
+
+    write_padded(&mut aligned_data, &mut staged_file)
+        .expect("failed to write padded data to staged sector file");
+
+    // Replicate the staged sector, write the replica file to `sealed_path`.
+    let porep_config = PoRepConfig(SectorSize(sector_size as u64), N_PARTITIONS);
+    let sector_id = SectorId::from(SECTOR_ID);
+
+    let seal_output = seal(
+        porep_config,
+        staged_file.path(),
+        sealed_file.path(),
+        &PROVER_ID,
+        sector_id,
+        &[sector_size_unpadded_bytes_ammount],
+    )
+    .expect("failed to seal");
+
+    // Store the replica's private and publicly facing info for proving and verifying respectively.
+    let mut pub_replica_info: BTreeMap<SectorId, PublicReplicaInfo> = BTreeMap::new();
+    let mut priv_replica_info: BTreeMap<SectorId, PrivateReplicaInfo> = BTreeMap::new();
+
+    pub_replica_info.insert(sector_id, PublicReplicaInfo::new(seal_output.comm_r));
+
+    priv_replica_info.insert(
+        sector_id,
+        PrivateReplicaInfo::new(sealed_path_string, seal_output.comm_r),
+    );
+
+    // Measure PoSt generation and verification.
+    let post_config = PoStConfig(SectorSize(sector_size as u64));
+
+    let gen_post_measurement =
+        measure(|| generate_post(post_config.clone(), &CHALLENGE_SEED, &priv_replica_info))
+            .expect("failed to generate PoSt");
+
+    let proof = &gen_post_measurement.return_value;
+
+    let verify_post_measurement =
+        measure(|| verify_post(post_config, &CHALLENGE_SEED, proof, &pub_replica_info))
+            .expect("failed to verify PoSt");
+
+    // Create a JSON serializable report that we print to stdout (that will later be parsed using
+    // the CLI JSON parser `jq`).
+    let report = Report {
+        inputs: Inputs { sector_size },
+        outputs: Outputs {
+            proving_cpu_time_ms: gen_post_measurement.cpu_time.as_millis() as u64,
+            proving_wall_time_ms: gen_post_measurement.wall_time.as_millis() as u64,
+            verifying_cpu_time_ms: verify_post_measurement.cpu_time.as_millis() as u64,
+            verifying_wall_time_ms: verify_post_measurement.wall_time.as_millis() as u64,
+        },
+    };
+
+    report.print();
+    Ok(())
+}

--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -1,10 +1,9 @@
 use std::fs::{File, OpenOptions};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use std::{io, u32};
 
 use bellperson::Circuit;
 use chrono::Utc;
-use cpu_time::ProcessTime;
 use failure::bail;
 use fil_sapling_crypto::jubjub::JubjubBls12;
 use log::info;
@@ -13,7 +12,7 @@ use memmap::MmapOptions;
 use paired::bls12_381::Bls12;
 use rand::{Rng, SeedableRng, XorShiftRng};
 
-use fil_proofs_tooling::metadata::Metadata;
+use fil_proofs_tooling::{measure, FuncMeasurement, Metadata};
 use storage_proofs::circuit::metric::MetricCS;
 use storage_proofs::circuit::zigzag::ZigZagCompound;
 use storage_proofs::compound_proof::{self, CompoundProof};
@@ -93,27 +92,6 @@ impl From<Params> for Inputs {
             taper_layers: p.taper_layers,
         }
     }
-}
-
-struct FuncMeasurement<T> {
-    cpu_time: Duration,
-    wall_time: Duration,
-    return_value: T,
-}
-
-fn measure<T, F: FnOnce() -> Result<T, failure::Error>>(
-    f: F,
-) -> Result<FuncMeasurement<T>, failure::Error> {
-    let cpu_time_start = ProcessTime::now();
-    let wall_start_time = Instant::now();
-
-    let x = f()?;
-
-    Ok(FuncMeasurement {
-        cpu_time: cpu_time_start.elapsed(),
-        wall_time: wall_start_time.elapsed(),
-        return_value: x,
-    })
 }
 
 fn generate_report<H: 'static>(params: Params) -> Result<Report, failure::Error>

--- a/fil-proofs-tooling/src/lib.rs
+++ b/fil-proofs-tooling/src/lib.rs
@@ -1,1 +1,5 @@
+pub mod measure;
 pub mod metadata;
+
+pub use measure::{measure, FuncMeasurement};
+pub use metadata::Metadata;

--- a/fil-proofs-tooling/src/measure.rs
+++ b/fil-proofs-tooling/src/measure.rs
@@ -1,0 +1,25 @@
+use std::time::{Duration, Instant};
+
+use cpu_time::ProcessTime;
+
+pub struct FuncMeasurement<T> {
+    pub cpu_time: Duration,
+    pub wall_time: Duration,
+    pub return_value: T,
+}
+
+pub fn measure<T, F>(f: F) -> Result<FuncMeasurement<T>, failure::Error>
+where
+    F: FnOnce() -> Result<T, failure::Error>,
+{
+    let cpu_time_start = ProcessTime::now();
+    let wall_start_time = Instant::now();
+
+    let x = f()?;
+
+    Ok(FuncMeasurement {
+        cpu_time: cpu_time_start.elapsed(),
+        wall_time: wall_start_time.elapsed(),
+        return_value: x,
+    })
+}


### PR DESCRIPTION
Adds `rational-post` subcommand to `benchy` for benchmarking `generate_post()` and `verify_post()`.

Closes #846