### PR TITLE
Simplify `transform_and_replicate_layers`.

### DIFF
--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -7,7 +7,7 @@ use rayon::prelude::*;
 use crate::error::*;
 use crate::hasher::pedersen::PedersenHasher;
 use crate::hasher::{Domain, Hasher};
-use crate::merkle::{MerkleStore, MerkleTree};
+use crate::merkle::MerkleTree;
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node, NODE_SIZE};
 use merkletree::merkle::FromIndexedParallelIterator;
@@ -63,16 +63,6 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
         } else {
             Ok(MerkleTree::new((0..self.size()).map(f)))
         }
-    }
-
-    /// Builds a merkle tree based on the given leaves store.
-    // FIXME: Add the parallel case (if it's worth it).
-    fn merkle_tree_from_leaves(
-        &self,
-        leaves: MerkleStore<H::Domain>,
-        leafs_number: usize,
-    ) -> Result<MerkleTree<H::Domain, H::Function>> {
-        Ok(MerkleTree::from_leaves_store(leaves, leafs_number))
     }
 
     /// Returns the merkle tree depth.


### PR DESCRIPTION
Easier to review [ignoring whitespaces](https://github.com/filecoin-project/rust-fil-proofs/pull/901/files?w=1).

Talking with @cryptonm today I realized this function is way more complex than it needs to be:

* The graph doesn't need to be involved in the MT construction.
* We don't need any elaborate channel communication, each thread should store its generated MT, they can share a centralized source without any serious penalty.

Hopefully this will smooth a bit the learning curve for @cryptonm to work on some of the MT integrations aspects of the code.
