### PR TITLE
feat: normalize ids

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/rational_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/rational_post.rs
@@ -17,7 +17,7 @@ use tempfile::NamedTempFile;
 // The seed for the rng used to generate which sectors to challenge.
 const CHALLENGE_SEED: [u8; 32] = [0; 32];
 
-const PROVER_ID: [u8; 31] = [0; 31];
+const PROVER_ID: [u8; 32] = [0; 32];
 const SECTOR_ID: u64 = 0;
 const N_PARTITIONS: PoRepProofPartitions = PoRepProofPartitions(1);
 
@@ -89,7 +89,7 @@ pub fn run(sector_size: usize) -> Result<(), failure::Error> {
         porep_config,
         staged_file.path(),
         sealed_file.path(),
-        &PROVER_ID,
+        PROVER_ID,
         sector_id,
         ticket,
         &[sector_size_unpadded_bytes_ammount],

--- a/storage-proofs/src/stacked/params.rs
+++ b/storage-proofs/src/stacked/params.rs
@@ -417,15 +417,15 @@ pub fn get_node<H: Hasher>(data: &[u8], index: usize) -> Result<H::Domain> {
 /// Generate the replica id as expected for Stacked DRG.
 pub fn generate_replica_id<H: Hasher>(
     prover_id: &[u8; 32],
-    sector_id: &[u8; 32],
+    sector_id: u64,
     ticket: &[u8; 32],
     comm_d: H::Domain,
 ) -> H::Domain {
-    let mut to_hash = [0u8; 4 * 32];
+    let mut to_hash = [0u8; 3 * 32 + 8];
     to_hash[..32].copy_from_slice(prover_id);
-    to_hash[32..64].copy_from_slice(sector_id);
-    to_hash[64..96].copy_from_slice(ticket);
-    to_hash[96..].copy_from_slice(AsRef::<[u8]>::as_ref(&comm_d));
+    to_hash[32..40].copy_from_slice(&sector_id.to_le_bytes()[..]);
+    to_hash[40..72].copy_from_slice(ticket);
+    to_hash[72..].copy_from_slice(AsRef::<[u8]>::as_ref(&comm_d));
 
     H::Function::hash(&to_hash[..])
 }

--- a/storage-proofs/src/stacked/params.rs
+++ b/storage-proofs/src/stacked/params.rs
@@ -6,14 +6,15 @@ use serde::{Deserialize, Serialize};
 use crate::drgporep;
 use crate::drgraph::Graph;
 use crate::error::Result;
-use crate::hasher::{Domain, HashFunction, Hasher};
+use crate::fr32::bytes_into_fr_repr_safe;
+use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::stacked::{
     column::Column, column_proof::ColumnProof, encoding_proof::EncodingProof,
     graph::StackedBucketGraph, hash::hash2, LayerChallenges,
 };
-use crate::util::data_at_node;
+use crate::util::{data_at_node, NODE_SIZE};
 
 pub type Tree<H> = MerkleTree<<H as Hasher>::Domain, <H as Hasher>::Function>;
 
@@ -421,11 +422,14 @@ pub fn generate_replica_id<H: Hasher>(
     ticket: &[u8; 32],
     comm_d: H::Domain,
 ) -> H::Domain {
-    let mut to_hash = [0u8; 3 * 32 + 8];
-    to_hash[..32].copy_from_slice(prover_id);
-    to_hash[32..40].copy_from_slice(&sector_id.to_le_bytes()[..]);
-    to_hash[40..72].copy_from_slice(ticket);
-    to_hash[72..].copy_from_slice(AsRef::<[u8]>::as_ref(&comm_d));
+    use blake2s_simd::Params as Blake2s;
 
-    H::Function::hash(&to_hash[..])
+    let mut hasher = Blake2s::new().hash_length(NODE_SIZE).to_state();
+
+    hasher.update(prover_id);
+    hasher.update(&sector_id.to_le_bytes()[..]);
+    hasher.update(ticket);
+    hasher.update(AsRef::<[u8]>::as_ref(&comm_d));
+
+    bytes_into_fr_repr_safe(hasher.finalize().as_ref()).into()
 }


### PR DESCRIPTION
- prover_id is now a [u8; 32]
- sector_id gets properly hashed as [u8; 8] not [u8; 32]
- use blake2s to calculate the replica_id