### PR TITLE
fix(benchy): pass correct file path to pre_commit + create correctly-sized byte vector

### DIFF
--- a/fil-proofs-tooling/scripts/benchy.sh
+++ b/fil-proofs-tooling/scripts/benchy.sh
@@ -52,4 +52,5 @@ if [[ ! $GTIME_EXIT_CODE -eq 0 || ! $JQ_EXIT_CODE -eq 0 ]]; then
     >&2 echo "<JQ_STDERR>"
     >&2 echo "$(cat $JQ_STDERR)"
     >&2 echo "</JQ_STDERR>"
+    exit 1
 fi

--- a/fil-proofs-tooling/scripts/micro.sh
+++ b/fil-proofs-tooling/scripts/micro.sh
@@ -34,4 +34,5 @@ if [[ ! $MICRO_EXIT_CODE -eq 0 || ! $JQ_EXIT_CODE -eq 0 ]]; then
     >&2 echo "<JQ_STDERR>"
     >&2 echo "$(cat $JQ_STDERR)"
     >&2 echo "</JQ_STDERR>"
+    exit 1
 fi


### PR DESCRIPTION
## What's in this PR?

Ensure that:

- len(user bytes) < len(bit-padded(user bytes))
- we pass the correct file to pre_commit
- we propagate failures encountered when running benchy