### PR TITLE
Reduce unwrap()s in code

### DIFF
--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -73,7 +73,7 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>>(
     let pp = public_params(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
-    );
+    )?;
 
     let offset_padded: PaddedBytesAmount = UnpaddedBytesAmount::from(offset).into();
     let num_bytes_padded: PaddedBytesAmount = num_bytes.into();

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -77,7 +77,7 @@ pub fn seal_pre_commit<R: AsRef<Path>, T: AsRef<Path>, S: AsRef<Path>>(
         vanilla_params: setup_params(
             PaddedBytesAmount::from(porep_config),
             usize::from(PoRepProofPartitions::from(porep_config)),
-        ),
+        )?,
         partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
     };
 
@@ -219,7 +219,7 @@ pub fn seal_commit<T: AsRef<Path>>(
         vanilla_params: setup_params(
             PaddedBytesAmount::from(porep_config),
             usize::from(PoRepProofPartitions::from(porep_config)),
-        ),
+        )?,
         partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
     };
 
@@ -290,7 +290,7 @@ pub fn verify_seal(
         vanilla_params: setup_params(
             PaddedBytesAmount::from(porep_config),
             usize::from(PoRepProofPartitions::from(porep_config)),
-        ),
+        )?,
         partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
     };
 

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -71,7 +71,7 @@ pub fn seal_pre_commit<R: AsRef<Path>, T: AsRef<Path>, S: AsRef<Path>>(
     // Zero-pad the data to the requested size by extending the underlying file if needed.
     f_data.set_len(sector_bytes as u64)?;
 
-    let mut data = unsafe { MmapOptions::new().map_mut(&f_data).unwrap() };
+    let mut data = unsafe { MmapOptions::new().map_mut(&f_data)? };
 
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -35,7 +35,8 @@ fn cache_porep_params(porep_config: PoRepConfig) {
     let public_params = public_params(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
-    );
+    )
+    .unwrap();
 
     {
         let circuit = <StackedCompound as CompoundProof<
@@ -70,7 +71,7 @@ fn cache_post_params(post_config: PoStConfig) {
         n
     );
 
-    let post_public_params = post_public_params(post_config);
+    let post_public_params = post_public_params(post_config).unwrap();
 
     {
         let post_circuit: ElectionPoStCircuit<Bls12, PedersenHasher> =

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -81,7 +81,7 @@ pub fn get_stacked_params(porep_config: PoRepConfig) -> Result<Arc<groth16::Para
     let public_params = public_params(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
-    );
+    )?;
 
     let parameters_generator = || {
         <StackedCompound as CompoundProof<
@@ -102,7 +102,7 @@ pub fn get_stacked_params(porep_config: PoRepConfig) -> Result<Arc<groth16::Para
 }
 
 pub fn get_post_params(post_config: PoStConfig) -> Result<Arc<groth16::Parameters<Bls12>>> {
-    let post_public_params = post_public_params(post_config);
+    let post_public_params = post_public_params(post_config)?;
 
     let parameters_generator = || {
         <ElectionPoStCompound<DefaultTreeHasher> as CompoundProof<
@@ -126,7 +126,7 @@ pub fn get_stacked_verifying_key(porep_config: PoRepConfig) -> Result<Arc<Bls12V
     let public_params = public_params(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
-    );
+    )?;
 
     let vk_generator = || {
         <StackedCompound as CompoundProof<
@@ -147,7 +147,7 @@ pub fn get_stacked_verifying_key(porep_config: PoRepConfig) -> Result<Arc<Bls12V
 }
 
 pub fn get_post_verifying_key(post_config: PoStConfig) -> Result<Arc<Bls12VerifyingKey>> {
-    let post_public_params = post_public_params(post_config);
+    let post_public_params = post_public_params(post_config)?;
 
     let vk_generator = || {
         <ElectionPoStCompound<DefaultTreeHasher> as CompoundProof<

--- a/filecoin-proofs/src/parameters.rs
+++ b/filecoin-proofs/src/parameters.rs
@@ -22,12 +22,11 @@ pub type PostPublicParams = election_post::PublicParams;
 pub fn public_params(
     sector_bytes: PaddedBytesAmount,
     partitions: usize,
-) -> stacked::PublicParams<DefaultTreeHasher> {
+) -> Result<stacked::PublicParams<DefaultTreeHasher>> {
     StackedDrg::<DefaultTreeHasher, DefaultPieceHasher>::setup(&setup_params(
         sector_bytes,
         partitions,
-    ))
-    .unwrap()
+    )?)
 }
 
 pub fn window_size_nodes_for_sector_bytes(sector_size: PaddedBytesAmount) -> Result<usize> {
@@ -42,8 +41,8 @@ pub fn window_size_nodes_for_sector_bytes(sector_size: PaddedBytesAmount) -> Res
     }
 }
 
-pub fn post_public_params(post_config: PoStConfig) -> PostPublicParams {
-    ElectionPoSt::<DefaultTreeHasher>::setup(&post_setup_params(post_config)).unwrap()
+pub fn post_public_params(post_config: PoStConfig) -> Result<PostPublicParams> {
+    ElectionPoSt::<DefaultTreeHasher>::setup(&post_setup_params(post_config))
 }
 
 pub fn post_setup_params(post_config: PoStConfig) -> PostSetupParams {
@@ -54,7 +53,10 @@ pub fn post_setup_params(post_config: PoStConfig) -> PostSetupParams {
     }
 }
 
-pub fn setup_params(sector_bytes: PaddedBytesAmount, partitions: usize) -> stacked::SetupParams {
+pub fn setup_params(
+    sector_bytes: PaddedBytesAmount,
+    partitions: usize,
+) -> Result<stacked::SetupParams> {
     let window_challenges = select_challenges(partitions, POREP_WINDOW_MINIMUM_CHALLENGES, LAYERS);
     let wrapper_challenges =
         select_challenges(partitions, POREP_WRAPPER_MINIMUM_CHALLENGES, LAYERS);
@@ -80,14 +82,14 @@ pub fn setup_params(sector_bytes: PaddedBytesAmount, partitions: usize) -> stack
     );
 
     let nodes = sector_bytes / 32;
-    stacked::SetupParams {
+    Ok(stacked::SetupParams {
         nodes,
         degree: BASE_DEGREE,
         expansion_degree: EXP_DEGREE,
         seed: DRG_SEED,
         config,
         window_size_nodes,
-    }
+    })
 }
 
 fn select_challenges(

--- a/filecoin-proofs/src/types/porep_config.rs
+++ b/filecoin-proofs/src/types/porep_config.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use anyhow::Result;
+
 use paired::bls12_381::Bls12;
 use storage_proofs::circuit::stacked::{StackedCircuit, StackedCompound};
 use storage_proofs::drgraph::DefaultTreeHasher;
@@ -47,29 +49,29 @@ impl From<PoRepConfig> for SectorSize {
 
 impl PoRepConfig {
     /// Returns the cache identifier as used by `storage-proofs::paramater_cache`.
-    pub fn get_cache_identifier(&self) -> String {
+    pub fn get_cache_identifier(&self) -> Result<String> {
         let params =
-            crate::parameters::public_params(self.sector_size.into(), self.partitions.into());
+            crate::parameters::public_params(self.sector_size.into(), self.partitions.into())?;
 
-        <StackedCompound as CacheableParameters<
+        Ok(<StackedCompound as CacheableParameters<
             Bls12,
             StackedCircuit<_, DefaultTreeHasher, DefaultPieceHasher>,
             _,
-        >>::cache_identifier(&params)
+        >>::cache_identifier(&params))
     }
 
-    pub fn get_cache_metadata_path(&self) -> PathBuf {
-        let id = self.get_cache_identifier();
-        parameter_cache::parameter_cache_metadata_path(&id)
+    pub fn get_cache_metadata_path(&self) -> Result<PathBuf> {
+        let id = self.get_cache_identifier()?;
+        Ok(parameter_cache::parameter_cache_metadata_path(&id))
     }
 
-    pub fn get_cache_verifying_key_path(&self) -> PathBuf {
-        let id = self.get_cache_identifier();
-        parameter_cache::parameter_cache_verifying_key_path(&id)
+    pub fn get_cache_verifying_key_path(&self) -> Result<PathBuf> {
+        let id = self.get_cache_identifier()?;
+        Ok(parameter_cache::parameter_cache_verifying_key_path(&id))
     }
 
-    pub fn get_cache_params_path(&self) -> PathBuf {
-        let id = self.get_cache_identifier();
-        parameter_cache::parameter_cache_params_path(&id)
+    pub fn get_cache_params_path(&self) -> Result<PathBuf> {
+        let id = self.get_cache_identifier()?;
+        Ok(parameter_cache::parameter_cache_params_path(&id))
     }
 }

--- a/filecoin-proofs/src/types/post_config.rs
+++ b/filecoin-proofs/src/types/post_config.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 
+use anyhow::Result;
+
 use paired::bls12_381::Bls12;
 use storage_proofs::circuit::election_post::{ElectionPoStCircuit, ElectionPoStCompound};
 use storage_proofs::drgraph::DefaultTreeHasher;
@@ -30,28 +32,30 @@ impl From<PoStConfig> for UnpaddedBytesAmount {
 
 impl PoStConfig {
     /// Returns the cache identifier as used by `storage-proofs::paramater_cache`.
-    pub fn get_cache_identifier(self) -> String {
-        let params = crate::parameters::post_public_params(self);
+    pub fn get_cache_identifier(self) -> Result<String> {
+        let params = crate::parameters::post_public_params(self)?;
 
-        <ElectionPoStCompound<DefaultTreeHasher> as CacheableParameters<
-            Bls12,
-            ElectionPoStCircuit<_, DefaultTreeHasher>,
-            _,
-        >>::cache_identifier(&params)
+        Ok(
+            <ElectionPoStCompound<DefaultTreeHasher> as CacheableParameters<
+                Bls12,
+                ElectionPoStCircuit<_, DefaultTreeHasher>,
+                _,
+            >>::cache_identifier(&params),
+        )
     }
 
-    pub fn get_cache_metadata_path(self) -> PathBuf {
-        let id = self.get_cache_identifier();
-        parameter_cache::parameter_cache_metadata_path(&id)
+    pub fn get_cache_metadata_path(self) -> Result<PathBuf> {
+        let id = self.get_cache_identifier()?;
+        Ok(parameter_cache::parameter_cache_metadata_path(&id))
     }
 
-    pub fn get_cache_verifying_key_path(self) -> PathBuf {
-        let id = self.get_cache_identifier();
-        parameter_cache::parameter_cache_verifying_key_path(&id)
+    pub fn get_cache_verifying_key_path(self) -> Result<PathBuf> {
+        let id = self.get_cache_identifier()?;
+        Ok(parameter_cache::parameter_cache_verifying_key_path(&id))
     }
 
-    pub fn get_cache_params_path(self) -> PathBuf {
-        let id = self.get_cache_identifier();
-        parameter_cache::parameter_cache_params_path(&id)
+    pub fn get_cache_params_path(self) -> Result<PathBuf> {
+        let id = self.get_cache_identifier()?;
+        Ok(parameter_cache::parameter_cache_params_path(&id))
     }
 }

--- a/storage-proofs/benches/encode.rs
+++ b/storage-proofs/benches/encode.rs
@@ -54,7 +54,7 @@ fn encode_single_node<H: Hasher>(
 
     let node_data = H::Domain::try_from_bytes(&data[start..end]).unwrap();
     let key_data = H::Domain::try_from_bytes(&key).unwrap();
-    let encoded = H::sloth_encode(&key_data, &node_data);
+    let encoded = H::sloth_encode(&key_data, &node_data).unwrap();
     encoded.write_bytes(&mut data[start..end]).unwrap();
 }
 

--- a/storage-proofs/src/circuit/create_label.rs
+++ b/storage-proofs/src/circuit/create_label.rs
@@ -44,8 +44,8 @@ where
     let fr = if alloc_bits[0].get_value().is_some() {
         let be_bits = alloc_bits
             .iter()
-            .map(|v| v.get_value().unwrap())
-            .collect::<Vec<bool>>();
+            .map(|v| v.get_value().ok_or(SynthesisError::AssignmentMissing))
+            .collect::<Result<Vec<bool>, SynthesisError>>()?;
 
         let le_bits = be_bits
             .chunks(8)

--- a/storage-proofs/src/circuit/create_label.rs
+++ b/storage-proofs/src/circuit/create_label.rs
@@ -119,7 +119,7 @@ mod tests {
             acc
         });
 
-        let expected = crypto::create_label::create_label(input_bytes.as_slice(), m);
+        let expected = crypto::create_label::create_label(input_bytes.as_slice(), m).unwrap();
 
         assert_eq!(
             expected,
@@ -178,7 +178,7 @@ mod tests {
             input_bytes.extend_from_slice(parent);
         }
 
-        let expected = crypto::create_label::create_label(input_bytes.as_slice(), m);
+        let expected = crypto::create_label::create_label(input_bytes.as_slice(), m).unwrap();
 
         assert_eq!(
             expected,

--- a/storage-proofs/src/circuit/variables.rs
+++ b/storage-proofs/src/circuit/variables.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use anyhow::Result;
+
 use bellperson::gadgets::num::AllocatedNum;
 use bellperson::{ConstraintSystem, SynthesisError};
 use paired::Engine;
@@ -39,8 +41,8 @@ impl<E: Engine> Root<E> {
         }
     }
 
-    pub fn var<CS: ConstraintSystem<E>>(cs: CS, fr: E::Fr) -> Self {
-        Root::Var(AllocatedNum::alloc(cs, || Ok(fr)).unwrap())
+    pub fn var<CS: ConstraintSystem<E>>(cs: CS, fr: E::Fr) -> Result<Self> {
+        Ok(Root::Var(AllocatedNum::alloc(cs, || Ok(fr))?))
     }
 
     pub fn is_some(&self) -> bool {

--- a/storage-proofs/src/crypto/create_label.rs
+++ b/storage-proofs/src/crypto/create_label.rs
@@ -1,3 +1,4 @@
+use anyhow::Result;
 use ff::PrimeField;
 use paired::bls12_381::Fr;
 use sha2::{Digest, Sha256};
@@ -5,9 +6,9 @@ use sha2::{Digest, Sha256};
 use crate::fr32::bytes_into_fr_repr_safe;
 
 /// Key derivation function, based on pedersen hashing.
-pub fn create_label(data: &[u8], _m: usize) -> Fr {
+pub fn create_label(data: &[u8], _m: usize) -> Result<Fr> {
     let hash = Sha256::digest(data);
-    Fr::from_repr(bytes_into_fr_repr_safe(hash.as_ref())).unwrap()
+    Ok(Fr::from_repr(bytes_into_fr_repr_safe(hash.as_ref()))?)
 }
 
 #[cfg(test)]
@@ -30,7 +31,7 @@ mod tests {
         ];
         let expected = Fr::from_repr(FrRepr(repr)).unwrap();
 
-        let res = create_label(&data, m);
+        let res = create_label(&data, m).unwrap();
         assert_eq!(res, expected);
     }
 }

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -459,7 +459,7 @@ where
             let end = start + NODE_SIZE;
 
             let node_data = H::Domain::try_from_bytes(&data[start..end])?;
-            let encoded = H::sloth_encode(key.as_ref(), &node_data);
+            let encoded = H::sloth_encode(key.as_ref(), &node_data)?;
 
             encoded.write_bytes(&mut data[start..end])?;
         }

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -38,17 +38,17 @@ impl Hasher for Blake2sHasher {
         Ok(<Self::Function as HashFunction<Self::Domain>>::hash(data))
     }
 
-    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain {
+    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain> {
         // TODO: validate this is how sloth should work in this case
         let k = (*key).into();
         let c = (*ciphertext).into();
 
-        sloth::encode::<Bls12>(&k, &c).into()
+        Ok(sloth::encode::<Bls12>(&k, &c).into())
     }
 
-    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain {
+    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain> {
         // TODO: validate this is how sloth should work in this case
-        sloth::decode::<Bls12>(&(*key).into(), &(*ciphertext).into()).into()
+        Ok(sloth::decode::<Bls12>(&(*key).into(), &(*ciphertext).into()).into())
     }
 }
 
@@ -247,8 +247,8 @@ impl HashFunction<Blake2sDomain> for Blake2sFunction {
             Some(_) => {
                 let bits = alloc_bits
                     .iter()
-                    .map(|v| v.get_value().unwrap())
-                    .collect::<Vec<bool>>();
+                    .map(|v| v.get_value().ok_or(SynthesisError::AssignmentMissing))
+                    .collect::<std::result::Result<Vec<bool>, SynthesisError>>()?;
                 // TODO: figure out if we can avoid this
                 let frs = multipack::compute_multipacking::<E>(&bits);
                 Ok(frs[0])

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -26,7 +26,7 @@ impl Hasher for Blake2sHasher {
         "Blake2sHasher".into()
     }
 
-    fn create_label(data: &[u8], m: usize) -> Self::Domain {
+    fn create_label(data: &[u8], m: usize) -> Result<Self::Domain> {
         assert_eq!(
             data.len(),
             32 * (1 + m),
@@ -35,7 +35,7 @@ impl Hasher for Blake2sHasher {
             m
         );
 
-        <Self::Function as HashFunction<Self::Domain>>::hash(data)
+        Ok(<Self::Function as HashFunction<Self::Domain>>::hash(data))
     }
 
     fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain {

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -27,8 +27,8 @@ impl Hasher for PedersenHasher {
         "PedersenHasher".into()
     }
 
-    fn create_label(data: &[u8], m: usize) -> Self::Domain {
-        create_label::create_label(data, m).into()
+    fn create_label(data: &[u8], m: usize) -> Result<Self::Domain> {
+        Ok(create_label::create_label(data, m)?.into())
     }
 
     #[inline]

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -32,20 +32,20 @@ impl Hasher for PedersenHasher {
     }
 
     #[inline]
-    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain {
+    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain> {
         // Unrapping here is safe; `Fr` elements and hash domain elements are the same byte length.
-        let key = Fr::from_repr(key.0).unwrap();
-        let ciphertext = Fr::from_repr(ciphertext.0).unwrap();
-        sloth::encode::<Bls12>(&key, &ciphertext).into()
+        let key = Fr::from_repr(key.0)?;
+        let ciphertext = Fr::from_repr(ciphertext.0)?;
+        Ok(sloth::encode::<Bls12>(&key, &ciphertext).into())
     }
 
     #[inline]
-    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain {
+    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain> {
         // Unrapping here is safe; `Fr` elements and hash domain elements are the same byte length.
-        let key = Fr::from_repr(key.0).unwrap();
-        let ciphertext = Fr::from_repr(ciphertext.0).unwrap();
+        let key = Fr::from_repr(key.0)?;
+        let ciphertext = Fr::from_repr(ciphertext.0)?;
 
-        sloth::decode::<Bls12>(&key, &ciphertext).into()
+        Ok(sloth::decode::<Bls12>(&key, &ciphertext).into())
     }
 }
 

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -30,17 +30,17 @@ impl Hasher for Sha256Hasher {
         Ok(<Self::Function as HashFunction<Self::Domain>>::hash(data))
     }
 
-    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain {
+    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain> {
         // TODO: validate this is how sloth should work in this case
         let k = (*key).into();
         let c = (*ciphertext).into();
 
-        sloth::encode::<Bls12>(&k, &c).into()
+        Ok(sloth::encode::<Bls12>(&k, &c).into())
     }
 
-    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain {
+    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain> {
         // TODO: validate this is how sloth should work in this case
-        sloth::decode::<Bls12>(&(*key).into(), &(*ciphertext).into()).into()
+        Ok(sloth::decode::<Bls12>(&(*key).into(), &(*ciphertext).into()).into())
     }
 }
 
@@ -223,8 +223,8 @@ impl HashFunction<Sha256Domain> for Sha256Function {
         let fr = if alloc_bits[0].get_value().is_some() {
             let be_bits = alloc_bits
                 .iter()
-                .map(|v| v.get_value().unwrap())
-                .collect::<Vec<bool>>();
+                .map(|v| v.get_value().ok_or(SynthesisError::AssignmentMissing))
+                .collect::<std::result::Result<Vec<bool>, SynthesisError>>()?;
 
             let le_bits = be_bits
                 .chunks(8)

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -26,8 +26,8 @@ impl Hasher for Sha256Hasher {
         "Sha256Hasher".into()
     }
 
-    fn create_label(data: &[u8], _m: usize) -> Self::Domain {
-        <Self::Function as HashFunction<Self::Domain>>::hash(data)
+    fn create_label(data: &[u8], _m: usize) -> Result<Self::Domain> {
+        Ok(<Self::Function as HashFunction<Self::Domain>>::hash(data))
     }
 
     fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain {

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -74,8 +74,8 @@ pub trait Hasher: Clone + ::std::fmt::Debug + Eq + Default + Send + Sync {
     type Function: HashFunction<Self::Domain>;
 
     fn create_label(data: &[u8], m: usize) -> Result<Self::Domain>;
-    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain;
-    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain;
+    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain>;
+    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain>;
 
     fn name() -> String;
 }

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -73,7 +73,7 @@ pub trait Hasher: Clone + ::std::fmt::Debug + Eq + Default + Send + Sync {
     type Domain: Domain + LightHashable<Self::Function> + AsRef<Self::Domain>;
     type Function: HashFunction<Self::Domain>;
 
-    fn create_label(data: &[u8], m: usize) -> Self::Domain;
+    fn create_label(data: &[u8], m: usize) -> Result<Self::Domain>;
     fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain;
     fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Self::Domain;
 

--- a/storage-proofs/src/test_helper.rs
+++ b/storage-proofs/src/test_helper.rs
@@ -68,7 +68,7 @@ pub fn fake_drgpoprep_proof<R: Rng>(
         )
         .unwrap();
 
-    let key = crypto::create_label::create_label(ciphertexts.as_slice(), m);
+    let key = crypto::create_label::create_label(ciphertexts.as_slice(), m).unwrap();
     // run sloth(key, node)
 
     let replica_node: Fr = crypto::sloth::encode::<Bls12>(&key, &data_node);


### PR DESCRIPTION
This is the first step to having less panics. I went through all the `unwrap()`s in the code and removed most of then (except the ones in tests and binaries). There is still a few unwraps left. Some are safe (when there are prior assertions about them) or where it is logically safe (like allocating a 32 byte array and writing 32 bytes into it.

There are still a few `unwrap()`s left with a todo. Those are the ones within a parallel iterator that is using `flat_map()`. Handling errors there is not that simple and needs more thought.

Please also note that this PR is only about `unwrap()`s. There is still other cases where panics could be triggered (e.g. by `assert!()`s) Those other cases will be fixed by subsequent PRs.

Please do a thorough review, some changes are non-trivial and perhaps sometimes other/better error messages might make sense.