### PR TITLE
feat(filecoin-proofs): improve add_piece

### DIFF
--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -179,7 +179,6 @@ impl Domain for Blake2sDomain {
 
     fn try_from_bytes(raw: &[u8]) -> Result<Self> {
         if raw.len() != 32 || u32::from(raw[31]) > Fr::NUM_BITS {
-            println!("{:?}", raw[31]);
             return Err(Error::InvalidInputSize);
         }
 

--- a/storage-proofs/src/pieces.rs
+++ b/storage-proofs/src/pieces.rs
@@ -77,14 +77,9 @@ pub fn generate_piece_commitment_bytes_from_source<H: Hasher>(
 
     let mut buf = [0; NODE_SIZE];
 
-    loop {
-        let bytes_read = source.read(&mut buf)?;
-        total_bytes_read += bytes_read;
-        if bytes_read > 0 {
-            domain_data.push(<H::Domain as Domain>::try_from_bytes(&buf[..bytes_read])?);
-        } else {
-            break;
-        }
+    while let Ok(_) = source.read_exact(&mut buf) {
+        total_bytes_read += NODE_SIZE;
+        domain_data.push(<H::Domain as Domain>::try_from_bytes(&buf)?);
     }
 
     if total_bytes_read < NODE_SIZE {


### PR DESCRIPTION
It now calculates the comm_p, such that it is not necessary to call `generate_piece_commitment` manually when adding a piece.