### PR TITLE
feat(env): rename parameter cache environment variable to convention

### DIFF
--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -30,7 +30,7 @@ pub fn main() {
         .about(
             &format!(
                 "
-Set $FILECOIN_PARAMETER_CACHE to specify parameter directory.
+Set $FIL_PROOFS_PARAMETER_CACHE to specify parameter directory.
 Defaults to '{}'
 ",
                 PARAMETER_CACHE_DIR

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -18,7 +18,7 @@ use crate::error::Error::Unclassified;
 /// Bump this when circuits change to invalidate the cache.
 pub const VERSION: usize = 12;
 
-pub const PARAMETER_CACHE_ENV_VAR: &str = "FILECOIN_PARAMETER_CACHE";
+pub const PARAMETER_CACHE_ENV_VAR: &str = "FIL_PROOFS_PARAMETER_CACHE";
 
 pub const PARAMETER_CACHE_DIR: &str = "/var/tmp/filecoin-proof-parameters/";
 


### PR DESCRIPTION
Fixes #741 