### PR TITLE
encapsulate logic in expaned parents

### DIFF
--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -460,8 +460,8 @@ mod tests {
 
         // End copied section.
 
-        let expected_inputs = 36;
-        let expected_constraints = 432312;
+        let expected_inputs = 52;
+        let expected_constraints = 673496;
         {
             // Verify that MetricCS returns the same metrics as TestConstraintSystem.
             let mut cs = MetricCS::<Bls12>::new();

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -231,13 +231,6 @@ impl<Z: ZigZag> Graph<Z::BaseHasher> for Z {
         });
 
         assert!(parents.len() == self.degree());
-        if self.forward() {
-            parents.sort();
-        } else {
-            // Sort in reverse order.
-            parents.sort_by(|a, b| a.cmp(b).reverse());
-        }
-
         assert!(parents.iter().all(|p| if self.forward() {
             *p <= raw_node
         } else {
@@ -366,6 +359,13 @@ where
             pad_parent;
             self.expansion_degree * 2 - expanded_parents.len()
         ]);
+
+        if self.forward() {
+            expanded_parents.sort();
+        } else {
+            // Sort in reverse order.
+            expanded_parents.sort_by(|a, b| a.cmp(b).reverse());
+        }
 
         expanded_parents
     }

--- a/storage-proofs/src/zigzag_graph.rs
+++ b/storage-proofs/src/zigzag_graph.rs
@@ -355,10 +355,7 @@ where
 
         // Add padding parents.
         let pad_parent = if self.reversed() { self.size() - 1 } else { 0 } as u32;
-        expanded_parents.extend(vec![
-            pad_parent;
-            self.expansion_degree * 2 - expanded_parents.len()
-        ]);
+        expanded_parents.resize(self.expansion_degree * 2, pad_parent);
 
         if self.forward() {
             expanded_parents.sort();


### PR DESCRIPTION
New `parents()` method:

https://github.com/filecoin-project/rust-fil-proofs/blob/4a6f1944cfa9e77f18f1592a3e5c041fba7ec475/storage-proofs/src/zigzag_graph.rs#L215-L246