### PR TITLE
expose piece-writing function which expects caller to bin pack

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -41,6 +41,8 @@ tar = "0.4.26"
 rayon = "1.1.0"
 blake2s_simd = "0.5.8"
 hex = "0.4.0"
+tee = "0.1.0"
+os_pipe = "0.9.1"
 
 [dependencies.reqwest]
 version = "0.9"

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -36,7 +36,7 @@ pub fn compute_comm_d(sector_size: SectorSize, piece_infos: &[PieceInfo]) -> Res
         "Too many pieces"
     );
 
-    // make sure the pice sizes are at most a sector size large
+    // make sure the piece sizes are at most a sector size large
     let piece_size: u64 = piece_infos
         .iter()
         .map(|info| u64::from(PaddedBytesAmount::from(info.size)))

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -267,7 +267,7 @@ pub fn get_aligned_source<T: Read>(
     source: T,
     pieces: &[UnpaddedBytesAmount],
     piece_bytes: UnpaddedBytesAmount,
-) -> (UnpaddedBytesAmount, impl Read) {
+) -> (UnpaddedBytesAmount, PieceAlignment, impl Read) {
     let written_bytes = sum_piece_bytes_with_alignment(pieces);
     let piece_alignment = get_piece_alignment(written_bytes, piece_bytes);
     let expected_num_bytes_written =
@@ -275,6 +275,7 @@ pub fn get_aligned_source<T: Read>(
 
     (
         expected_num_bytes_written,
+        piece_alignment.clone(),
         with_alignment(source, piece_alignment),
     )
 }


### PR DESCRIPTION
## Why does this PR exist?

The verify_seal function will soon reject sectors which were not packed up to some threshold. Also, generating the CommP can happen in a streaming fashion (by miners) at the time of writing and preprocessing.

## What's in this PR?

1. Exposes new vanity function which never adds alignment bytes
1. Modifies piece-adding functions to produce piece commitment in addition to number of bytes written-value