### PR TITLE
fix(storage-proofs): spec sync 

### DIFF
--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -7,8 +7,8 @@ use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::{Bls12, Fr};
 
 use crate::circuit::constraint;
+use crate::circuit::create_label::create_label as kdf;
 use crate::circuit::encode;
-use crate::circuit::kdf::kdf;
 use crate::circuit::por::{PoRCircuit, PoRCompound};
 use crate::circuit::variables::Root;
 use crate::compound_proof::{CircuitComponent, CompoundProof};

--- a/storage-proofs/src/circuit/mod.rs
+++ b/storage-proofs/src/circuit/mod.rs
@@ -1,8 +1,8 @@
 mod constraint;
 
+pub mod create_label;
 pub mod drgporep;
 pub mod encode;
-pub mod kdf;
 pub mod multi_proof;
 pub mod pedersen;
 pub mod por;

--- a/storage-proofs/src/circuit/stacked/encoding_proof.rs
+++ b/storage-proofs/src/circuit/stacked/encoding_proof.rs
@@ -3,7 +3,7 @@ use fil_sapling_crypto::circuit::{boolean::Boolean, num};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::{Bls12, Fr};
 
-use crate::circuit::{constraint, encode::encode, kdf::kdf, uint64};
+use crate::circuit::{constraint, create_label::create_label as kdf, encode::encode, uint64};
 use crate::drgraph::Graph;
 use crate::fr32::fr_into_bytes;
 use crate::hasher::Hasher;

