### PR TITLE
allow remote benchmarks to be run on topic branches, not just master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -199,19 +199,19 @@ jobs:
       - run:
           name: Run hash-constraints benchmarks on remote host
           command: |
-            ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" hash-constraints > hash-constraints.json
+            ./fil-proofs-tooling/scripts/benchy-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" hash-constraints > hash-constraints.json
             cat hash-constraints.json
           no_output_timeout: 60m
       - run:
           name: Run micro benchmarks
           command: |
-            ./fil-proofs-tooling/scripts/micro-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" > micro-benchmarks.json
+            ./fil-proofs-tooling/scripts/micro-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" > micro-benchmarks.json
             cat micro-benchmarks.json
           no_output_timeout: 60m
       - run:
           name: Run ZigZag benchmarks using 1GiB sectors
           command: |
-            ./fil-proofs-tooling/scripts/benchy-remote.sh "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) > zigzag-benchmarks.json
+            ./fil-proofs-tooling/scripts/benchy-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) > zigzag-benchmarks.json
             cat zigzag-benchmarks.json
           no_output_timeout: 60m
       - run:

--- a/fil-proofs-tooling/README.md
+++ b/fil-proofs-tooling/README.md
@@ -90,7 +90,7 @@ To run benchy on a remote server, provide SSH connection information to the
 benchy-remote.sh script:
 
 ```shell
-10:13 $ ./fil-proofs-tooling/scripts/benchy-remote.sh foo@16.16.16.16 zigzag --size=1 | jq '.'
+10:13 $ ./fil-proofs-tooling/scripts/benchy-remote.sh master foo@16.16.16.16 zigzag --size=1 | jq '.'
 {
   "inputs": {
     // ...

--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -6,12 +6,12 @@ CMDS=$(cat <<EOF
 cd \$(mktemp -d)
 git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
-git checkout -q master
+git checkout -q $1
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/with-dots.sh \
-    ./fil-proofs-tooling/scripts/benchy.sh ${@:2}
+    ./fil-proofs-tooling/scripts/benchy.sh ${@:3}
 EOF
 )
 
-ssh -q $1 "$CMDS"
+ssh -q $2 "$CMDS"

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -6,12 +6,12 @@ CMDS=$(cat <<EOF
 cd \$(mktemp -d)
 git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
-git checkout -q master
+git checkout -q $1
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/with-dots.sh \
-    ./fil-proofs-tooling/scripts/micro.sh ${@:2}
+    ./fil-proofs-tooling/scripts/micro.sh ${@:3}
 EOF
 )
 
-ssh -q $1 "$CMDS"
+ssh -q $2 "$CMDS"


### PR DESCRIPTION
## Why does this PR exist?

When we make tweaks to benchy or micro-benchmarks, we want to test them out on CircleCI before merging into master. Currently, the `remote-benchy.sh` and `micro-remote.sh` scripts assume that we're always running the code at the head of `master`.

## What's in this PR?

This changeset modifies the scripts to accept a branch name as they're first argument, and updates CircleCI to consume this new API.