### PR TITLE
rework CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,17 @@
 version: 2.1
 
 jobs:
+  ensure_groth_parameters_and_keys_linux:
+    docker:
+      - image: filecoin/rust:latest
+    working_directory: /mnt/crate
+    resource_class: 2xlarge
+    steps:
+      - configure_environment_variables
+      - checkout
+      - restore_parameter_cache
+      - ensure_filecoin_parameters
+      - save_parameter_cache
   cargo_fetch:
     docker:
       - image: filecoin/rust:latest
@@ -9,7 +20,6 @@ jobs:
     steps:
       - configure_environment_variables
       - checkout
-      - obtain_filecoin_parameters
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
@@ -46,9 +56,7 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v13-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-      - restore_cache:
-          keys:
-            - parameter-cache-{{ .Revision }}
+      - restore_parameter_cache
       - run:
           name: Test (stable)
           command: cargo +stable test --verbose --all
@@ -77,7 +85,7 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v13-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-            - parameter-cache-{{ .Revision }}
+      - restore_parameter_cache
       - run:
           name: Test (stable) in release profile
           command: |
@@ -103,7 +111,7 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v13-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-            - parameter-cache-{{ .Revision }}
+      - restore_parameter_cache
       - run:
           name: Test ignored in release profile
           command: |
@@ -112,10 +120,6 @@ jobs:
           environment:
             RUST_TEST_THREADS: 1
           no_output_timeout: 30m
-      - save_cache:
-          key: parameter-cache-{{ .Revision }}
-          paths:
-            - /root/.filecoin-parameter-cache
 
   test_nightly:
     docker:
@@ -130,9 +134,7 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v13-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-      - restore_cache:
-          keys:
-            - parameter-cache-{{ .Revision }}
+      - restore_parameter_cache
       - run:
           name: Test (nightly)
           command: cargo +$(cat rust-toolchain) test --verbose --all
@@ -151,9 +153,7 @@ jobs:
       - restore_cache:
           keys:
             - cargo-v13-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-      - restore_cache:
-          keys:
-            - parameter-cache-{{ .Revision }}
+      - restore_parameter_cache
       - run:
           name: Benchmarks (nightly)
           command: cargo +$(cat rust-toolchain) build --benches --verbose --all
@@ -273,13 +273,13 @@ jobs:
           name: Install Rust
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
-      - run:
-          name: Install pkg-config and md5sum
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install md5sha1sum
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update
       - run: cargo fetch
+      - restore_parameter_cache
+      - ensure_filecoin_parameters
+      - save_parameter_cache
       - run:
           name: Test (nightly, Darwin)
           command: cargo +$(cat rust-toolchain) test --release --verbose --all
@@ -302,15 +302,9 @@ jobs:
           command: |
               npx commitlint --extends @commitlint/config-angular --from origin/master --to $CIRCLE_SHA1
 commands:
-  obtain_filecoin_parameters:
+  ensure_filecoin_parameters:
     steps:
       - configure_environment_variables
-      - run:
-          name: Compute parameters.json checksum
-          command: md5sum filecoin-proofs/parameters.json | cut -c1-8 > checksum.txt
-      - restore_cache:
-          keys:
-            - proof-params-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
       - run:
           name: Build paramcache if it doesn't already exist
           command: |
@@ -320,11 +314,19 @@ commands:
           name: Obtain filecoin groth parameters
           command: ~/paramcache.awesome --params-for-sector-sizes='1024'
           no_output_timeout: 60m
+  save_parameter_cache:
+    steps:
       - save_cache:
           key: proof-params-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
           paths:
             - "~/paramcache.awesome"
             - "~/filecoin-proof-parameters/"
+  restore_parameter_cache:
+    steps:
+      - configure_environment_variables
+      - restore_cache:
+          keys:
+            - proof-params-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
   configure_environment_variables:
     steps:
       - run:
@@ -338,6 +340,7 @@ workflows:
   version: 2.1
   test_all:
     jobs:
+      - ensure_groth_parameters_and_keys_linux
       - cargo_fetch
       - rustfmt:
           requires:
@@ -348,26 +351,32 @@ workflows:
       - test_release:
           requires:
             - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
       - test_ignored_release:
           name: test_ignored_release_storage_proofs
           crate: "storage-proofs"
           features: "--features unchecked-degrees"
           requires:
             - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
       - test_ignored_release:
           name: test_ignored_release_filecoin_proofs
           crate: "filecoin-proofs"
           requires:
             - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
       - test:
           requires:
             - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
       - test_nightly:
           requires:
             - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
       - bench_nightly:
           requires:
             - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
       - validate_commit_msg
       - test_nightly_darwin
       - metrics_capture:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,29 +253,7 @@ jobs:
           name: Run cargo clippy
           command: cargo clippy --all
 
-  build_linux_release:
-    docker:
-      - image: filecoin/rust:latest
-    working_directory: /mnt/crate
-    resource_class: 2xlarge
-    steps:
-      - checkout
-      - attach_workspace:
-          at: "."
-      - restore_cache:
-          keys:
-            - cargo-v13-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
-      - run:
-          name: Build (release)
-          command: cargo +$(cat rust-toolchain) build --release --verbose --all
-      - run:
-          name: Install jq
-          command: apt-get install jq -yqq
-      - run:
-          name: Run publish-release.sh
-          command: bash ./scripts/publish-release.sh
-
-  build_darwin_release:
+  test_nightly_darwin:
     macos:
       xcode: "10.0.0"
     working_directory: ~/crate
@@ -285,7 +263,6 @@ jobs:
           name: Configure environment variables
           command: |
             echo 'export PATH="${HOME}/.cargo/bin:${HOME}/.bin:${PATH}"' >> $BASH_ENV