--- a/storage-proofs/src/circuit/stacked/encoding_proof.rs
+++ b/storage-proofs/src/circuit/stacked/encoding_proof.rs
@@ -18,15 +18,10 @@ pub struct EncodingProof {
 
 impl EncodingProof {
     /// Create an empty proof, used in `blank_circuit`s.
-    pub fn empty<H: Hasher>(params: &PublicParams<H>, layer: usize) -> Self {
-        let degree = if layer == 1 {
-            params.graph.base_graph().degree()
-        } else {
-            params.graph.degree()
-        };
+    pub fn empty<H: Hasher>(params: &PublicParams<H>) -> Self {
         EncodingProof {
             node: None,
-            parents: vec![None; degree],
+            parents: vec![None; params.graph.degree()],
         }
     }
 
@@ -68,30 +63,7 @@ impl EncodingProof {
         )
     }
 
-    pub fn synthesize_key<CS: ConstraintSystem<Bls12>>(
-        self,
-        mut cs: CS,
-        params: &<Bls12 as JubjubEngine>::Params,
-        replica_id: &[Boolean],
-        exp_encoded_node: &num::AllocatedNum<Bls12>,
-    ) -> Result<(), SynthesisError> {
-        let EncodingProof { node, parents } = self;
-
-        let key = Self::create_key(
-            cs.namespace(|| "create_key"),
-            params,
-            replica_id,
-            node,
-            parents,
-        )?;
-
-        // enforce equality
-        constraint::equal(&mut cs, || "equality_key", &exp_encoded_node, &key);
-
-        Ok(())
-    }
-
-    pub fn synthesize_decoded<CS: ConstraintSystem<Bls12>>(
+    pub fn synthesize<CS: ConstraintSystem<Bls12>>(
         self,
         mut cs: CS,
         params: &<Bls12 as JubjubEngine>::Params,

--- a/storage-proofs/src/circuit/stacked/labeling_proof.rs
+++ b/storage-proofs/src/circuit/stacked/labeling_proof.rs
@@ -1,0 +1,105 @@
+use bellperson::{ConstraintSystem, SynthesisError};
+use fil_sapling_crypto::circuit::{boolean::Boolean, num};
+use fil_sapling_crypto::jubjub::JubjubEngine;
+use paired::bls12_381::{Bls12, Fr};
+
+use crate::circuit::{constraint, kdf::kdf, uint64};
+use crate::drgraph::Graph;
+use crate::hasher::Hasher;
+use crate::stacked::{LabelingProof as VanillaLabelingProof, PublicParams};
+
+#[derive(Debug, Clone)]
+pub struct LabelingProof {
+    node: Option<u64>,
+    parents: Vec<Option<Fr>>,
+}
+
+impl LabelingProof {
+    /// Create an empty proof, used in `blank_circuit`s.
+    pub fn empty<H: Hasher>(params: &PublicParams<H>, layer: usize) -> Self {
+        let degree = if layer == 1 {
+            params.graph.base_graph().degree()
+        } else {
+            params.graph.degree()
+        };
+        LabelingProof {
+            node: None,
+            parents: vec![None; degree],
+        }
+    }
+
+    fn create_key<CS: ConstraintSystem<Bls12>>(
+        mut cs: CS,
+        _params: &<Bls12 as JubjubEngine>::Params,
+        replica_id: &[Boolean],
+        node: Option<u64>,
+        parents: Vec<Option<Fr>>,
+    ) -> Result<num::AllocatedNum<Bls12>, SynthesisError> {
+        let parents_num = parents
+            .into_iter()
+            .enumerate()
+            .map(|(i, parent)| {
+                num::AllocatedNum::alloc(cs.namespace(|| format!("parent_{}_num", i)), || {
+                    parent
+                        .map(Into::into)
+                        .ok_or_else(|| SynthesisError::AssignmentMissing)
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        let parents_bits = parents_num
+            .into_iter()
+            .enumerate()
+            .map(|(i, parent)| {
+                let mut bits =
+                    parent.into_bits_le(cs.namespace(|| format!("parent_{}_bits", i)))?;
+                while bits.len() % 8 > 0 {
+                    bits.push(Boolean::Constant(false));
+                }
+                Ok(bits)
+            })
+            .collect::<Result<Vec<_>, SynthesisError>>()?;
+
+        let node_num = uint64::UInt64::alloc(cs.namespace(|| "node"), node)?;
+
+        kdf(
+            cs.namespace(|| "create_key"),
+            replica_id,
+            parents_bits,
+            Some(node_num),
+        )
+    }
+
+    pub fn synthesize<CS: ConstraintSystem<Bls12>>(
+        self,
+        mut cs: CS,
+        params: &<Bls12 as JubjubEngine>::Params,
+        replica_id: &[Boolean],
+        exp_encoded_node: &num::AllocatedNum<Bls12>,
+    ) -> Result<(), SynthesisError> {
+        let LabelingProof { node, parents } = self;
+
+        let key = Self::create_key(
+            cs.namespace(|| "create_key"),
+            params,
+            replica_id,
+            node,
+            parents,
+        )?;
+
+        // enforce equality
+        constraint::equal(&mut cs, || "equality_key", &exp_encoded_node, &key);
+
+        Ok(())
+    }
+}
+
+impl<H: Hasher> From<VanillaLabelingProof<H>> for LabelingProof {
+    fn from(vanilla_proof: VanillaLabelingProof<H>) -> Self {
+        let VanillaLabelingProof { parents, node, .. } = vanilla_proof;
+
+        LabelingProof {
+            node: Some(node),
+            parents: parents.into_iter().map(|p| Some(p.into())).collect(),
+        }
+    }
+}

--- a/storage-proofs/src/circuit/stacked/labeling_proof.rs
+++ b/storage-proofs/src/circuit/stacked/labeling_proof.rs
@@ -3,7 +3,7 @@ use fil_sapling_crypto::circuit::{boolean::Boolean, num};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::{Bls12, Fr};
 
-use crate::circuit::{constraint, kdf::kdf, uint64};
+use crate::circuit::{constraint, create_label::create_label, uint64};
 use crate::drgraph::Graph;
 use crate::hasher::Hasher;
 use crate::stacked::{LabelingProof as VanillaLabelingProof, PublicParams};
@@ -28,7 +28,7 @@ impl LabelingProof {
         }
     }
 
-    fn create_key<CS: ConstraintSystem<Bls12>>(
+    fn create_label<CS: ConstraintSystem<Bls12>>(
         mut cs: CS,
         _params: &<Bls12 as JubjubEngine>::Params,
         replica_id: &[Boolean],
@@ -61,8 +61,8 @@ impl LabelingProof {
 
         let node_num = uint64::UInt64::alloc(cs.namespace(|| "node"), node)?;
 
-        kdf(
-            cs.namespace(|| "create_key"),
+        create_label(
+            cs.namespace(|| "create_label"),
             replica_id,
             parents_bits,
             Some(node_num),
@@ -78,8 +78,8 @@ impl LabelingProof {
     ) -> Result<(), SynthesisError> {
         let LabelingProof { node, parents } = self;
 
-        let key = Self::create_key(
-            cs.namespace(|| "create_key"),
+        let key = Self::create_label(
+            cs.namespace(|| "create_label"),
             params,
             replica_id,
             node,

--- a/storage-proofs/src/circuit/stacked/mod.rs
+++ b/storage-proofs/src/circuit/stacked/mod.rs
@@ -2,6 +2,7 @@ mod column;
 mod column_proof;
 mod encoding_proof;
 pub(crate) mod hash;
+mod labeling_proof;
 mod params;
 mod proof;
 

--- a/storage-proofs/src/circuit/stacked/params.rs
+++ b/storage-proofs/src/circuit/stacked/params.rs
@@ -87,7 +87,7 @@ impl<H: Hasher, G: Hasher> Proof<H, G> {
         // verify encodings
         for (layer, proof) in labeling_proofs.into_iter() {
             let raw = replica_column_proof.c_x.get_node_at_layer(layer);
-            let encoded_node =
+            let labeled_node =
                 num::AllocatedNum::alloc(cs.namespace(|| format!("label_node_{}", layer)), || {
                     raw.map(Into::into)
                         .ok_or_else(|| SynthesisError::AssignmentMissing)
@@ -97,7 +97,7 @@ impl<H: Hasher, G: Hasher> Proof<H, G> {
                 cs.namespace(|| format!("labeling_proof_{}", layer)),
                 params,
                 replica_id,
-                &encoded_node,
+                &labeled_node,
             )?;
         }
 

--- a/storage-proofs/src/circuit/stacked/params.rs
+++ b/storage-proofs/src/circuit/stacked/params.rs
@@ -5,7 +5,9 @@ use fil_sapling_crypto::circuit::{boolean::Boolean, num};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::{Bls12, Fr};
 
-use crate::circuit::stacked::{column_proof::ColumnProof, encoding_proof::EncodingProof};
+use crate::circuit::stacked::{
+    column_proof::ColumnProof, encoding_proof::EncodingProof, labeling_proof::LabelingProof,
+};
 use crate::circuit::{por::PoRCircuit, variables::Root};
 use crate::drgraph::Graph;
 use crate::hasher::Hasher;
@@ -19,7 +21,8 @@ pub struct Proof<H: Hasher, G: Hasher> {
     pub comm_d_proof: InclusionPath<G>,
     pub comm_r_last_proof: InclusionPath<H>,
     pub replica_column_proof: ReplicaColumnProof<H>,
-    pub encoding_proofs: Vec<EncodingProof>,
+    pub labeling_proofs: Vec<(usize, LabelingProof)>,
+    pub encoding_proof: EncodingProof,
 }
 
 impl<H: Hasher, G: Hasher> Proof<H, G> {
@@ -27,22 +30,25 @@ impl<H: Hasher, G: Hasher> Proof<H, G> {
     pub fn empty(params: &PublicParams<H>, challenge_index: usize) -> Self {
         let layers = params.layer_challenges.layers();
 
-        let mut encoding_proofs = Vec::with_capacity(layers);
+        let mut labeling_proofs = Vec::with_capacity(layers);
         for layer in 1..=layers {
-            if !params
+            let include_challenge = params
                 .layer_challenges
-                .include_challenge_at_layer(layer, challenge_index)
-            {
+                .include_challenge_at_layer(layer, challenge_index);
+
+            if !include_challenge {
                 continue;
             }
 
-            encoding_proofs.push(EncodingProof::empty(params, layer));
+            labeling_proofs.push((layer, LabelingProof::empty(params, layer)));
         }
+
         Proof {
             comm_d_proof: InclusionPath::empty(&params.graph),
             comm_r_last_proof: InclusionPath::empty(&params.graph),
             replica_column_proof: ReplicaColumnProof::empty(params),
-            encoding_proofs,
+            labeling_proofs,
+            encoding_proof: EncodingProof::empty(params),
         }
     }
 
@@ -62,7 +68,8 @@ impl<H: Hasher, G: Hasher> Proof<H, G> {
             comm_d_proof,
             comm_r_last_proof,
             replica_column_proof,
-            encoding_proofs,
+            labeling_proofs,
+            encoding_proof,
         } = self;
 
         // verify initial data layer
@@ -78,35 +85,29 @@ impl<H: Hasher, G: Hasher> Proof<H, G> {
             comm_r_last_proof.alloc_value(cs.namespace(|| "comm_r_last_data_leaf"))?;
 
         // verify encodings
-        for (i, proof) in encoding_proofs.into_iter().enumerate() {
-            let layer = i + 1;
+        for (layer, proof) in labeling_proofs.into_iter() {
+            let raw = replica_column_proof.c_x.get_node_at_layer(layer);
+            let encoded_node =
+                num::AllocatedNum::alloc(cs.namespace(|| format!("label_node_{}", layer)), || {
+                    raw.map(Into::into)
+                        .ok_or_else(|| SynthesisError::AssignmentMissing)
+                })?;
 
-            if layer == layers {
-                proof.synthesize_decoded(
-                    cs.namespace(|| format!("encoding_proof_{}", layer)),
-                    params,
-                    replica_id,
-                    &comm_r_last_data_leaf,
-                    &comm_d_leaf,
-                )?;
-            } else {
-                let raw = replica_column_proof.c_x.get_node_at_layer(layer);
-                let encoded_node = num::AllocatedNum::alloc(
-                    cs.namespace(|| format!("enc_node_{}", layer)),
-                    || {
-                        raw.map(Into::into)
-                            .ok_or_else(|| SynthesisError::AssignmentMissing)
-                    },
-                )?;
-
-                proof.synthesize_key(
-                    cs.namespace(|| format!("encoding_proof_{}", layer)),
-                    params,
-                    replica_id,
-                    &encoded_node,
-                )?;
-            }
+            proof.synthesize(
+                cs.namespace(|| format!("labeling_proof_{}", layer)),
+                params,
+                replica_id,
+                &encoded_node,
+            )?;
         }
+
+        encoding_proof.synthesize(
+            cs.namespace(|| format!("encoding_proof_{}", layers)),
+            params,
+            replica_id,
+            &comm_r_last_data_leaf,
+            &comm_d_leaf,
+        )?;
 
         // verify replica column openings
         replica_column_proof.synthesize(cs.namespace(|| "replica_column_proof"), params, comm_c)?;
@@ -129,14 +130,23 @@ impl<H: Hasher, G: Hasher> From<VanillaProof<H, G>> for Proof<H, G> {
             comm_d_proofs,
             comm_r_last_proof,
             replica_column_proofs,
-            encoding_proofs,
+            labeling_proofs,
+            encoding_proof,
         } = vanilla_proof;
+
+        let mut labeling_proofs: Vec<_> = labeling_proofs
+            .into_iter()
+            .map(|(layer, p)| (layer, p.into()))
+            .collect();
+
+        labeling_proofs.sort_by_cached_key(|(k, _)| *k);
 
         Proof {
             comm_d_proof: comm_d_proofs.into(),
             comm_r_last_proof: comm_r_last_proof.into(),
             replica_column_proof: replica_column_proofs.into(),
-            encoding_proofs: encoding_proofs.into_iter().map(|p| p.into()).collect(),
+            labeling_proofs,
+            encoding_proof: encoding_proof.into(),
         }
     }
 }

--- a/storage-proofs/src/circuit/stacked/proof.rs
+++ b/storage-proofs/src/circuit/stacked/proof.rs
@@ -401,7 +401,7 @@ mod tests {
         assert!(proofs_are_valid);
 
         let expected_inputs = 20;
-        let expected_constraints = 329_930;
+        let expected_constraints = 649_106;
 
         {
             // Verify that MetricCS returns the same metrics as TestConstraintSystem.

--- a/storage-proofs/src/crypto/create_label.rs
+++ b/storage-proofs/src/crypto/create_label.rs
@@ -5,19 +5,19 @@ use sha2::{Digest, Sha256};
 use crate::fr32::bytes_into_fr_repr_safe;
 
 /// Key derivation function, based on pedersen hashing.
-pub fn kdf(data: &[u8], _m: usize) -> Fr {
+pub fn create_label(data: &[u8], _m: usize) -> Fr {
     let hash = Sha256::digest(data);
     Fr::from_repr(bytes_into_fr_repr_safe(hash.as_ref())).unwrap()
 }
 
 #[cfg(test)]
 mod tests {
-    use super::kdf;
+    use super::create_label;
     use ff::PrimeField;
     use paired::bls12_381::{Fr, FrRepr};
 
     #[test]
-    fn kdf_valid_block_len() {
+    fn create_label_valid_block_len() {
         let m = 1;
         let size = 32 * (1 + m);
 
@@ -30,7 +30,7 @@ mod tests {
         ];
         let expected = Fr::from_repr(FrRepr(repr)).unwrap();
 
-        let res = kdf(&data, m);
+        let res = create_label(&data, m);
         assert_eq!(res, expected);
     }
 }

--- a/storage-proofs/src/crypto/mod.rs
+++ b/storage-proofs/src/crypto/mod.rs
@@ -1,6 +1,6 @@
 pub mod aes;
+pub mod create_label;
 pub mod feistel;
-pub mod kdf;
 pub mod pedersen;
 pub mod sloth;
 pub mod xor;

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -26,7 +26,7 @@ impl Hasher for Blake2sHasher {
         "Blake2sHasher".into()
     }
 
-    fn kdf(data: &[u8], m: usize) -> Self::Domain {
+    fn create_label(data: &[u8], m: usize) -> Self::Domain {
         assert_eq!(
             data.len(),
             32 * (1 + m),

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -11,7 +11,7 @@ use paired::bls12_381::{Bls12, Fr, FrRepr};
 use rand::{Rand, Rng};
 
 use crate::circuit::pedersen::pedersen_md_no_padding;
-use crate::crypto::{kdf, pedersen, sloth};
+use crate::crypto::{create_label, pedersen, sloth};
 use crate::error::{Error, Result};
 use crate::hasher::{Domain, HashFunction, Hasher};
 
@@ -26,8 +26,8 @@ impl Hasher for PedersenHasher {
         "PedersenHasher".into()
     }
 
-    fn kdf(data: &[u8], m: usize) -> Self::Domain {
-        kdf::kdf(data, m).into()
+    fn create_label(data: &[u8], m: usize) -> Self::Domain {
+        create_label::create_label(data, m).into()
     }
 
     #[inline]

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -26,15 +26,7 @@ impl Hasher for Sha256Hasher {
         "Sha256Hasher".into()
     }
 
-    fn kdf(data: &[u8], m: usize) -> Self::Domain {
-        assert_eq!(
-            data.len(),
-            32 * (1 + m),
-            "invalid input length: data.len(): {} m: {}",
-            data.len(),
-            m
-        );
-
+    fn create_label(data: &[u8], _m: usize) -> Self::Domain {
         <Self::Function as HashFunction<Self::Domain>>::hash(data)
     }
 

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -73,7 +73,7 @@ pub trait Hasher: Clone + ::std::fmt::Debug + Eq + Default + Send + Sync {
     type Domain: Domain + LightHashable<Self::Function> + AsRef<Self::Domain>;
     type Function: HashFunction<Self::Domain>;
 
-    fn kdf(data: &[u8], m: usize) -> Self::Domain;
+    fn create_label(data: &[u8], m: usize) -> Self::Domain;
     fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain;
     fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain;
 

--- a/storage-proofs/src/stacked/challenges.rs
+++ b/storage-proofs/src/stacked/challenges.rs
@@ -29,7 +29,7 @@ impl LayerChallenges {
         assert!(layer <= self.layers, "Layer too large");
 
         // TODO: proper tapering
-        if layer == 1 {
+        if layer == self.layers {
             self.max_count
         } else {
             self.max_count / 2

--- a/storage-proofs/src/stacked/column_proof.rs
+++ b/storage-proofs/src/stacked/column_proof.rs
@@ -22,13 +22,10 @@ pub struct ColumnProof<H: Hasher> {
 
 impl<H: Hasher> ColumnProof<H> {
     pub fn from_column(column: Column<H>, inclusion_proof: MerkleProof<H>) -> Self {
-        let res = ColumnProof {
+        ColumnProof {
             column,
             inclusion_proof,
-        };
-        debug_assert!(res.verify());
-
-        res
+        }
     }
 
     pub fn root(&self) -> &H::Domain {
@@ -52,10 +49,12 @@ impl<H: Hasher> ColumnProof<H> {
         self.column.hash()
     }
 
-    pub fn verify(&self) -> bool {
+    pub fn verify(&self, challenge: u32, expected_root: &H::Domain) -> bool {
         let c_i = self.column_hash();
 
+        check_eq!(self.inclusion_proof.root(), expected_root);
         check!(self.inclusion_proof.validate_data(c_i.as_ref()));
+        check!(self.inclusion_proof.validate(challenge as usize));
 
         true
     }

--- a/storage-proofs/src/stacked/encoding_proof.rs
+++ b/storage-proofs/src/stacked/encoding_proof.rs
@@ -44,16 +44,12 @@ impl<H: Hasher> EncodingProof<H> {
         &self,
         replica_id: &H::Domain,
         exp_encoded_node: &H::Domain,
-        decoded_node: Option<&G::Domain>,
+        decoded_node: &G::Domain,
     ) -> bool {
         let key = self.create_key(replica_id);
 
-        let encoded_node = if let Some(decoded_node) = decoded_node {
-            let fr: Fr = (*decoded_node).into();
-            encode(key, fr.into())
-        } else {
-            key
-        };
+        let fr: Fr = (*decoded_node).into();
+        let encoded_node = encode(key, fr.into());
 
         check_eq!(exp_encoded_node, &encoded_node);
 

--- a/storage-proofs/src/stacked/labeling_proof.rs
+++ b/storage-proofs/src/stacked/labeling_proof.rs
@@ -1,0 +1,48 @@
+use std::marker::PhantomData;
+
+use blake2s_simd::Params as Blake2s;
+
+use crate::fr32::bytes_into_fr_repr_safe;
+use crate::hasher::Hasher;
+use crate::util::NODE_SIZE;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LabelingProof<H: Hasher> {
+    pub(crate) parents: Vec<H::Domain>,
+    pub(crate) node: u64,
+    #[serde(skip)]
+    _h: PhantomData<H>,
+}
+
+impl<H: Hasher> LabelingProof<H> {
+    pub fn new(node: u64, parents: Vec<H::Domain>) -> Self {
+        LabelingProof {
+            node,
+            parents,
+            _h: PhantomData,
+        }
+    }
+
+    fn create_key(&self, replica_id: &H::Domain) -> H::Domain {
+        let mut hasher = Blake2s::new().hash_length(NODE_SIZE).to_state();
+
+        // replica_id
+        hasher.update(AsRef::<[u8]>::as_ref(replica_id));
+
+        // node id
+        hasher.update(&(self.node as u64).to_le_bytes());
+
+        for parent in &self.parents {
+            hasher.update(AsRef::<[u8]>::as_ref(parent));
+        }
+
+        bytes_into_fr_repr_safe(hasher.finalize().as_ref()).into()
+    }
+
+    pub fn verify(&self, replica_id: &H::Domain, exp_labeled_node: &H::Domain) -> bool {
+        let key = self.create_key(replica_id);
+        check_eq!(exp_labeled_node, &key);
+
+        true
+    }
+}

--- a/storage-proofs/src/stacked/labeling_proof.rs
+++ b/storage-proofs/src/stacked/labeling_proof.rs
@@ -1,10 +1,9 @@
 use std::marker::PhantomData;
 
-use blake2s_simd::Params as Blake2s;
+use sha2::{Digest, Sha256};
 
 use crate::fr32::bytes_into_fr_repr_safe;
 use crate::hasher::Hasher;
-use crate::util::NODE_SIZE;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LabelingProof<H: Hasher> {
@@ -24,19 +23,19 @@ impl<H: Hasher> LabelingProof<H> {
     }
 
     fn create_label(&self, replica_id: &H::Domain) -> H::Domain {
-        let mut hasher = Blake2s::new().hash_length(NODE_SIZE).to_state();
+        let mut hasher = Sha256::new();
 
         // replica_id
-        hasher.update(AsRef::<[u8]>::as_ref(replica_id));
+        hasher.input(AsRef::<[u8]>::as_ref(replica_id));
 
         // node id
-        hasher.update(&(self.node as u64).to_le_bytes());
+        hasher.input(&(self.node as u64).to_be_bytes());
 
         for parent in &self.parents {
-            hasher.update(AsRef::<[u8]>::as_ref(parent));
+            hasher.input(AsRef::<[u8]>::as_ref(parent));
         }
 
-        bytes_into_fr_repr_safe(hasher.finalize().as_ref()).into()
+        bytes_into_fr_repr_safe(hasher.result().as_ref()).into()
     }
 
     pub fn verify(&self, replica_id: &H::Domain, expected_label: &H::Domain) -> bool {

--- a/storage-proofs/src/stacked/labeling_proof.rs
+++ b/storage-proofs/src/stacked/labeling_proof.rs
@@ -23,7 +23,7 @@ impl<H: Hasher> LabelingProof<H> {
         }
     }
 
-    fn create_key(&self, replica_id: &H::Domain) -> H::Domain {
+    fn create_label(&self, replica_id: &H::Domain) -> H::Domain {
         let mut hasher = Blake2s::new().hash_length(NODE_SIZE).to_state();
 
         // replica_id
@@ -39,9 +39,9 @@ impl<H: Hasher> LabelingProof<H> {
         bytes_into_fr_repr_safe(hasher.finalize().as_ref()).into()
     }
 
-    pub fn verify(&self, replica_id: &H::Domain, exp_labeled_node: &H::Domain) -> bool {
-        let key = self.create_key(replica_id);
-        check_eq!(exp_labeled_node, &key);
+    pub fn verify(&self, replica_id: &H::Domain, expected_label: &H::Domain) -> bool {
+        let label = self.create_label(replica_id);
+        check_eq!(expected_label, &label);
 
         true
     }

--- a/storage-proofs/src/stacked/mod.rs
+++ b/storage-proofs/src/stacked/mod.rs
@@ -7,6 +7,7 @@ mod column_proof;
 mod encoding_proof;
 mod graph;
 pub(crate) mod hash;
+mod labeling_proof;
 mod params;
 mod porep;
 mod proof;
@@ -22,3 +23,4 @@ pub use self::params::{
     ReplicaColumnProof, SetupParams, Tau, TemporaryAux,
 };
 pub use self::proof::StackedDrg;
+pub use labeling_proof::LabelingProof;

--- a/storage-proofs/src/stacked/params.rs
+++ b/storage-proofs/src/stacked/params.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use merkletree::store::DiskStore;
@@ -12,8 +13,8 @@ use crate::hasher::{Domain, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::stacked::{
-    column::Column, column_proof::ColumnProof, encoding_proof::EncodingProof,
-    graph::StackedBucketGraph, hash::hash2, LayerChallenges,
+    column::Column, column_proof::ColumnProof, graph::StackedBucketGraph, hash::hash2,
+    EncodingProof, LabelingProof, LayerChallenges,
 };
 use crate::util::data_at_node;
 
@@ -141,11 +142,16 @@ pub struct Proof<H: Hasher, G: Hasher> {
     ))]
     pub replica_column_proofs: ReplicaColumnProof<H>,
     #[serde(bound(
+        serialize = "LabelingProof<H>: Serialize",
+        deserialize = "LabelingProof<H>: Deserialize<'de>"
+    ))]
+    /// Indexed by layer in 1..layers.
+    pub labeling_proofs: HashMap<usize, LabelingProof<H>>,
+    #[serde(bound(
         serialize = "EncodingProof<H>: Serialize",
         deserialize = "EncodingProof<H>: Deserialize<'de>"
     ))]
-    /// Indexed by layer in 1..layers.
-    pub encoding_proofs: Vec<EncodingProof<H>>,
+    pub encoding_proof: EncodingProof<H>,
 }
 
 impl<H: Hasher, G: Hasher> Proof<H, G> {
@@ -201,46 +207,43 @@ impl<H: Hasher, G: Hasher> Proof<H, G> {
 
         check!(self.verify_final_replica_layer(challenge));
 
-        check!(self.verify_encodings(replica_id, &pub_params.layer_challenges, challenge_index));
+        check!(self.verify_labels(replica_id, &pub_params.layer_challenges, challenge_index));
+
+        trace!("verify encoding");
+        check!(self.encoding_proof.verify::<G>(
+            replica_id,
+            self.comm_r_last_proof.leaf(),
+            self.comm_d_proofs.leaf()
+        ));
 
         true
     }
 
     /// Verify all encodings.
-    fn verify_encodings(
+    fn verify_labels(
         &self,
         replica_id: &H::Domain,
         layer_challenges: &LayerChallenges,
         challenge_index: usize,
     ) -> bool {
-        // Verify Encoding Layer 1..layers
+        // Verify Labels Layer 1..layers
         for layer in 1..=layer_challenges.layers() {
             let expect_challenge =
                 layer_challenges.include_challenge_at_layer(layer, challenge_index);
             trace!(
-                "verify encoding (layer: {} - expect_challenge: {})",
+                "verify labeling (layer: {} - expect_challenge: {})",
                 layer,
                 expect_challenge
             );
 
-            let (encoded_node, decoded_node) = if layer == layer_challenges.layers() {
-                (
-                    self.comm_r_last_proof.leaf(),
-                    Some(self.comm_d_proofs.leaf()),
-                )
-            } else {
-                (
-                    self.replica_column_proofs.c_x.get_node_at_layer(layer),
-                    None,
-                )
-            };
+            let labeled_node = self.replica_column_proofs.c_x.get_node_at_layer(layer);
 
             if expect_challenge {
-                check!(self.encoding_proofs.get(layer - 1).is_some());
-                let encoding_proof = &self.encoding_proofs[layer - 1];
-                check!(encoding_proof.verify::<G>(replica_id, encoded_node, decoded_node));
+                check!(self.labeling_proofs.contains_key(&layer));
+                let labeling_proof = &self.labeling_proofs.get(&layer).unwrap();
+                check!(labeling_proof.verify(replica_id, labeled_node));
             } else {
-                check!(self.encoding_proofs.get(layer - 1).is_none());
+                check!(self.labeling_proofs.get(&layer).is_none());
             }
         }
 
@@ -327,49 +330,49 @@ pub struct PersistentAux<D> {
 #[derive(Debug)]
 pub struct TemporaryAux<H: Hasher, G: Hasher> {
     /// The encoded nodes for 1..layers.
-    pub encodings: Encodings<H>,
+    pub labels: Labels<H>,
     pub tree_d: Tree<G>,
     pub tree_r_last: Tree<H>,
     pub tree_c: Tree<H>,
 }
 
 impl<H: Hasher, G: Hasher> TemporaryAux<H, G> {
-    pub fn encoding_at_layer(&self, layer: usize) -> &DiskStore<H::Domain> {
-        self.encodings.encoding_at_layer(layer)
+    pub fn labels_for_layer(&self, layer: usize) -> &DiskStore<H::Domain> {
+        self.labels.labels_for_layer(layer)
     }
 
-    pub fn domain_node_at_layer(&self, layer: usize, node_index: u32) -> Result<H::Domain> {
-        Ok(self.encoding_at_layer(layer).read_at(node_index as usize))
+    pub fn domain_node_at_layer(&self, layer: usize, node_index: u32) -> H::Domain {
+        self.labels_for_layer(layer).read_at(node_index as usize)
     }
 
     pub fn column(&self, column_index: u32) -> Result<Column<H>> {
-        self.encodings.column(column_index)
+        self.labels.column(column_index)
     }
 }
 
 #[derive(Debug)]
-pub struct Encodings<H: Hasher> {
-    encodings: Vec<DiskStore<H::Domain>>,
+pub struct Labels<H: Hasher> {
+    labels: Vec<DiskStore<H::Domain>>,
     _h: PhantomData<H>,
 }
 
-impl<H: Hasher> Encodings<H> {
-    pub fn new(encodings: Vec<DiskStore<H::Domain>>) -> Self {
-        Encodings {
-            encodings,
+impl<H: Hasher> Labels<H> {
+    pub fn new(labels: Vec<DiskStore<H::Domain>>) -> Self {
+        Labels {
+            labels,
             _h: PhantomData,
         }
     }
 
     pub fn len(&self) -> usize {
-        self.encodings.len()
+        self.labels.len()
     }
 
     pub fn is_empty(&self) -> bool {
-        self.encodings.is_empty()
+        self.labels.is_empty()
     }
 
-    pub fn encoding_at_layer(&self, layer: usize) -> &DiskStore<H::Domain> {
+    pub fn labels_for_layer(&self, layer: usize) -> &DiskStore<H::Domain> {
         assert!(layer != 0, "Layer cannot be 0");
         assert!(
             layer <= self.layers(),
@@ -379,25 +382,25 @@ impl<H: Hasher> Encodings<H> {
         );
 
         let row_index = layer - 1;
-        &self.encodings[row_index]
+        &self.labels[row_index]
     }
 
-    /// Returns encoding on the last layer.
-    pub fn encoding_at_last_layer(&self) -> &DiskStore<H::Domain> {
-        &self.encodings[self.encodings.len() - 1]
+    /// Returns the labels on the last layer.
+    pub fn labels_for_last_layer(&self) -> &DiskStore<H::Domain> {
+        &self.labels[self.labels.len() - 1]
     }
 
     /// How many layers are available.
     fn layers(&self) -> usize {
-        self.encodings.len()
+        self.labels.len()
     }
 
     /// Build the column for the given node.
     pub fn column(&self, node: u32) -> Result<Column<H>> {
         let rows = self
-            .encodings
+            .labels
             .iter()
-            .map(|encoding| encoding.read_at(node as usize))
+            .map(|labels| labels.read_at(node as usize))
             .collect();
 
         Ok(Column::new(node, rows))

--- a/storage-proofs/src/stacked/proof.rs
+++ b/storage-proofs/src/stacked/proof.rs
@@ -15,7 +15,6 @@ use crate::merkle::{MerkleProof, MerkleTree, Store};
 use crate::stacked::{
     challenges::LayerChallenges,
     column::Column,
-    encoding_proof::EncodingProof,
     graph::StackedBucketGraph,
     hash::hash2,
     params::{

--- a/storage-proofs/src/stacked/proof.rs
+++ b/storage-proofs/src/stacked/proof.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::marker::PhantomData;
 
 use merkletree::merkle::FromIndexedParallelIterator;
@@ -18,9 +19,10 @@ use crate::stacked::{
     graph::StackedBucketGraph,
     hash::hash2,
     params::{
-        get_node, Encodings, PersistentAux, Proof, PublicInputs, ReplicaColumnProof, Tau,
+        get_node, Labels, PersistentAux, Proof, PublicInputs, ReplicaColumnProof, Tau,
         TemporaryAux, TransformedLayers, Tree,
     },
+    EncodingProof, LabelingProof,
 };
 use crate::util::{data_at_node, data_at_node_offset, NODE_SIZE};
 
@@ -43,7 +45,7 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
         partition_count: usize,
     ) -> Result<Vec<Vec<Proof<H, G>>>> {
         assert!(layers > 0);
-        assert_eq!(t_aux.encodings.len(), layers);
+        assert_eq!(t_aux.labels.len(), layers);
 
         let graph_size = graph.size();
 
@@ -123,8 +125,9 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                         let comm_r_last_proof =
                             MerkleProof::new_from_proof(&t_aux.tree_r_last.gen_proof(challenge));
 
-                        // Encoding Proof Layer 1..l
-                        let mut encoding_proofs = Vec::with_capacity(layers);
+                        // Labeling Proofs Layer 1..l
+                        let mut labeling_proofs = HashMap::with_capacity(layers);
+                        let mut encoding_proof = None;
 
                         for layer in 1..=layers {
                             let include_challenge =
@@ -140,14 +143,14 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                                 continue;
                             }
 
-                            let parents_data = if layer == 1 {
+                            let parents_data: Vec<H::Domain> = if layer == 1 {
                                 let mut parents = vec![0; graph.base_graph().degree()];
                                 graph.base_parents(challenge, &mut parents);
 
                                 parents
                                     .into_iter()
                                     .map(|parent| t_aux.domain_node_at_layer(layer, parent))
-                                    .collect::<Result<_>>()?
+                                    .collect()
                             } else {
                                 let mut parents = vec![0; graph.degree()];
                                 graph.parents(challenge, &mut parents);
@@ -165,36 +168,34 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                                             t_aux.domain_node_at_layer(layer - 1, parent)
                                         }
                                     })
-                                    .collect::<Result<_>>()?
+                                    .collect()
                             };
 
-                            let proof = EncodingProof::<H>::new(challenge as u64, parents_data);
+                            let proof =
+                                LabelingProof::<H>::new(challenge as u64, parents_data.clone());
 
                             {
-                                let (encoded_node, decoded_node) = if layer == layers {
-                                    (comm_r_last_proof.leaf(), Some(comm_d_proof.leaf()))
-                                } else {
-                                    (rpc.c_x.get_node_at_layer(layer), None)
-                                };
-
+                                let labeled_node = rpc.c_x.get_node_at_layer(layer);
                                 assert!(
-                                    proof.verify::<G>(
-                                        &pub_inputs.replica_id,
-                                        &encoded_node,
-                                        decoded_node
-                                    ),
+                                    proof.verify(&pub_inputs.replica_id, &labeled_node),
                                     "Invalid encoding proof generated"
                                 );
                             }
 
-                            encoding_proofs.push(proof);
+                            labeling_proofs.insert(layer, proof);
+
+                            if layer == layers {
+                                encoding_proof =
+                                    Some(EncodingProof::new(challenge as u64, parents_data));
+                            }
                         }
 
                         Ok(Proof {
                             comm_d_proofs: comm_d_proof,
                             replica_column_proofs: rpc,
                             comm_r_last_proof,
-                            encoding_proofs,
+                            labeling_proofs,
+                            encoding_proof: encoding_proof.expect("invalid tapering"),
                         })
                     })
                     .collect()
@@ -213,13 +214,13 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
         let layers = layer_challenges.layers();
         assert!(layers > 0);
 
-        // generate encodings
-        let (encodings, _) = Self::generate_layers(graph, layer_challenges, replica_id, false)?;
+        // generate labels
+        let (labels, _) = Self::generate_labels(graph, layer_challenges, replica_id, false)?;
 
-        let size = encodings.encoding_at_last_layer().len();
+        let size = labels.labels_for_last_layer().len();
 
-        for (key, encoded_node_bytes) in encodings
-            .encoding_at_last_layer()
+        for (key, encoded_node_bytes) in labels
+            .labels_for_last_layer()
             .read_range(0..size)
             .into_iter()
             .zip(data.chunks_mut(NODE_SIZE))
@@ -235,19 +236,19 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
     }
 
     #[allow(clippy::type_complexity)]
-    fn generate_layers(
+    fn generate_labels(
         graph: &StackedBucketGraph<H>,
         layer_challenges: &LayerChallenges,
         replica_id: &<H as Hasher>::Domain,
         with_hashing: bool,
-    ) -> Result<(Encodings<H>, Option<Vec<[u8; 32]>>)> {
-        info!("generate layers");
+    ) -> Result<(Labels<H>, Option<Vec<[u8; 32]>>)> {
+        info!("generate labels");
         let layers = layer_challenges.layers();
-        let mut encodings: Vec<DiskStore<H::Domain>> = Vec::with_capacity(layers);
+        let mut labels: Vec<DiskStore<H::Domain>> = Vec::with_capacity(layers);
 
         let layer_size = graph.size() * NODE_SIZE;
         let mut parents = vec![0; graph.degree()];
-        let mut encoding = vec![0u8; layer_size];
+        let mut layer_labels = vec![0u8; layer_size];
 
         use crate::crypto::pedersen::Hasher as PedersenHasher;
 
@@ -266,7 +267,7 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
 
         let graph_size = graph.size();
 
-        // 1 less, to account for the thread we are on, which is doign the encoding.
+        // 1 less, to account for the thread we are on.
         let chunks = std::cmp::min(graph_size / 4, num_cpus::get() - 1);
         let chunk_len = (graph_size as f64 / chunks as f64).ceil() as usize;
 
@@ -313,8 +314,6 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
             for node in 0..graph.size() {
                 graph.parents(node, &mut parents);
 
-                // CreateKey inlined, to avoid borrow issues
-
                 let mut hasher = base_hasher.clone();
 
                 // hash node id
@@ -327,7 +326,8 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
 
                     // Base parents
                     for parent in parents.iter().take(base_parents_count) {
-                        let buf = data_at_node(&encoding, *parent as usize).expect("invalid node");
+                        let buf =
+                            data_at_node(&layer_labels, *parent as usize).expect("invalid node");
                         hasher.input(buf);
                     }
 
@@ -351,7 +351,7 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                 key[31] &= 0b0011_1111;
 
                 // store the newly generated key
-                encoding[start..end].copy_from_slice(&key[..]);
+                layer_labels[start..end].copy_from_slice(&key[..]);
 
                 if with_hashing {
                     let sender_index = node / chunk_len;
@@ -381,17 +381,17 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
 
             // NOTE: this means we currently keep 2x sector size around, to improve speed.
             if let Some(ref mut exp_parents_data) = exp_parents_data {
-                exp_parents_data.copy_from_slice(&encoding);
+                exp_parents_data.copy_from_slice(&layer_labels);
             } else {
-                exp_parents_data = Some(encoding.clone());
+                exp_parents_data = Some(layer_labels.clone());
             }
 
             // Write the result to disk to avoid keeping it in memory all the time.
-            encodings.push(DiskStore::new_from_slice(layer_size, &encoding)?);
+            labels.push(DiskStore::new_from_slice(layer_size, &layer_labels)?);
         }
 
         assert_eq!(
-            encodings.len(),
+            labels.len(),
             layers,
             "Invalid amount of layers encoded expected"
         );
@@ -404,8 +404,8 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                 .collect()
         });
 
-        info!("Layers generated");
-        Ok((Encodings::<H>::new(encodings), column_hashes))
+        info!("Labels generated");
+        Ok((Labels::<H>::new(labels), column_hashes))
     }
 
     fn build_tree<K: Hasher>(tree_data: &[u8]) -> Tree<K> {
@@ -435,9 +435,9 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
         let layers = layer_challenges.layers();
         assert!(layers > 0);
 
-        let (encodings, column_hashes, tree_d) = crossbeam::thread::scope(|s| {
+        let (labels, column_hashes, tree_d) = crossbeam::thread::scope(|s| {
             // Generate key layers.
-            let h = s.spawn(|_| Self::generate_layers(graph, layer_challenges, replica_id, true));
+            let h = s.spawn(|_| Self::generate_labels(graph, layer_challenges, replica_id, true));
 
             // Build the MerkleTree over the original data.
             let tree_d = match data_tree {
@@ -448,10 +448,10 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                 }
             };
 
-            let (encodings, column_hashes) = h.join().unwrap().unwrap();
+            let (labels, column_hashes) = h.join().unwrap().unwrap();
             let column_hashes = column_hashes.unwrap();
 
-            (encodings, column_hashes, tree_d)
+            (labels, column_hashes, tree_d)
         })?;
 
         let (tree_r_last, tree_c, comm_r): (Tree<H>, Tree<H>, H::Domain) =
@@ -459,9 +459,9 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                 // Encode original data into the last layer.
                 let tree_r_last_handle = s.spawn(|_| {
                     info!("encoding data");
-                    let size = encodings.encoding_at_last_layer().len();
-                    encodings
-                        .encoding_at_last_layer()
+                    let size = labels.labels_for_last_layer().len();
+                    labels
+                        .labels_for_last_layer()
                         .read_range(0..size)
                         .into_par_iter()
                         .zip(data.par_chunks_mut(NODE_SIZE))
@@ -513,7 +513,7 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                 comm_r_last: tree_r_last.root(),
             },
             TemporaryAux {
-                encodings,
+                labels,
                 tree_c,
                 tree_d,
                 tree_r_last,

--- a/storage-proofs/src/stacked/proof_scheme.rs
+++ b/storage-proofs/src/stacked/proof_scheme.rs
@@ -113,6 +113,15 @@ impl<'a, 'c, H: 'static + Hasher, G: 'static + Hasher> ProofScheme<'a> for Stack
                 // Validate for this challenge
                 let challenge = challenges[i];
 
+                // make sure all proofs have the same comm_c
+                if proof.comm_c() != proofs[0].comm_c() {
+                    return false;
+                }
+                // make sure all proofs have the same comm_r_last
+                if proof.comm_r_last() != proofs[0].comm_r_last() {
+                    return false;
+                }
+
                 proof.verify(pub_params, pub_inputs, challenge, i, graph)
             });
 

--- a/storage-proofs/src/stacked/proof_scheme.rs
+++ b/storage-proofs/src/stacked/proof_scheme.rs
@@ -1,3 +1,4 @@
+use paired::bls12_381::Fr;
 use rayon::prelude::*;
 
 use crate::drgraph::Graph;
@@ -7,6 +8,7 @@ use crate::proof::ProofScheme;
 use crate::stacked::{
     challenges::ChallengeRequirements,
     graph::StackedBucketGraph,
+    hash::hash2,
     params::{PrivateInputs, Proof, PublicInputs, PublicParams, SetupParams},
     proof::StackedDrg,
 };
@@ -78,12 +80,29 @@ impl<'a, 'c, H: 'static + Hasher, G: 'static + Hasher> ProofScheme<'a> for Stack
         // generate graphs
         let graph = &pub_params.graph;
 
+        let expected_comm_r = if let Some(ref tau) = pub_inputs.tau {
+            &tau.comm_r
+        } else {
+            return Ok(false);
+        };
+
         for (k, proofs) in partition_proofs.iter().enumerate() {
             trace!(
                 "verifying partition proof {}/{}",
                 k + 1,
                 partition_proofs.len()
             );
+
+            trace!("verify comm_r");
+            let actual_comm_r: H::Domain = {
+                let comm_c = proofs[0].comm_c();
+                let comm_r_last = proofs[0].comm_r_last();
+                Fr::from(hash2(comm_c, comm_r_last)).into()
+            };
+
+            if expected_comm_r != &actual_comm_r {
+                return Ok(false);
+            }
 
             let challenges =
                 pub_inputs.all_challenges(&pub_params.layer_challenges, graph.size(), Some(k));

--- a/storage-proofs/src/test_helper.rs
+++ b/storage-proofs/src/test_helper.rs
@@ -54,7 +54,7 @@ pub fn fake_drgpoprep_proof<R: Rng>(
     // Part 2: replica data inputs
     // generate parent nodes
     let replica_parents: Vec<Fr> = (0..m).map(|_| rng.gen()).collect();
-    // run kdf for proverid, parent nodes
+    // run create_label for proverid, parent nodes
     let ciphertexts = replica_parents
         .iter()
         .fold(
@@ -68,7 +68,7 @@ pub fn fake_drgpoprep_proof<R: Rng>(
         )
         .unwrap();
 
-    let key = crypto::kdf::kdf(ciphertexts.as_slice(), m);
+    let key = crypto::create_label::create_label(ciphertexts.as_slice(), m);
     // run sloth(key, node)
 
     let replica_node: Fr = crypto::sloth::encode::<Bls12>(&key, &data_node);


### PR DESCRIPTION
The first round of updating naming and adjusting some smaller things better matching the spec.

Important to note
- fixed logic in tapering, such that it starts at the last layer note the first
- split labeling proofs and encoding proofs
- add missing round of labeling proofs for the last layer