### PR TITLE
fix(params): ensure benchmarking server has groth params and keys before running benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,15 +175,14 @@ jobs:
       - checkout
       - attach_workspace:
           at: "."
-      - restore_cache:
-          keys:
-            - cargo-v13-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-      - restore_cache:
-          keys:
-            - parameter-cache-{{ .Revision }}
       - run:
           name: Install jq
           command: apt-get install time jq -yqq
+      - run:
+          name: Ensure existence of Groth parameters and keys on remote host
+          command: |
+            ./fil-proofs-tooling/scripts/paramcache-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" "$((1024*1024*1024))"
+          no_output_timeout: 60m
       - run:
           name: Run hash-constraints benchmarks on remote host
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
       - run:
           name: Ensure existence of Groth parameters and keys on remote host
           command: |
-            ./fil-proofs-tooling/scripts/paramcache-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" "$((1024*1024*1024))"
+            ./fil-proofs-tooling/scripts/paramcache-remote.sh "${CIRCLE_BRANCH}" "${BENCHMARK_SERVER_SSH_USERNAME}@${BENCHMARK_SERVER_IP_ADDR}" "-z=$((1024*1024*1024))"
           no_output_timeout: 60m
       - run:
           name: Run hash-constraints benchmarks on remote host

--- a/fil-proofs-tooling/scripts/paramcache-remote.sh
+++ b/fil-proofs-tooling/scripts/paramcache-remote.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+CMDS=$(cat <<EOF
+cd \$(mktemp -d)
+git clone https://github.com/filecoin-project/rust-fil-proofs.git
+cd rust-fil-proofs
+git checkout -q $1
+./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
+    ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
+    ./fil-proofs-tooling/scripts/with-dots.sh \
+    RUST_LOG=info cargo run --release --package filecoin-proofs --bin=paramcache -- ${@:3}
+EOF
+)
+
+ssh -q $2 "$CMDS"

--- a/fil-proofs-tooling/scripts/paramcache-remote.sh
+++ b/fil-proofs-tooling/scripts/paramcache-remote.sh
@@ -7,10 +7,11 @@ cd \$(mktemp -d)
 git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
 git checkout -q $1
+export RUST_LOG=info
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/with-dots.sh \
-    RUST_LOG=info cargo run --release --package filecoin-proofs --bin=paramcache -- ${@:3}
+    cargo run --release --package filecoin-proofs --bin=paramcache -- ${@:3}
 EOF
 )
 


### PR DESCRIPTION
## Why does this PR exist?

The metrics_capture job relies on the existence of Groth parameters and keys for PoSt generation and sealing. Without this PR, new parameters will be generated lazily, impacting performance metrics.

## What's in this PR?

- delete cache restoration steps from metrics_capture
- invoke paramcache on remote host to ensure params n' keys