### PR TITLE
[WIP] feat: implement progress callback for seal and replicate

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/rational_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/rational_post.rs
@@ -91,6 +91,7 @@ pub fn run(sector_size: usize) -> Result<(), failure::Error> {
         &PROVER_ID,
         sector_id,
         &[sector_size_unpadded_bytes_ammount],
+        |event| info!("seal: {:?}", event),
     )
     .expect("failed to seal");
 

--- a/fil-proofs-tooling/src/bin/benchy/zigzag.rs
+++ b/fil-proofs-tooling/src/bin/benchy/zigzag.rs
@@ -152,7 +152,10 @@ where
                 wall_time: replication_wall_time,
                 return_value: (pub_inputs, priv_inputs),
             } = measure(|| {
-                let (tau, aux) = ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, &mut data, None)?;
+                let (tau, aux) =
+                    ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, &mut data, None, |event| {
+                        info!("replicate: {:?}", event);
+                    })?;
 
                 let pb = layered_drgporep::PublicInputs::<H::Domain> {
                     replica_id,

--- a/filecoin-proofs/examples/drgporep-vanilla-disk.rs
+++ b/filecoin-proofs/examples/drgporep-vanilla-disk.rs
@@ -70,7 +70,10 @@ fn do_the_work<H: Hasher>(data_size: usize, challenge_count: usize) {
 
     info!("running replicate");
     let (tau, aux) =
-        DrgPoRep::<H, _>::replicate(&pp, &replica_id.into(), &mut mmapped, None).unwrap();
+        DrgPoRep::<H, _>::replicate(&pp, &replica_id.into(), &mut mmapped, None, |event| {
+            info!("replicate progress: {:?}", event);
+        })
+        .unwrap();
 
     let pub_inputs = PublicInputs::<H::Domain> {
         replica_id: Some(replica_id.into()),

--- a/filecoin-proofs/examples/drgporep-vanilla.rs
+++ b/filecoin-proofs/examples/drgporep-vanilla.rs
@@ -86,7 +86,10 @@ fn do_the_work<H: Hasher>(data_size: usize, challenge_count: usize) {
 
     start_profile("replicate");
     let (tau, aux) =
-        DrgPoRep::<H, _>::replicate(&pp, &replica_id, data.as_mut_slice(), None).unwrap();
+        DrgPoRep::<H, _>::replicate(&pp, &replica_id, data.as_mut_slice(), None, |event| {
+            info!("replicate progress: {:?}", event);
+        })
+        .unwrap();
     stop_profile();
     let pub_inputs = PublicInputs {
         replica_id: Some(replica_id),

--- a/filecoin-proofs/examples/zigzag.rs
+++ b/filecoin-proofs/examples/zigzag.rs
@@ -207,7 +207,11 @@ fn do_the_work<H: 'static>(
         info!("running replicate");
 
         start_profile("replicate");
-        let (tau, aux) = ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, &mut data, None).unwrap();
+        let (tau, aux) =
+            ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, &mut data, None, |event| {
+                info!("replicate progress: {:?}", event);
+            })
+            .unwrap();
         stop_profile();
         let pub_inputs = layered_drgporep::PublicInputs::<H::Domain> {
             replica_id,

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -581,6 +581,7 @@ mod tests {
             &replica_id.into(),
             data.as_mut_slice(),
             None,
+            |_| {},
         )
         .expect("failed to replicate");
 
@@ -770,6 +771,7 @@ mod tests {
             &replica_id.into(),
             data.as_mut_slice(),
             None,
+            |_| {},
         )
         .expect("failed to replicate");
 

--- a/storage-proofs/src/circuit/zigzag.rs
+++ b/storage-proofs/src/circuit/zigzag.rs
@@ -430,9 +430,14 @@ mod tests {
         };
 
         let pp = ZigZagDrgPoRep::setup(&sp).expect("setup failed");
-        let (tau, aux) =
-            ZigZagDrgPoRep::replicate(&pp, &replica_id.into(), data_copy.as_mut_slice(), None)
-                .expect("replication failed");
+        let (tau, aux) = ZigZagDrgPoRep::replicate(
+            &pp,
+            &replica_id.into(),
+            data_copy.as_mut_slice(),
+            None,
+            |_| {},
+        )
+        .expect("replication failed");
         assert_ne!(data, data_copy);
 
         let simplified_tau = tau.clone().simplify();
@@ -641,6 +646,7 @@ mod tests {
             &replica_id.into(),
             data_copy.as_mut_slice(),
             None,
+            |_| {},
         )
         .expect("replication failed");
 

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -432,13 +432,18 @@ where
 {
     type Tau = porep::Tau<H::Domain>;
     type ProverAux = porep::ProverAux<H>;
+    type ReplicateEvent = ();
 
-    fn replicate(
+    fn replicate<F>(
         pp: &Self::PublicParams,
         replica_id: &H::Domain,
         data: &mut [u8],
         data_tree: Option<MerkleTree<H::Domain, H::Function>>,
-    ) -> Result<(porep::Tau<H::Domain>, porep::ProverAux<H>)> {
+        _progress: F,
+    ) -> Result<(porep::Tau<H::Domain>, porep::ProverAux<H>)>
+    where
+        F: Fn(Self::ReplicateEvent),
+    {
         let tree_d = match data_tree {
             Some(tree) => tree,
             None => pp.graph.merkle_tree(data)?,
@@ -525,7 +530,7 @@ mod tests {
 
         let pp = DrgPoRep::<H, BucketGraph<H>>::setup(&sp).expect("setup failed");
 
-        DrgPoRep::replicate(&pp, &replica_id, &mut mmapped_data_copy, None)
+        DrgPoRep::replicate(&pp, &replica_id, &mut mmapped_data_copy, None, |_| {})
             .expect("replication failed");
 
         let mut copied = vec![0; data.len()];
@@ -578,7 +583,7 @@ mod tests {
 
         let pp = DrgPoRep::<H, BucketGraph<H>>::setup(&sp).expect("setup failed");
 
-        DrgPoRep::replicate(&pp, &replica_id, &mut mmapped_data_copy, None)
+        DrgPoRep::replicate(&pp, &replica_id, &mut mmapped_data_copy, None, |_| {})
             .expect("replication failed");
 
         let mut copied = vec![0; data.len()];
@@ -653,7 +658,7 @@ mod tests {
             let pp = DrgPoRep::<H, BucketGraph<_>>::setup(&sp).expect("setup failed");
 
             let (tau, aux) =
-                DrgPoRep::<H, _>::replicate(&pp, &replica_id, &mut mmapped_data_copy, None)
+                DrgPoRep::<H, _>::replicate(&pp, &replica_id, &mut mmapped_data_copy, None, |_| {})
                     .expect("replication failed");
 
             let mut copied = vec![0; data.len()];

--- a/storage-proofs/src/porep.rs
+++ b/storage-proofs/src/porep.rs
@@ -50,13 +50,17 @@ impl<H: Hasher> ProverAux<H> {
 pub trait PoRep<'a, H: Hasher>: ProofScheme<'a> {
     type Tau;
     type ProverAux;
+    type ReplicateEvent;
 
-    fn replicate(
+    fn replicate<F>(
         pub_params: &'a Self::PublicParams,
         replica_id: &H::Domain,
         data: &mut [u8],
         data_tree: Option<MerkleTree<H::Domain, H::Function>>,
-    ) -> Result<(Self::Tau, Self::ProverAux)>;
+        progress: F,
+    ) -> Result<(Self::Tau, Self::ProverAux)>
+    where
+        F: Fn(Self::ReplicateEvent);
 
     fn extract_all(
         pub_params: &'a Self::PublicParams,

--- a/storage-proofs/src/zigzag_drgporep.rs
+++ b/storage-proofs/src/zigzag_drgporep.rs
@@ -104,7 +104,7 @@ mod tests {
             pp.graph = zigzag(&pp.graph);
         }
 
-        ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None)
+        ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None, |_| {})
             .expect("replication failed");
 
         let transformed_params = PublicParams::new(pp.graph, challenges.clone());
@@ -161,9 +161,14 @@ mod tests {
         };
 
         let pp = ZigZagDrgPoRep::<H>::setup(&sp).expect("setup failed");
-        let (tau, aux) =
-            ZigZagDrgPoRep::<H>::replicate(&pp, &replica_id, data_copy.as_mut_slice(), None)
-                .expect("replication failed");
+        let (tau, aux) = ZigZagDrgPoRep::<H>::replicate(
+            &pp,
+            &replica_id,
+            data_copy.as_mut_slice(),
+            None,
+            |_| {},
+        )
+        .expect("replication failed");
         assert_ne!(data, data_copy);
 
         let pub_inputs = PublicInputs::<H::Domain> {


### PR DESCRIPTION
Uses a simple callback that is called whenever a new event happens. This currently only covers Seal and Replicate, but should be a good start to figure out the api from start to finish.

Ref #886 