### PR TITLE
feat(filecoin-proofs): generate_post and seal both accept cache dir-path

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/rational_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/rational_post.rs
@@ -82,11 +82,13 @@ pub fn run(sector_size: usize) -> Result<(), failure::Error> {
 
     // Replicate the staged sector, write the replica file to `sealed_path`.
     let porep_config = PoRepConfig(SectorSize(sector_size as u64), N_PARTITIONS);
+    let cache_dir = tempfile::tempdir().unwrap();
     let sector_id = SectorId::from(SECTOR_ID);
     let ticket = [0u8; 32];
 
     let seal_output = seal(
         porep_config,
+        cache_dir.path(),
         staged_file.path(),
         sealed_file.path(),
         PROVER_ID,
@@ -104,7 +106,12 @@ pub fn run(sector_size: usize) -> Result<(), failure::Error> {
 
     priv_replica_info.insert(
         sector_id,
-        PrivateReplicaInfo::new(sealed_path_string, seal_output.comm_r, seal_output.p_aux),
+        PrivateReplicaInfo::new(
+            sealed_path_string,
+            seal_output.comm_r,
+            seal_output.p_aux,
+            cache_dir.into_path(),
+        ),
     );
 
     // Measure PoSt generation and verification.

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -19,6 +19,7 @@ use crate::error;
 use crate::parameters::{post_setup_params, public_params};
 use crate::singletons::ENGINE_PARAMS;
 use crate::types::{PaddedBytesAmount, PoStConfig};
+use std::path::PathBuf;
 
 /// The minimal information required about a replica, in order to be able to generate
 /// a PoSt over it.
@@ -32,6 +33,8 @@ pub struct PrivateReplicaInfo {
     aux: PersistentAux,
     /// Is this sector marked as a fault?
     is_fault: bool,
+    /// Contains sector-specific (e.g. merkle trees) assets
+    cache_dir: PathBuf,
 }
 
 impl std::cmp::Ord for PrivateReplicaInfo {
@@ -47,21 +50,28 @@ impl std::cmp::PartialOrd for PrivateReplicaInfo {
 }
 
 impl PrivateReplicaInfo {
-    pub fn new(access: String, comm_r: Commitment, aux: PersistentAux) -> Self {
+    pub fn new(access: String, comm_r: Commitment, aux: PersistentAux, cache_dir: PathBuf) -> Self {
         PrivateReplicaInfo {
             access,
             comm_r,
             aux,
             is_fault: false,
+            cache_dir,
         }
     }
 
-    pub fn new_faulty(access: String, comm_r: Commitment, aux: PersistentAux) -> Self {
+    pub fn new_faulty(
+        access: String,
+        comm_r: Commitment,
+        aux: PersistentAux,
+        cache_dir: PathBuf,
+    ) -> Self {
         PrivateReplicaInfo {
             access,
             comm_r,
             aux,
             is_fault: true,
+            cache_dir,
         }
     }
 


### PR DESCRIPTION
## Why does this PR exist?

The `seal` function creates a bunch of merkle trees which `generate_post` needs to make use of (so that it doesn't have to regenerate said merkle trees).

## What's in this PR?

This PR modifies both `seal` and `generate_post` to accept a per-sector cache path. The `seal` function will ultimately write to this directory and `generate_post` will read from it.