### PR TITLE
fix: add more sanity checks for commitments

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/election_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/election_post.rs
@@ -133,7 +133,7 @@ pub fn run(sector_size: usize) -> anyhow::Result<()> {
     let mut pub_replica_info: BTreeMap<SectorId, PublicReplicaInfo> = BTreeMap::new();
     let mut priv_replica_info: BTreeMap<SectorId, PrivateReplicaInfo> = BTreeMap::new();
 
-    pub_replica_info.insert(sector_id, PublicReplicaInfo::new(comm_r));
+    pub_replica_info.insert(sector_id, PublicReplicaInfo::new(comm_r)?);
 
     priv_replica_info.insert(
         sector_id,

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -132,10 +132,7 @@ pub fn generate_piece_commitment<T: std::io::Read>(
     let commitment =
         generate_piece_commitment_bytes_from_source::<DefaultPieceHasher>(&mut temp_piece_file)?;
 
-    Ok(PieceInfo {
-        commitment,
-        size: piece_size,
-    })
+    PieceInfo::new(commitment, piece_size)
 }
 
 /// Computes a NUL-byte prefix and/or suffix for `source` using the provided

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -49,6 +49,8 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>>(
     offset: UnpaddedByteIndex,
     num_bytes: UnpaddedBytesAmount,
 ) -> Result<UnpaddedBytesAmount> {
+    ensure!(comm_d != [0; 32], "Invalid all zero commitment (comm_d)");
+
     let comm_d =
         as_safe_commitment::<<DefaultPieceHasher as Hasher>::Domain, _>(&comm_d, "comm_d")?;
 
@@ -329,7 +331,7 @@ mod tests {
             );
 
             if let Err(err) = result {
-                let needle = "Invalid commitment (comm_r)";
+                let needle = "Invalid all zero commitment";
                 let haystack = format!("{}", err);
 
                 assert!(
@@ -357,7 +359,7 @@ mod tests {
             );
 
             if let Err(err) = result {
-                let needle = "Invalid commitment (comm_d)";
+                let needle = "Invalid all zero commitment";
                 let haystack = format!("{}", err);
 
                 assert!(
@@ -381,7 +383,7 @@ mod tests {
         let mut replicas = BTreeMap::new();
         replicas.insert(
             1.into(),
-            PublicReplicaInfo::new(not_convertible_to_fr_bytes),
+            PublicReplicaInfo::new(not_convertible_to_fr_bytes).unwrap(),
         );
         let winner = Candidate {
             sector_id: 1.into(),

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -57,6 +57,8 @@ impl std::cmp::PartialOrd for PrivateReplicaInfo {
 
 impl PrivateReplicaInfo {
     pub fn new(access: String, comm_r: Commitment, cache_dir: PathBuf) -> Result<Self> {
+        ensure!(comm_r != [0; 32], "Invalid all zero commitment (comm_r)");
+
         let aux = {
             let mut aux_bytes = vec![];
             let mut f_aux = File::open(cache_dir.join(CacheKey::PAux.to_string()))?;
@@ -134,8 +136,9 @@ impl std::cmp::PartialOrd for PublicReplicaInfo {
 }
 
 impl PublicReplicaInfo {
-    pub fn new(comm_r: Commitment) -> Self {
-        PublicReplicaInfo { comm_r }
+    pub fn new(comm_r: Commitment) -> Result<Self> {
+        ensure!(comm_r != [0; 32], "Invalid all zero commitment (comm_r)");
+        Ok(PublicReplicaInfo { comm_r })
     }
 
     pub fn safe_comm_r(&self) -> Result<<DefaultTreeHasher as Hasher>::Domain> {

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -157,6 +157,8 @@ pub fn seal_commit<T: AsRef<Path>>(
 
     let SealPreCommitOutput { comm_d, comm_r } = pre_commit;
 
+    ensure!(comm_d != [0; 32], "Invalid all zero commitment (comm_d)");
+    ensure!(comm_r != [0; 32], "Invalid all zero commitment (comm_r)");
     ensure!(
         verify_pieces(&comm_d, piece_infos, porep_config.into())?,
         "pieces and comm_d do not match"
@@ -276,6 +278,9 @@ pub fn verify_seal(
     seed: Ticket,
     proof_vec: &[u8],
 ) -> Result<bool> {
+    ensure!(comm_d_in != [0; 32], "Invalid all zero commitment (comm_d)");
+    ensure!(comm_r_in != [0; 32], "Invalid all zero commitment (comm_r)");
+
     let sector_bytes = PaddedBytesAmount::from(porep_config);
     let comm_r = as_safe_commitment(&comm_r_in, "comm_r")?;
     let comm_d = as_safe_commitment(&comm_d_in, "comm_d")?;

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -382,15 +382,14 @@ mod tests {
         let mut g = [0u8; 32];
         let h = piece_hash(&e, &f);
         g.copy_from_slice(h.as_ref());
+        let a = PieceInfo::new(a, UnpaddedBytesAmount(127)).unwrap();
+        let b = PieceInfo::new(b, UnpaddedBytesAmount(127)).unwrap();
+        let c = PieceInfo::new(c, UnpaddedBytesAmount(127)).unwrap();
+        let d = PieceInfo::new(d, UnpaddedBytesAmount(127)).unwrap();
 
-        let a = PieceInfo::new(a, UnpaddedBytesAmount(127));
-        let b = PieceInfo::new(b, UnpaddedBytesAmount(127));
-        let c = PieceInfo::new(c, UnpaddedBytesAmount(127));
-        let d = PieceInfo::new(d, UnpaddedBytesAmount(127));
-
-        let e = PieceInfo::new(e, UnpaddedBytesAmount(254));
-        let f = PieceInfo::new(f, UnpaddedBytesAmount(254));
-        let g = PieceInfo::new(g, UnpaddedBytesAmount(508));
+        let e = PieceInfo::new(e, UnpaddedBytesAmount(254)).unwrap();
+        let f = PieceInfo::new(f, UnpaddedBytesAmount(254)).unwrap();
+        let g = PieceInfo::new(g, UnpaddedBytesAmount(508)).unwrap();
 
         let sector_size = SectorSize(4 * 128);
         let comm_d = g.commitment;

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -163,7 +163,7 @@ fn zero_padding(size: UnpaddedBytesAmount) -> Result<PieceInfo> {
         "Hashed size must equal padded size"
     );
 
-    Ok(PieceInfo { size, commitment })
+    PieceInfo::new(commitment, size)
 }
 
 /// Join two equally sized `PieceInfo`s together, by hashing them and adding their sizes.
@@ -447,50 +447,26 @@ mod tests {
         let pad = zero_padding(UnpaddedBytesAmount(127)).unwrap();
 
         let pieces = vec![
-            PieceInfo {
-                commitment: [1u8; 32],
-                size: UnpaddedBytesAmount(1 * 127),
-            },
-            PieceInfo {
-                commitment: [2u8; 32],
-                size: UnpaddedBytesAmount(4 * 127),
-            },
-            PieceInfo {
-                commitment: [3u8; 32],
-                size: UnpaddedBytesAmount(2 * 127),
-            },
-            PieceInfo {
-                commitment: [4u8; 32],
-                size: UnpaddedBytesAmount(8 * 127),
-            },
+            PieceInfo::new([1u8; 32], UnpaddedBytesAmount(1 * 127)).unwrap(),
+            PieceInfo::new([2u8; 32], UnpaddedBytesAmount(4 * 127)).unwrap(),
+            PieceInfo::new([3u8; 32], UnpaddedBytesAmount(2 * 127)).unwrap(),
+            PieceInfo::new([4u8; 32], UnpaddedBytesAmount(8 * 127)).unwrap(),
         ];
 
         let padded_pieces = vec![
-            PieceInfo {
-                commitment: [1u8; 32],
-                size: UnpaddedBytesAmount(1 * 127),
-            },
+            PieceInfo::new([1u8; 32], UnpaddedBytesAmount(1 * 127)).unwrap(),
             pad.clone(),
             pad.clone(),
             pad.clone(),
-            PieceInfo {
-                commitment: [2u8; 32],
-                size: UnpaddedBytesAmount(4 * 127),
-            },
-            PieceInfo {
-                commitment: [3u8; 32],
-                size: UnpaddedBytesAmount(2 * 127),
-            },
+            PieceInfo::new([2u8; 32], UnpaddedBytesAmount(4 * 127)).unwrap(),
+            PieceInfo::new([3u8; 32], UnpaddedBytesAmount(2 * 127)).unwrap(),
             pad.clone(),
             pad.clone(),
             pad.clone(),
             pad.clone(),
             pad.clone(),
             pad.clone(),
-            PieceInfo {
-                commitment: [4u8; 32],
-                size: UnpaddedBytesAmount(8 * 127),
-            },
+            PieceInfo::new([4u8; 32], UnpaddedBytesAmount(8 * 127)).unwrap(),
             pad.clone(),
             pad.clone(),
             pad.clone(),

--- a/filecoin-proofs/src/types/piece_info.rs
+++ b/filecoin-proofs/src/types/piece_info.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 
+use anyhow::Result;
+
 use crate::types::{Commitment, UnpaddedBytesAmount};
 
 #[derive(Clone, Default, PartialEq, Eq)]
@@ -18,7 +20,8 @@ impl fmt::Debug for PieceInfo {
 }
 
 impl PieceInfo {
-    pub fn new(commitment: Commitment, size: UnpaddedBytesAmount) -> Self {
-        PieceInfo { commitment, size }
+    pub fn new(commitment: Commitment, size: UnpaddedBytesAmount) -> Result<Self> {
+        ensure!(commitment != [0; 32], "Invalid all zero commitment");
+        Ok(PieceInfo { commitment, size })
     }
 }


### PR DESCRIPTION
This is about commitments in `filecoin-proofs`.  `storage-proofs` seem to use another type of commitments.