### PR TITLE
fix(benchmarks): fix benchmark invocations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,10 +216,10 @@ jobs:
             cat micro-benchmarks.json
           no_output_timeout: 60m
       - run:
-          name: Run ZigZag benchmarks using 1GiB sectors
+          name: Run stacked benchmarks using 1GiB sectors
           command: |
-            ./fil-proofs-tooling/scripts/benchy-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" zigzag --size=$((1024*1024)) > zigzag-benchmarks.json
-            cat zigzag-benchmarks.json
+            ./fil-proofs-tooling/scripts/benchy-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" stacked --size=$((1024*1024)) > stacked-benchmarks.json
+            cat stacked-benchmarks.json
           no_output_timeout: 60m
       - run:
           name: Run Rational PoST benchmarks using a 1GiB sector
@@ -230,10 +230,10 @@ jobs:
       - run:
           name: Aggregate benchmarks into single JSON document
           command: |
-            ./fil-proofs-tooling/scripts/aggregate-benchmarks.sh zigzag-benchmarks.json micro-benchmarks.json hash-constraints.json rational-post-benchmarks.json > aggregated-benchmarks.json
+            ./fil-proofs-tooling/scripts/aggregate-benchmarks.sh stacked-benchmarks.json micro-benchmarks.json hash-constraints.json rational-post-benchmarks.json > aggregated-benchmarks.json
             cat aggregated-benchmarks.json
       - store_artifacts:
-          path: zigzag-benchmarks.json
+          path: stacked-benchmarks.json
       - store_artifacts:
           path: hash-constraints.json
       - store_artifacts:


### PR DESCRIPTION
## Why does this PR exist?

The existing metrics capture CircleCI config is busted, which means that `master` is busted.

## What's in this PR?

This PR fixes the CircleCI config such that metrics can again be captured.