### PR TITLE
feat(storage-proofs): prevent building on 32-bit architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Configure to use nightly:
 
 ## Build
 
+**NOTE:** `rust-fil-proofs` can only be built for and run on 64-bit platforms; building will panic if the target architecture is not 64-bits.
+
 ```
 > cargo build --release --all
 ```

--- a/storage-proofs/build.rs
+++ b/storage-proofs/build.rs
@@ -1,0 +1,10 @@
+fn is_compiled_for_64_bit_arch() -> bool {
+    cfg!(target_pointer_width = "64")
+}
+
+fn main() {
+    assert!(
+        is_compiled_for_64_bit_arch(),
+        "must be built for 64-bit architectures"
+    );
+}


### PR DESCRIPTION
Prevent `storage-proofs` from building on 32-bit architectures.

Closes #870.