-            echo 'export CIRCLE_ARTIFACTS="/tmp"' >> $BASH_ENV
       - checkout
       - run:
           name: Install Rust
@@ -296,18 +273,9 @@ jobs:
       - run: cargo update
       - run: cargo fetch
       - run:
-          name: Build (release)
-          command: cargo +$(cat rust-toolchain) build --release --verbose --all
-      - run:
-          name: Install jq
-          command: |
-            mkdir $HOME/.bin
-            curl --location https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64 --output $HOME/.bin/jq
-            chmod +x $HOME/.bin/jq
-      - run:
-          name: Run publish-release.sh
-          command: bash ./scripts/publish-release.sh
-
+          name: Test (nightly, Darwin)
+          command: cargo +$(cat rust-toolchain) test --verbose --all
+          no_output_timeout: 15m
 
   validate_commit_msg:
     docker:
@@ -360,6 +328,7 @@ workflows:
           requires:
             - cargo_fetch
       - validate_commit_msg
+      - test_nightly_darwin
       - metrics_capture:
           requires:
             - cargo_fetch
@@ -367,19 +336,3 @@ workflows:
             branches:
               only:
                 - master
-      - build_linux_release:
-          requires:
-            - cargo_fetch
-          filters:
-            branches:
-              only:
-                - master
-                - /hotfix.*/
-      - build_darwin_release:
-          requires:
-            - cargo_fetch
-          filters:
-            branches:
-              only:
-                - master
-                - /hotfix.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,9 @@ jobs:
     working_directory: /mnt/crate
     resource_class: 2xlarge
     steps:
+      - configure_environment_variables
       - checkout
+      - obtain_filecoin_parameters
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
@@ -37,6 +39,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: 2xlarge
     steps:
+      - configure_environment_variables
       - checkout
       - attach_workspace:
           at: "."
@@ -67,6 +70,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: 2xlarge
     steps:
+      - configure_environment_variables
       - checkout
       - attach_workspace:
           at: "."
@@ -92,6 +96,7 @@ jobs:
         type: string
         default: ""
     steps:
+      - configure_environment_variables
       - checkout
       - attach_workspace:
           at: "."
@@ -118,6 +123,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: 2xlarge
     steps:
+      - configure_environment_variables
       - checkout
       - attach_workspace:
           at: "."
@@ -138,6 +144,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: 2xlarge
     steps:
+      - configure_environment_variables
       - checkout
       - attach_workspace:
           at: "."
@@ -227,6 +234,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: 2xlarge
     steps:
+      - configure_environment_variables
       - checkout
       - attach_workspace:
           at: "."
@@ -243,6 +251,7 @@ jobs:
     working_directory: /mnt/crate
     resource_class: 2xlarge
     steps:
+      - configure_environment_variables
       - checkout
       - attach_workspace:
           at: "."
@@ -252,22 +261,21 @@ jobs:
       - run:
           name: Run cargo clippy
           command: cargo clippy --all
-
   test_nightly_darwin:
     macos:
       xcode: "10.0.0"
     working_directory: ~/crate
     resource_class: large
     steps:
-      - run:
-          name: Configure environment variables
-          command: |
-            echo 'export PATH="${HOME}/.cargo/bin:${HOME}/.bin:${PATH}"' >> $BASH_ENV
+      - configure_environment_variables
       - checkout
       - run:
           name: Install Rust
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - run:
+          name: Install pkg-config and md5sum
+          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install md5sha1sum
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update
@@ -282,6 +290,7 @@ jobs:
       - image: circleci/node:latest
     resource_class: xlarge
     steps:
+      - configure_environment_variables
       - checkout
       - attach_workspace:
           at: "."
@@ -292,6 +301,38 @@ jobs:
           name: Validate Commit Messages
           command: |
               npx commitlint --extends @commitlint/config-angular --from origin/master --to $CIRCLE_SHA1
+commands:
+  obtain_filecoin_parameters:
+    steps:
+      - configure_environment_variables
+      - run:
+          name: Compute parameters.json checksum
+          command: md5sum filecoin-proofs/parameters.json | cut -c1-8 > checksum.txt
+      - restore_cache:
+          keys:
+            - proof-params-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+      - run:
+          name: Build paramcache if it doesn't already exist
+          command: |
+            set -x; test -f ~/paramcache.awesome \
+            || (cargo build --release --all && find . -type f -name paramcache | xargs -I {} mv {} ~/paramcache.awesome)
+      - run:
+          name: Obtain filecoin groth parameters
+          command: ~/paramcache.awesome --params-for-sector-sizes='1024'
+          no_output_timeout: 60m
+      - save_cache:
+          key: proof-params-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+          paths:
+            - "~/paramcache.awesome"
+            - "~/filecoin-proof-parameters/"
+  configure_environment_variables:
+    steps:
+      - run:
+          name: Configure environment variables
+          command: |
+            echo 'export FIL_PROOFS_PARAMETER_CACHE="${HOME}/filecoin-proof-parameters/"' >> $BASH_ENV
+            echo 'export PATH="${HOME}/.cargo/bin:${PATH}"' >> $BASH_ENV
+            echo 'export RUST_LOG=info' >> $BASH_ENV
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -274,7 +274,7 @@ jobs:
       - run: cargo fetch
       - run:
           name: Test (nightly, Darwin)
-          command: cargo +$(cat rust-toolchain) test --verbose --all
+          command: cargo +$(cat rust-toolchain) test --release --verbose --all
           no_output_timeout: 15m
 
   validate_commit_msg:


### PR DESCRIPTION
## What's in this PR?

- jobs which run tests now need to populate their Groth parameter cache
- stop publishing build artifacts (paramcache and paramfetch and parameters.json)
- make sure we run the test suite with Darwin and not just Linux
- general refactor of CircleCI config