### PR TITLE
refactor(filecoin-proofs): add more information to piece size errors

### DIFF
--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -90,6 +90,12 @@ pub fn generate_piece_commitment<T: std::io::Read>(
     let n = write_padded(source, &temp_piece_file)
         .map_err(|err| format_err!("failed to write and preprocess bytes: {:?}", err))?;
 
+    if n == 0 {
+        return Err(format_err!(
+            "generate_piece_commitment: read 0 bytes from source before EOF"
+        ));
+    }
+
     let n = UnpaddedBytesAmount(n as u64);
 
     if n != piece_size {
@@ -177,6 +183,8 @@ where
 
     match (write_rslt, join_rslt) {
         (Ok(n), Ok(Ok(r))) => {
+            ensure!(n != 0, "add_piece: read 0 bytes before EOF from source");
+
             let n = UnpaddedBytesAmount(n as u64);
 
             ensure!(

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -94,7 +94,7 @@ pub fn generate_piece_commitment<T: std::io::Read>(
 
     if n != piece_size {
         return Err(format_err!(
-            "wrote more bytes ({:?}) than expected ({:?}) when preprocessing",
+            "wrote ({:?}) but expected to write ({:?}) when preprocessing",
             n,
             piece_size
         ));

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -52,14 +52,16 @@ pub fn compute_comm_d(sector_size: SectorSize, piece_infos: &[PieceInfo]) -> Res
     let first = piece_infos.first().unwrap().clone();
     ensure!(
         u64::from(PaddedBytesAmount::from(first.size)).is_power_of_two(),
-        "Piece size must be a power of 2."
+        "Piece size ({:?}) must be a power of 2.",
+        PaddedBytesAmount::from(first.size)
     );
     stack.shift(first);
 
     for piece_info in piece_infos.iter().skip(1) {
         ensure!(
             u64::from(PaddedBytesAmount::from(piece_info.size)).is_power_of_two(),
-            "Piece size must be a power of 2."
+            "Piece size ({:?}) must be a power of 2.",
+            PaddedBytesAmount::from(piece_info.size)
         );
 
         while stack.peek().size < piece_info.size {

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -661,8 +661,6 @@ mod tests {
         }
         assert_eq!(staged_sector.len(), u64::from(sector_size) as usize);
 
-        // println!("{:?}", &piece_infos);
-
         let data_tree = graph.merkle_tree(&staged_sector)?;
         let comm_d_root: Fr = data_tree.root().into();
         let comm_d = commitment_from_fr::<Bls12>(comm_d_root);


### PR DESCRIPTION
## What's in this PR?

If a piece is not sized correctly, our system produces an error when we try to add it to a staged sector. This error now includes the size of the piece to be added, which helps in debugging. We also alert the user to an EOF from the byte source, which is typically caused when caller passes a fd that needs to be fseeked back to its head.