### PR TITLE
research spike: when generating PoSt, reuse merkle trees generated during replication

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -20,7 +20,7 @@ use storage_proofs::compound_proof::{self, CompoundProof};
 use storage_proofs::drgporep;
 use storage_proofs::drgraph::*;
 use storage_proofs::hasher::{Blake2sHasher, Hasher, PedersenHasher, Sha256Hasher};
-use storage_proofs::layered_drgporep::{self, ChallengeRequirements, LayerChallenges};
+use storage_proofs::layered_drgporep::{self, ChallengeRequirements, DumbCache, LayerChallenges};
 use storage_proofs::porep::PoRep;
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::settings;
@@ -174,7 +174,10 @@ where
                 wall_time: replication_wall_time,
                 return_value: (pub_inputs, priv_inputs),
             } = measure(|| {
-                let (tau, aux) = ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, &mut data, None)?;
+                let mut cache = DumbCache::new(tempfile::TempDir::new().unwrap().into_path());
+
+                let (tau, aux) =
+                    ZigZagDrgPoRep::<H>::replicate(&mut cache, &pp, &replica_id, &mut data, None)?;
 
                 let pb = layered_drgporep::PublicInputs::<H::Domain> {
                     replica_id,

--- a/filecoin-proofs/examples/drgporep-vanilla.rs
+++ b/filecoin-proofs/examples/drgporep-vanilla.rs
@@ -18,6 +18,7 @@ use storage_proofs::drgraph::*;
 use storage_proofs::example_helper::prettyb;
 use storage_proofs::fr32::fr_into_bytes;
 use storage_proofs::hasher::{Blake2sHasher, Hasher, PedersenHasher, Sha256Hasher};
+use storage_proofs::layered_drgporep::DumbCache;
 use storage_proofs::porep::PoRep;
 use storage_proofs::proof::ProofScheme;
 
@@ -84,9 +85,12 @@ fn do_the_work<H: Hasher>(data_size: usize, challenge_count: usize) {
 
     info!("running replicate");
 
+    let mut cache = DumbCache::new(tempfile::TempDir::new().unwrap().into_path());
+
     start_profile("replicate");
     let (tau, aux) =
-        DrgPoRep::<H, _>::replicate(&pp, &replica_id, data.as_mut_slice(), None).unwrap();
+        DrgPoRep::<H, _>::replicate(&mut cache, &pp, &replica_id, data.as_mut_slice(), None)
+            .unwrap();
     stop_profile();
     let pub_inputs = PublicInputs {
         replica_id: Some(replica_id),

--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -31,7 +31,7 @@ use storage_proofs::drgraph::*;
 use storage_proofs::example_helper::prettyb;
 use storage_proofs::fr32::fr_into_bytes;
 use storage_proofs::hasher::{Blake2sHasher, Hasher, PedersenHasher, Sha256Hasher};
-use storage_proofs::layered_drgporep::{self, ChallengeRequirements, LayerChallenges};
+use storage_proofs::layered_drgporep::{self, ChallengeRequirements, DumbCache, LayerChallenges};
 use storage_proofs::porep::PoRep;
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::settings;
@@ -206,8 +206,11 @@ fn do_the_work<H: 'static>(
 
         info!("running replicate");
 
+        let mut cache = DumbCache::new(tempfile::TempDir::new().unwrap().into_path());
+
         start_profile("replicate");
-        let (tau, aux) = ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, &mut data, None).unwrap();
+        let (tau, aux) =
+            ZigZagDrgPoRep::<H>::replicate(&mut cache, &pp, &replica_id, &mut data, None).unwrap();
         stop_profile();
         let pub_inputs = layered_drgporep::PublicInputs::<H::Domain> {
             replica_id,

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -148,7 +148,7 @@ fn generate_piece_specs_from_source(
 }
 
 pub(crate) fn create_dumb_cache(sector_id: SectorId) -> Result<DumbCache, failure::Error> {
-    let abs_path = format!("/tmp/merkle-cache-{:?}", sector_id);
+    let abs_path = format!("/tmp/merkle-cache-sector-id-{}", u64::from(sector_id));
     let _ = std::fs::create_dir_all(abs_path.clone())?;
     Ok(DumbCache::new(PathBuf::from(abs_path)))
 }

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -149,7 +149,7 @@ fn generate_piece_specs_from_source(
 
 pub(crate) fn create_dumb_cache(sector_id: SectorId) -> Result<DumbCache, failure::Error> {
     let abs_path = format!("/tmp/merkle-cache-sector-id-{}", u64::from(sector_id));
-    let _ = std::fs::create_dir_all(abs_path.clone())?;
+    std::fs::create_dir_all(abs_path.clone())?;
     Ok(DumbCache::new(PathBuf::from(abs_path)))
 }
 

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -203,19 +203,8 @@ pub fn generate_post(
             let tree: std::result::Result<_, failure::Error> = if Path::new(&leaves).exists() {
                 println!("merkle tree (leaves) cache-file existed: {:?}", leaves);
 
-                let mut leaves_cache_file = File::open(leaves.clone()).unwrap();
-
-                leaves_cache_file.seek(SeekFrom::Start(0)).unwrap();
-
-                let mut top_half_cache_file = OpenOptions::new()
-                    .create(true)
-                    .write(true)
-                    .truncate(false)
-                    .read(true)
-                    .open(top_half.clone())
-                    .unwrap();
-
-                top_half_cache_file.seek(SeekFrom::Start(0)).unwrap();
+                let leaves_cache_file = cache.load_file(&leaves);
+                let top_half_cache_file = cache.load_file(&top_half);
 
                 MerkleTree::new_with_files(
                     sector_size as usize / NODE_SIZE,

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -201,17 +201,22 @@ pub fn generate_post(
             println!("checking merkle tree (leaves) cache-file: {:?}", leaves);
 
             let tree: std::result::Result<_, failure::Error> = if Path::new(&leaves).exists() {
+                // FIXME: Evaluate moving this check inside the cache.
+
                 println!("merkle tree (leaves) cache-file existed: {:?}", leaves);
 
                 let leaves_cache_file = cache.load_file(&leaves);
                 let top_half_cache_file = cache.load_file(&top_half);
+                // FIXME: We're assuming now that if the leaves file existed the top half
+                // file also did (as we always have 2 files or none), should we explicitly
+                // check that?
 
                 MerkleTree::new_with_files(
                     sector_size as usize / NODE_SIZE,
                     Some(leaves_cache_file),
                     Some(top_half_cache_file),
                     sector_size as usize / NODE_SIZE,
-                    true,
+                    false, // Do not build the top half again, just load the file contents from cache.
                 )
                 .map_err(|err| err.into())
             } else {

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -4,7 +4,7 @@ pub const POREP_MINIMUM_CHALLENGES: usize = 12; // FIXME: 8,000
 pub const SINGLE_PARTITION_PROOF_LEN: usize = 192;
 
 // Sector size, in bytes, for tests.
-pub const TEST_SECTOR_SIZE: u64 = 1024;
+pub const TEST_SECTOR_SIZE: u64 = 128;
 
 // Sector size, in bytes, during live operation.
 pub const LIVE_SECTOR_SIZE: u64 = 1 << 28; // 256MiB

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -1,6 +1,6 @@
 use storage_proofs::util::NODE_SIZE;
 
-pub const POREP_MINIMUM_CHALLENGES: usize = 12; // FIXME: 8,000
+pub const POREP_MINIMUM_CHALLENGES: usize = 1; // FIXME: 8,000
 pub const SINGLE_PARTITION_PROOF_LEN: usize = 192;
 
 // Sector size, in bytes, for tests.

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -50,7 +50,7 @@ log = "0.4.7"
 pretty_env_logger = "0.3.0"
 
 [features]
-default = []
+default = ["unchecked-degrees"]
 simd = []
 asm = ["sha2/sha2-asm"]
 mem-trees = []

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 bitvec = "0.5"
 rand = "0.4"
 libc = "0.2"
-merkletree = "=0.10"
+merkletree = { path = "/Users/erinswenson-healey/dev/merkle_light/merkle" }
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,9 @@ bench = false
 bitvec = "0.5"
 rand = "0.4"
 libc = "0.2"
-merkletree = { path = "/Users/erinswenson-healey/dev/merkle_light/merkle" }
+# merkletree = "=0.10"
+# FIXME: BLOCKING: Update to new release.
+merkletree = { git = "https://github.com/filecoin-project/merkle_light", branch = "feat/new/add-path-option"}
 failure = "0.1"
 byteorder = "1"
 config = "0.9.3"

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -531,6 +531,7 @@ mod tests {
     use crate::settings;
     use crate::util::data_at_node;
 
+    use crate::layered_drgporep::DumbCache;
     use ff::Field;
     use fil_sapling_crypto::jubjub::JubjubBls12;
     use rand::{Rand, Rng, SeedableRng, XorShiftRng};
@@ -574,9 +575,12 @@ mod tests {
             challenges_count: 1,
         };
 
+        let mut cache = DumbCache::new(tempfile::TempDir::new().unwrap().into_path());
+
         let pp = drgporep::DrgPoRep::<PedersenHasher, BucketGraph<_>>::setup(&sp)
             .expect("failed to create drgporep setup");
         let (tau, aux) = drgporep::DrgPoRep::<PedersenHasher, _>::replicate(
+            &mut cache,
             &pp,
             &replica_id.into(),
             data.as_mut_slice(),
@@ -765,7 +769,10 @@ mod tests {
         let public_params =
             DrgPoRepCompound::<H, BucketGraph<_>>::setup(&setup_params).expect("setup failed");
 
+        let mut cache = DumbCache::new(tempfile::TempDir::new().unwrap().into_path());
+
         let (tau, aux) = drgporep::DrgPoRep::<H, _>::replicate(
+            &mut cache,
             &public_params.vanilla_params,
             &replica_id.into(),
             data.as_mut_slice(),

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -435,7 +435,7 @@ where
     type ProverAux = porep::ProverAux<H>;
 
     fn replicate(
-        cache: &mut DumbCache,
+        _cache: &mut DumbCache, // TODO: What do we do with this cache?
         pp: &Self::PublicParams,
         replica_id: &H::Domain,
         data: &mut [u8],

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -11,6 +11,7 @@ use crate::merkle::{MerkleStore, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node, NODE_SIZE};
 use merkletree::merkle::FromIndexedParallelIterator;
+use std::fs::File;
 
 /// The default hasher currently in use.
 pub type DefaultTreeHasher = PedersenHasher;

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -68,6 +68,7 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
 
     /// Builds a merkle tree based on the given leaves store.
     // FIXME: Add the parallel case (if it's worth it).
+    // FIXME: May need to be removed once the MT cache is implemented.
     fn merkle_tree_from_leaves(
         &self,
         leaves: MerkleStore<H::Domain>,

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -18,7 +18,7 @@ pub type DefaultTreeHasher = PedersenHasher;
 pub const PARALLEL_MERKLE: bool = true;
 
 /// The base degree used for all drg graphs.
-pub const BASE_DEGREE: usize = 5;
+pub const BASE_DEGREE: usize = 1;
 
 /// A depth robust graph.
 pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -11,7 +11,6 @@ use crate::merkle::{MerkleStore, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node, NODE_SIZE};
 use merkletree::merkle::FromIndexedParallelIterator;
-use std::fs::File;
 
 /// The default hasher currently in use.
 pub type DefaultTreeHasher = PedersenHasher;
@@ -29,6 +28,7 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
     }
 
     /// Builds a merkle tree based on the given data.
+    /// TODO: Do we need to provide this thing with a merkle tree cache path, too?
     fn merkle_tree<'a>(&self, data: &'a [u8]) -> Result<MerkleTree<H::Domain, H::Function>> {
         self.merkle_tree_aux(data, PARALLEL_MERKLE)
     }

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -241,13 +241,13 @@ impl DumbCache {
 
     /// Create a cache file to write new content.
     pub fn create_file(&self, path: &PathBuf) -> File {
-        info!("creating (truncating) merkle tree cache-file: {:?}", path);
+        println!("creating (truncating) merkle tree cache-file: {:?}", path);
         self.open_file(path, true)
     }
 
     /// Load a cache file with previously created content..
     pub fn load_file(&self, path: &PathBuf) -> File {
-        info!("loading merkle tree cache-file: {:?}", path);
+        println!("loading merkle tree cache-file: {:?}", path);
         self.open_file(path, false)
         // FIXME: Actually if this is a load operation the
         // `create` option should be set to false and this

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -241,11 +241,13 @@ impl DumbCache {
 
     /// Create a cache file to write new content.
     pub fn create_file(&self, path: &PathBuf) -> File {
+        info!("creating (truncating) merkle tree cache-file: {:?}", path);
         self.open_file(path, true)
     }
 
     /// Load a cache file with previously created content..
     pub fn load_file(&self, path: &PathBuf) -> File {
+        info!("loading merkle tree cache-file: {:?}", path);
         self.open_file(path, false)
         // FIXME: Actually if this is a load operation the
         // `create` option should be set to false and this
@@ -480,11 +482,6 @@ pub trait Layers {
                     };
 
                     let CachedTreeAbsPaths { top_half, leaves } = cache.paths(key);
-
-                    println!(
-                        "creating (truncating) merkle tree (leaves) cache-file: {:?}",
-                        leaves
-                    );
 
                     // TODO: This isn't thread safe at all
                     let leaves_cache_file = cache.create_file(&leaves);

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -490,7 +490,9 @@ pub trait Layers {
 
                     let top_half_cache_file = cache.create_file(&top_half);
                     let top_half_store: MerkleStore<<Self::Hasher as Hasher>::Domain> =
-                        MerkleStore::new_with_file(pow, Some(top_half_cache_file)).unwrap();
+                        MerkleStore::new_with_file(pow - 1, Some(top_half_cache_file)).unwrap();
+                    // FIXME: The top half has `leaves - 1` (`pow - 1`) nodes, but the MT
+                    // repo should be worrying about this, not us.
 
                     populate_leaves::<
                         _,

--- a/storage-proofs/src/layered_drgporep.rs
+++ b/storage-proofs/src/layered_drgporep.rs
@@ -213,7 +213,7 @@ impl DumbCache {
         }
     }
 
-    pub fn paths<'a>(&self, k: MerkleTreeCacheKey) -> CachedTreeAbsPaths {
+    pub fn paths(&self, k: MerkleTreeCacheKey) -> CachedTreeAbsPaths {
         let (top_half, leaves) = self.file_names(k);
 
         CachedTreeAbsPaths {

--- a/storage-proofs/src/porep.rs
+++ b/storage-proofs/src/porep.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use crate::hasher::{Domain, HashFunction, Hasher};
+use crate::layered_drgporep::DumbCache;
 use crate::merkle::MerkleTree;
 use crate::proof::ProofScheme;
 
@@ -52,6 +53,7 @@ pub trait PoRep<'a, H: Hasher>: ProofScheme<'a> {
     type ProverAux;
 
     fn replicate(
+        cache: &mut DumbCache,
         pub_params: &'a Self::PublicParams,
         replica_id: &H::Domain,
         data: &mut [u8],

--- a/storage-proofs/src/settings.rs
+++ b/storage-proofs/src/settings.rs
@@ -28,7 +28,7 @@ impl Default for Settings {
             merkle_tree_path: "/tmp/merkle-trees".into(),
             num_proving_threads: 1,
             replicated_trees_dir: "".into(),
-            pedersen_hash_exp_window_size: 16,
+            pedersen_hash_exp_window_size: 8,
         }
     }
 }

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -10,7 +10,7 @@ use crate::parameter_cache::ParameterSetMetadata;
 use crate::settings;
 
 /// The expansion degree used for ZigZag Graphs.
-pub const EXP_DEGREE: usize = 8;
+pub const EXP_DEGREE: usize = 0;
 
 lazy_static! {
     // This parents cache is currently used for the *expanded parents only*, generated


### PR DESCRIPTION
## Why does this PR exist?

This changeset demonstrates a bare-bones merkle tree cache, and hopefully will give @schomatis some ideas for how rust-fil-proofs might integrate with the merkle_light changes he's made recently.

## Running the Code

To exercise this code, run:

```
RUST_LOG=INFO cargo test \
  --color=always \
  --release \
  --package filecoin-proofs \
  --lib api::tests::test_pip_lifecycle -- --nocapture --exact --ignored
```