### PR TITLE
caller to provide challenge count to PoSt ops

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/election_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/election_post.rs
@@ -139,8 +139,16 @@ pub fn run(sector_size: usize) -> Result<(), failure::Error> {
     // Measure PoSt generation and verification.
     let post_config = PoStConfig(SectorSize(sector_size as u64));
 
+    let challenge_count = 1u64;
+
     let gen_candidates_measurement = measure(|| {
-        generate_candidates(post_config, &CHALLENGE_SEED, &priv_replica_info, PROVER_ID)
+        generate_candidates(
+            post_config,
+            &CHALLENGE_SEED,
+            challenge_count,
+            &priv_replica_info,
+            PROVER_ID,
+        )
     })
     .expect("failed to generate post candidates");
 
@@ -167,6 +175,7 @@ pub fn run(sector_size: usize) -> Result<(), failure::Error> {
         verify_post(
             post_config,
             &CHALLENGE_SEED,
+            challenge_count,
             proof,
             &pub_replica_info,
             &candidates

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -369,6 +369,7 @@ mod tests {
         let result = verify_post(
             PoStConfig(SectorSize(SECTOR_SIZE_ONE_KIB)),
             &[0; 32],
+            1,
             &[vec![0u8; SINGLE_PARTITION_PROOF_LEN]][..],
             &replicas,
             &[winner][..],

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -149,6 +149,7 @@ impl PublicReplicaInfo {
 pub fn generate_candidates(
     post_config: PoStConfig,
     randomness: &ChallengeSeed,
+    challenge_count: u64,
     replicas: &BTreeMap<SectorId, PrivateReplicaInfo>,
     prover_id: ProverId,
 ) -> error::Result<Vec<Candidate>> {
@@ -167,7 +168,8 @@ pub fn generate_candidates(
 
     let sectors = replicas.keys().copied().collect();
 
-    let challenged_sectors = election_post::generate_sector_challenges(randomness, &sectors)?;
+    let challenged_sectors =
+        election_post::generate_sector_challenges(randomness, challenge_count, &sectors)?;
 
     // Match the replicas to the challenges, as these are the only ones required.
     let challenged_replicas: Vec<_> = challenged_sectors
@@ -285,6 +287,7 @@ pub fn generate_post(
 pub fn verify_post(
     post_config: PoStConfig,
     randomness: &ChallengeSeed,
+    challenge_count: u64,
     proofs: &[Vec<u8>],
     replicas: &BTreeMap<SectorId, PublicReplicaInfo>,
     winners: &[Candidate],
@@ -320,7 +323,7 @@ pub fn verify_post(
         let comm_r = replica.safe_comm_r()?;
 
         if !election_post::is_valid_sector_challenge_index(
-            sector_count as usize,
+            challenge_count,
             winner.sector_challenge_index,
         ) {
             return Ok(false);

--- a/storage-proofs/src/election_post.rs
+++ b/storage-proofs/src/election_post.rs
@@ -22,7 +22,6 @@ use crate::util::NODE_SIZE;
 
 pub const POST_CHALLENGE_COUNT: usize = 8;
 pub const POST_CHALLENGED_NODES: usize = 16;
-pub const CHALLENGE_COUNT_DENOMINATOR: f64 = 25.;
 
 #[derive(Debug, Clone)]
 pub struct SetupParams {
@@ -218,18 +217,16 @@ pub fn finalize_ticket(partial_ticket: &Fr) -> [u8; 32] {
     ticket
 }
 
-pub fn is_valid_sector_challenge_index(sector_count: usize, index: u64) -> bool {
-    let max = (sector_count as f64 / CHALLENGE_COUNT_DENOMINATOR).ceil() as u64;
-    index < max
+pub fn is_valid_sector_challenge_index(challenge_count: u64, index: u64) -> bool {
+    index < challenge_count
 }
 
 pub fn generate_sector_challenges(
     randomness: &[u8; 32],
+    challenge_count: u64,
     sectors: &OrderedSectorSet,
 ) -> Result<Vec<SectorId>> {
-    let challenge_count = (sectors.len() as f64 / CHALLENGE_COUNT_DENOMINATOR).ceil() as usize;
-
-    let mut challenges = Vec::with_capacity(challenge_count);
+    let mut challenges = Vec::with_capacity(challenge_count as usize);
 
     for n in 0..challenge_count as usize {
         let sector = generate_sector_challenge(randomness, n, sectors)?;


### PR DESCRIPTION
## Why does this PR exist?

The number of challenges for a given miner is a function of the size of their proving set - but we don't know what that function is. It may be a per-miner value or it may be a network-wide parameter. Either way, it's in a state of flux. 

## What's in this PR?

This changeset allows the caller of the rust-fil-proofs library to provide a challenge count instead of having the rust-fil-proofs library do this for them. 