### PR TITLE
Improve code quality

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/election_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/election_post.rs
@@ -12,6 +12,7 @@ use filecoin_proofs::{
     seal_pre_commit, verify_post, PrivateReplicaInfo, PublicReplicaInfo,
 };
 use log::info;
+use serde::Serialize;
 use storage_proofs::sector::SectorId;
 use tempfile::NamedTempFile;
 

--- a/fil-proofs-tooling/src/bin/benchy/hash_fns.rs
+++ b/fil-proofs-tooling/src/bin/benchy/hash_fns.rs
@@ -3,6 +3,7 @@ use bellperson::ConstraintSystem;
 use fil_proofs_tooling::metadata::Metadata;
 use paired::bls12_381::Bls12;
 use rand::RngCore;
+use serde::Serialize;
 use storage_proofs::circuit::pedersen::{pedersen_compression_num, pedersen_md_no_padding};
 use storage_proofs::circuit::test::TestConstraintSystem;
 use storage_proofs::crypto;

--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate serde;
-
 use clap::{value_t, App, Arg, SubCommand};
 
 mod election_post;

--- a/fil-proofs-tooling/src/bin/benchy/stacked.rs
+++ b/fil-proofs-tooling/src/bin/benchy/stacked.rs
@@ -11,6 +11,7 @@ use memmap::MmapOptions;
 use merkletree::store::{StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};
 use paired::bls12_381::Bls12;
 use rand::Rng;
+use serde::Serialize;
 
 use fil_proofs_tooling::{measure, FuncMeasurement, Metadata};
 use storage_proofs::circuit::bench::BenchCS;

--- a/fil-proofs-tooling/src/bin/micro.rs
+++ b/fil-proofs-tooling/src/bin/micro.rs
@@ -1,15 +1,10 @@
-#[macro_use]
-extern crate commandspec;
-#[macro_use]
-extern crate anyhow;
-#[macro_use]
-extern crate serde;
-
 use std::io::{self, BufRead};
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
+use commandspec::command;
 use fil_proofs_tooling::metadata::Metadata;
 use regex::Regex;
+use serde::Serialize;
 
 #[derive(Debug, Default, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]

--- a/fil-proofs-tooling/src/bin/micro.rs
+++ b/fil-proofs-tooling/src/bin/micro.rs
@@ -7,7 +7,7 @@ extern crate serde;
 
 use std::io::{self, BufRead};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use fil_proofs_tooling::metadata::Metadata;
 use regex::Regex;
 
@@ -277,9 +277,7 @@ fn run_benches(mut args: Vec<String>) -> Result<()> {
 
     let process = cmd.stdout(std::process::Stdio::piped()).spawn()?;
 
-    let stdout = process
-        .stdout
-        .ok_or_else(|| format_err!("Failed to capture stdout"))?;
+    let stdout = process.stdout.context("Failed to capture stdout")?;
 
     let reader = std::io::BufReader::new(stdout);
     let mut stdout = String::new();
@@ -296,7 +294,7 @@ fn run_benches(mut args: Vec<String>) -> Result<()> {
 
     let wrapped = Metadata::wrap(parsed_results)?;
 
-    serde_json::to_writer(io::stdout(), &wrapped).expect("cannot write report-JSON to stdout");
+    serde_json::to_writer(io::stdout(), &wrapped).context("cannot write report-JSON to stdout")?;
 
     Ok(())
 }

--- a/filecoin-proofs/benches/preprocessing.rs
+++ b/filecoin-proofs/benches/preprocessing.rs
@@ -1,11 +1,8 @@
-#[macro_use]
-extern crate criterion;
-
 use std::fs::File;
 use std::io::{Read, Seek, SeekFrom};
 use std::time::Duration;
 
-use criterion::{Criterion, ParameterizedBenchmark, Throughput};
+use criterion::{criterion_group, criterion_main, Criterion, ParameterizedBenchmark, Throughput};
 use filecoin_proofs::fr32::{write_padded, write_unpadded};
 use rand::{thread_rng, Rng};
 

--- a/filecoin-proofs/examples/stacked.rs
+++ b/filecoin-proofs/examples/stacked.rs
@@ -1,17 +1,12 @@
-#[macro_use]
-extern crate clap;
-#[cfg(any(feature = "cpu-profile", feature = "heap-profile"))]
-extern crate gperftools;
-#[macro_use]
-extern crate log;
-
 use chrono::Utc;
+use clap::value_t;
 use clap::{App, Arg};
 use ff::Field;
 #[cfg(feature = "heap-profile")]
 use gperftools::heap_profiler::HEAP_PROFILER;
 #[cfg(feature = "cpu-profile")]
 use gperftools::profiler::PROFILER;
+use log::{info, warn};
 use memmap::MmapMut;
 use memmap::MmapOptions;
 use merkletree::store::{StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use merkletree::store::{StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};
 use storage_proofs::drgraph::DefaultTreeHasher;
 use storage_proofs::hasher::Hasher;

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use bincode::deserialize;
 use merkletree::merkle::{get_merkle_tree_leafs, MerkleTree};
 use merkletree::store::{DiskStore, Store, StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};
@@ -179,7 +179,7 @@ pub fn generate_candidates(
             if let Some(replica) = replicas.get(c) {
                 Ok((c, replica))
             } else {
-                Err(format_err!(
+                Err(anyhow!(
                     "Invalid challenge generated: {}, only {} sectors are being proven",
                     c,
                     sector_count
@@ -228,8 +228,8 @@ pub type SnarkProof = Vec<u8>;
 
 /// Generates a ticket from a partial_ticket.
 pub fn finalize_ticket(partial_ticket: &[u8; 32]) -> Result<[u8; 32]> {
-    let partial_ticket = bytes_into_fr::<Bls12>(partial_ticket)
-        .map_err(|err| format_err!("Invalid partial_ticket: {:?}", err))?;
+    let partial_ticket =
+        bytes_into_fr::<Bls12>(partial_ticket).context("Invalid partial_ticket")?;
     Ok(election_post::finalize_ticket(&partial_ticket))
 }
 
@@ -263,15 +263,9 @@ pub fn generate_post(
     let inputs: Vec<_> = winners
         .par_iter()
         .map(|winner| {
-            let replica = match replicas.get(&winner.sector_id) {
-                Some(replica) => replica,
-                None => {
-                    return Err(format_err!(
-                        "Missing replica for sector: {}",
-                        winner.sector_id
-                    ))
-                }
-            };
+            let replica = replicas
+                .get(&winner.sector_id)
+                .with_context(|| format!("Missing replica for sector: {}", winner.sector_id))?;
             let tree = replica.merkle_tree(tree_size, tree_leafs)?;
 
             let comm_r = replica.safe_comm_r()?;
@@ -339,15 +333,9 @@ pub fn verify_post(
 
     let verifying_key = get_post_verifying_key(post_config)?;
     for (proof, winner) in proofs.iter().zip(winners.iter()) {
-        let replica = match replicas.get(&winner.sector_id) {
-            Some(replica) => replica,
-            None => {
-                return Err(format_err!(
-                    "Missing replica for sector: {}",
-                    winner.sector_id
-                ))
-            }
-        };
+        let replica = replicas
+            .get(&winner.sector_id)
+            .with_context(|| format!("Missing replica for sector: {}", winner.sector_id))?;
         let comm_r = replica.safe_comm_r()?;
 
         if !election_post::is_valid_sector_challenge_index(

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -3,8 +3,9 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::PathBuf;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, ensure, Context, Result};
 use bincode::deserialize;
+use log::info;
 use merkletree::merkle::{get_merkle_tree_leafs, MerkleTree};
 use merkletree::store::{DiskStore, Store, StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};
 use paired::bls12_381::Bls12;

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -2,8 +2,9 @@ use std::fs::{self, File, OpenOptions};
 use std::io::prelude::*;
 use std::path::Path;
 
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use bincode::{deserialize, serialize};
+use log::info;
 use memmap::MmapOptions;
 use merkletree::store::{StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};
 use paired::bls12_381::{Bls12, Fr};

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -48,21 +48,11 @@ pub fn seal_pre_commit<R: AsRef<Path>, T: AsRef<Path>, S: AsRef<Path>>(
     info!("seal_pre_commit: start");
     let sector_bytes = usize::from(PaddedBytesAmount::from(porep_config));
 
-    if let Err(err) = std::fs::metadata(&in_path) {
-        return Err(format_err!(
-            "could not read in_path={:?} (err = {:?})",
-            in_path.as_ref(),
-            err
-        ));
-    }
+    std::fs::metadata(&in_path)
+        .with_context(|| format!("could not read in_path={:?})", in_path.as_ref()))?;
 
-    if let Err(ref err) = std::fs::metadata(&out_path) {
-        return Err(format_err!(
-            "could not read out_path={:?} (err = {:?})",
-            in_path.as_ref(),
-            err
-        ));
-    }
+    std::fs::metadata(&out_path)
+        .with_context(|| format!("could not read out_path={:?}", out_path.as_ref()))?;
 
     // Copy unsealed data to output location, where it will be sealed in place.
     fs::copy(&in_path, &out_path)?;

--- a/filecoin-proofs/src/api/util.rs
+++ b/filecoin-proofs/src/api/util.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use paired::bls12_381::Bls12;
 use paired::Engine;
 use storage_proofs::fr32::{bytes_into_fr, fr_into_bytes};
@@ -10,13 +10,9 @@ pub(crate) fn as_safe_commitment<H: Domain, T: AsRef<str>>(
     comm: &Commitment,
     commitment_name: T,
 ) -> Result<H> {
-    bytes_into_fr::<Bls12>(comm).map(Into::into).map_err(|err| {
-        format_err!(
-            "Invalid commitment ({}): {:?}",
-            commitment_name.as_ref(),
-            err
-        )
-    })
+    bytes_into_fr::<Bls12>(comm)
+        .map(Into::into)
+        .with_context(|| format!("Invalid commitment ({})", commitment_name.as_ref(),))
 }
 
 pub(crate) fn commitment_from_fr<E: Engine>(fr: E::Fr) -> Commitment {

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -1,7 +1,5 @@
-#[macro_use]
-extern crate log;
-
 use clap::{values_t, App, Arg};
+use log::info;
 use paired::bls12_381::Bls12;
 use rand::{rngs::OsRng, SeedableRng};
 use rand_xorshift::XorShiftRng;

--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate anyhow;
-
 use std::collections::BTreeMap;
 use std::fs::{read_dir, File};
 use std::io;
@@ -9,7 +6,7 @@ use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
 
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
 use clap::{App, Arg, ArgMatches};
 use itertools::Itertools;
 

--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -9,7 +9,7 @@ use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 use std::process::{exit, Command};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::{App, Arg, ArgMatches};
 use itertools::Itertools;
 
@@ -107,11 +107,11 @@ fn publish(matches: &ArgMatches) -> Result<()> {
 
         for filename in filenames {
             let id = filename_to_parameter_id(&filename)
-                .ok_or_else(|| format_err!("failed to parse id from file name {}", filename))?;
+                .with_context(|| format!("failed to parse id from file name {}", filename))?;
 
             let meta: &CacheEntryMetadata = meta_map
                 .get(&id)
-                .ok_or_else(|| format_err!("no metadata found for parameter id {}", id))?;
+                .with_context(|| format!("no metadata found for parameter id {}", id))?;
 
             println!("publishing: {}", filename);
             print!("publishing to ipfs... ");

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -4,6 +4,8 @@ use std::sync::Mutex;
 
 use anyhow::Result;
 use bellperson::groth16;
+use lazy_static::lazy_static;
+use log::info;
 use paired::bls12_381::Bls12;
 use storage_proofs::circuit::election_post::ElectionPoStCircuit;
 use storage_proofs::circuit::election_post::ElectionPoStCompound;

--- a/filecoin-proofs/src/lib.rs
+++ b/filecoin-proofs/src/lib.rs
@@ -1,14 +1,5 @@
 #![deny(clippy::all, clippy::perf, clippy::correctness)]
 
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate anyhow;
-#[macro_use]
-extern crate log;
-
-extern crate bincode;
-
 mod api;
 mod caches;
 
@@ -24,10 +15,6 @@ pub mod types;
 pub use api::*;
 pub use constants::SINGLE_PARTITION_PROOF_LEN;
 pub use types::*;
-
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
 
 #[cfg(test)]
 pub(crate) const TEST_SEED: [u8; 16] = [

--- a/filecoin-proofs/src/parameters.rs
+++ b/filecoin-proofs/src/parameters.rs
@@ -1,4 +1,4 @@
-use anyhow::{ensure, Result};
+use anyhow::{anyhow, ensure, Result};
 use storage_proofs::drgraph::{DefaultTreeHasher, BASE_DEGREE};
 use storage_proofs::election_post::{self, ElectionPoSt};
 use storage_proofs::proof::ProofScheme;

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -2,7 +2,8 @@ use std::io::Cursor;
 use std::io::Read;
 use std::iter::Iterator;
 
-use anyhow::{Context, Result};
+use anyhow::{ensure, Context, Result};
+use log::info;
 use storage_proofs::hasher::{HashFunction, Hasher};
 use storage_proofs::util::NODE_SIZE;
 

--- a/filecoin-proofs/src/singletons.rs
+++ b/filecoin-proofs/src/singletons.rs
@@ -1,4 +1,5 @@
 use ff::PrimeField;
+use lazy_static::lazy_static;
 use paired::bls12_381::Fr;
 
 use storage_proofs::hasher::pedersen::PedersenDomain;

--- a/filecoin-proofs/src/types/piece_info.rs
+++ b/filecoin-proofs/src/types/piece_info.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use anyhow::Result;
+use anyhow::{ensure, Result};
 
 use crate::types::{Commitment, UnpaddedBytesAmount};
 

--- a/filecoin-proofs/tests/paramfetch/support/session.rs
+++ b/filecoin-proofs/tests/paramfetch/support/session.rs
@@ -1,5 +1,3 @@
-extern crate rexpect;
-
 use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};

--- a/filecoin-proofs/tests/parampublish/prompts_to_publish.rs
+++ b/filecoin-proofs/tests/parampublish/prompts_to_publish.rs
@@ -1,5 +1,3 @@
-extern crate rexpect;
-
 use std::collections::HashSet;
 use std::iter::FromIterator;
 

--- a/filecoin-proofs/tests/parampublish/support/session.rs
+++ b/filecoin-proofs/tests/parampublish/support/session.rs
@@ -1,5 +1,3 @@
-extern crate rexpect;
-
 use std::fs::File;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};

--- a/filecoin-proofs/tests/suite.rs
+++ b/filecoin-proofs/tests/suite.rs
@@ -1,8 +1,3 @@
-extern crate rexpect;
-
-#[macro_use]
-extern crate failure;
-
 mod paramfetch;
 mod parampublish;
 mod support;

--- a/filecoin-proofs/tests/support/mod.rs
+++ b/filecoin-proofs/tests/support/mod.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::{env, thread};
 
+use failure::format_err;
 use filecoin_proofs::param::ParameterData;
 use rexpect::session::PtyBashSession;
 use rexpect::spawn_bash;

--- a/storage-proofs/benches/blake2s.rs
+++ b/storage-proofs/benches/blake2s.rs
@@ -1,10 +1,7 @@
-#[macro_use]
-extern crate criterion;
-
 use bellperson::gadgets::boolean::{self, Boolean};
 use bellperson::groth16::*;
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
-use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::Bls12;
 use rand::{thread_rng, Rng};

--- a/storage-proofs/benches/drgraph.rs
+++ b/storage-proofs/benches/drgraph.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate criterion;
-
-use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use storage_proofs::drgraph::*;
 use storage_proofs::hasher::pedersen::*;
 

--- a/storage-proofs/benches/encode.rs
+++ b/storage-proofs/benches/encode.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate criterion;
-
-use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use ff::Field;
 use paired::bls12_381::{Bls12, Fr};
 use rand::thread_rng;

--- a/storage-proofs/benches/fr.rs
+++ b/storage-proofs/benches/fr.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate criterion;
-
-use criterion::{black_box, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ff::Field;
 use paired::bls12_381::{Bls12, Fr};
 use rand::thread_rng;

--- a/storage-proofs/benches/merkle.rs
+++ b/storage-proofs/benches/merkle.rs
@@ -1,7 +1,4 @@
-#[macro_use]
-extern crate criterion;
-
-use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use rand::{thread_rng, Rng};
 use storage_proofs::drgraph::{new_seed, Graph, BASE_DEGREE};
 use storage_proofs::hasher::blake2s::Blake2sHasher;

--- a/storage-proofs/benches/parents.rs
+++ b/storage-proofs/benches/parents.rs
@@ -1,9 +1,4 @@
-#[macro_use]
-extern crate criterion;
-#[cfg(feature = "cpu-profile")]
-extern crate gperftools;
-
-use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use storage_proofs::drgraph::{Graph, BASE_DEGREE};
 use storage_proofs::hasher::blake2s::Blake2sHasher;
 use storage_proofs::hasher::pedersen::PedersenHasher;

--- a/storage-proofs/benches/pedersen.rs
+++ b/storage-proofs/benches/pedersen.rs
@@ -1,10 +1,7 @@
-#[macro_use]
-extern crate criterion;
-
 use bellperson::gadgets::boolean::{self, Boolean};
 use bellperson::groth16::*;
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
-use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::Bls12;
 use rand::{thread_rng, Rng};

--- a/storage-proofs/benches/sha256.rs
+++ b/storage-proofs/benches/sha256.rs
@@ -1,10 +1,7 @@
-#[macro_use]
-extern crate criterion;
-
 use bellperson::gadgets::boolean::{self, Boolean};
 use bellperson::groth16::*;
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
-use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::Bls12;
 use rand::{thread_rng, Rng};

--- a/storage-proofs/benches/xor.rs
+++ b/storage-proofs/benches/xor.rs
@@ -1,10 +1,7 @@
-#[macro_use]
-extern crate criterion;
-
 use bellperson::gadgets::boolean::{self, Boolean};
 use bellperson::groth16::*;
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
-use criterion::{black_box, Criterion, ParameterizedBenchmark};
+use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::Bls12;
 use rand::{thread_rng, Rng};

--- a/storage-proofs/src/circuit/create_label.rs
+++ b/storage-proofs/src/circuit/create_label.rs
@@ -6,6 +6,7 @@ use bellperson::gadgets::{
 use bellperson::{ConstraintSystem, SynthesisError};
 use ff::PrimeField;
 use fil_sapling_crypto::jubjub::JubjubEngine;
+use log::trace;
 
 use crate::circuit::uint64;
 

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use bellperson::gadgets::boolean::Boolean;
 use bellperson::gadgets::num;
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use anyhow::ensure;
 use bellperson::gadgets::{boolean, multipack, num};
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
 use fil_sapling_crypto::jubjub::JubjubEngine;

--- a/storage-proofs/src/circuit/rational_post.rs
+++ b/storage-proofs/src/circuit/rational_post.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use anyhow::ensure;
 use bellperson::gadgets::num;
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
 use fil_sapling_crypto::jubjub::JubjubEngine;

--- a/storage-proofs/src/compound_proof.rs
+++ b/storage-proofs/src/compound_proof.rs
@@ -1,8 +1,9 @@
 use rayon::prelude::*;
 
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use bellperson::{groth16, Circuit};
 use fil_sapling_crypto::jubjub::JubjubEngine;
+use log::info;
 use rand::{rngs::OsRng, RngCore};
 
 use crate::circuit::multi_proof::MultiProof;

--- a/storage-proofs/src/crypto/pedersen.rs
+++ b/storage-proofs/src/crypto/pedersen.rs
@@ -1,7 +1,8 @@
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use ff::PrimeFieldRepr;
 use fil_sapling_crypto::jubjub::JubjubBls12;
 use fil_sapling_crypto::pedersen_hash::Personalization;
+use lazy_static::lazy_static;
 use paired::bls12_381::{Bls12, Fr, FrRepr};
 
 use crate::error::Result;

--- a/storage-proofs/src/crypto/sloth.rs
+++ b/storage-proofs/src/crypto/sloth.rs
@@ -25,6 +25,7 @@ mod tests {
     use super::*;
     use ff::PrimeField;
     use paired::bls12_381::{Bls12, Fr, FrRepr};
+    use proptest::{prop_compose, proptest, proptest_helper};
 
     // the modulus from `bls12_381::Fr`
     // The definition of MODULUS and comment defining r come from paired/src/bls_12_381/fr.rs.

--- a/storage-proofs/src/crypto/xor.rs
+++ b/storage-proofs/src/crypto/xor.rs
@@ -1,4 +1,5 @@
 use crate::error::Result;
+use anyhow::ensure;
 
 /// Encodes plaintext by elementwise xoring with the passed in key.
 pub fn encode(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -1,11 +1,10 @@
 use std::marker::PhantomData;
 
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use byteorder::{LittleEndian, WriteBytesExt};
 use merkletree::store::StoreConfig;
 use rayon::prelude::*;
-use serde::de::Deserialize;
-use serde::ser::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::drgraph::Graph;

--- a/storage-proofs/src/election_post.rs
+++ b/storage-proofs/src/election_post.rs
@@ -2,12 +2,11 @@ use std::collections::BTreeMap;
 use std::fmt;
 use std::marker::PhantomData;
 
-use anyhow::{ensure, Context};
+use anyhow::{bail, ensure, Context};
 use byteorder::{ByteOrder, LittleEndian};
 use paired::bls12_381::{Bls12, Fr};
 use rayon::prelude::*;
-use serde::de::Deserialize;
-use serde::ser::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::crypto::pedersen::{pedersen_md_no_padding_bits, Bits};

--- a/storage-proofs/src/example_helper.rs
+++ b/storage-proofs/src/example_helper.rs
@@ -5,8 +5,9 @@ use std::time::{Duration, Instant};
 
 use bellperson::groth16::*;
 use bellperson::Circuit;
-use clap::{self, App, Arg, SubCommand};
+use clap::{self, value_t, App, Arg, SubCommand};
 use fil_sapling_crypto::jubjub::{JubjubBls12, JubjubEngine};
+use log::info;
 use paired::bls12_381::Bls12;
 use pbr::ProgressBar;
 use rand::{Rng, SeedableRng};

--- a/storage-proofs/src/fr32.rs
+++ b/storage-proofs/src/fr32.rs
@@ -1,6 +1,6 @@
 use crate::error::*;
 
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 use ff::{PrimeField, PrimeFieldRepr, ScalarEngine};
 use paired::bls12_381::FrRepr;

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -1,6 +1,7 @@
 use std::fmt;
 use std::hash::Hasher as StdHasher;
 
+use anyhow::ensure;
 use bellperson::gadgets::{blake2s as blake2s_circuit, boolean, multipack, num};
 use bellperson::{ConstraintSystem, SynthesisError};
 use blake2s_simd::{Hash as Blake2sHash, Params as Blake2s, State};
@@ -10,6 +11,7 @@ use merkletree::hash::{Algorithm, Hashable};
 use merkletree::merkle::Element;
 use paired::bls12_381::{Bls12, Fr, FrRepr};
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
 
 use super::{Domain, HashFunction, Hasher};
 use crate::crypto::sloth;

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -1,5 +1,6 @@
 use std::hash::Hasher as StdHasher;
 
+use anyhow::ensure;
 use bellperson::gadgets::{boolean, num};
 use bellperson::{ConstraintSystem, SynthesisError};
 use ff::{Field, PrimeField, PrimeFieldRepr};

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -2,6 +2,7 @@ use sha2::{Digest, Sha256};
 
 use std::hash::Hasher as StdHasher;
 
+use anyhow::ensure;
 use bellperson::gadgets::{boolean, multipack, num, sha256::sha256 as sha256_circuit};
 use bellperson::{ConstraintSystem, SynthesisError};
 use ff::{Field, PrimeField, PrimeFieldRepr};
@@ -10,6 +11,7 @@ use merkletree::hash::{Algorithm, Hashable};
 use merkletree::merkle::Element;
 use paired::bls12_381::{Bls12, Fr, FrRepr};
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
 
 use super::{Domain, HashFunction, Hasher};
 use crate::crypto::sloth;

--- a/storage-proofs/src/lib.rs
+++ b/storage-proofs/src/lib.rs
@@ -3,24 +3,6 @@
 #![allow(clippy::type_repetition_in_bounds)]
 
 #[macro_use]
-extern crate anyhow;
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate clap;
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde;
-
-#[cfg(test)]
-#[macro_use]
-extern crate pretty_assertions;
-#[cfg(test)]
-#[macro_use]
-extern crate proptest;
-
-#[macro_use]
 pub mod test_helper;
 
 pub mod example_helper;

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -2,12 +2,14 @@
 
 use std::marker::PhantomData;
 
+use anyhow::ensure;
 use merkletree::hash::Algorithm;
 use merkletree::merkle;
 use merkletree::proof;
 use merkletree::store::StoreConfig;
 use paired::bls12_381::Fr;
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 
 use crate::error::*;
 use crate::hasher::{Domain, Hasher};
@@ -157,11 +159,11 @@ impl<H: Hasher> MerkleProof<H> {
         let mut out = Vec::new();
 
         for (hash, is_right) in &self.path {
-            out.extend(hash.serialize());
+            out.extend(Domain::serialize(hash));
             out.push(*is_right as u8);
         }
-        out.extend(self.leaf().serialize());
-        out.extend(self.root().serialize());
+        out.extend(Domain::serialize(self.leaf()));
+        out.extend(Domain::serialize(self.root()));
 
         out
     }

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use anyhow::ensure;
 use serde::{Deserialize, Serialize};
 
 use crate::drgraph::graph_height;

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -1,10 +1,13 @@
 use crate::error::*;
+use anyhow::bail;
 use bellperson::groth16::Parameters;
 use bellperson::{groth16, Circuit};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use fs2::FileExt;
 use itertools::Itertools;
+use log::info;
 use rand::RngCore;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use std::env;

--- a/storage-proofs/src/pieces.rs
+++ b/storage-proofs/src/pieces.rs
@@ -1,3 +1,4 @@
+use anyhow::ensure;
 use itertools::Itertools;
 use merkletree::merkle::{self, next_pow2};
 use merkletree::store::VecStore;

--- a/storage-proofs/src/porep.rs
+++ b/storage-proofs/src/porep.rs
@@ -4,6 +4,7 @@ use crate::merkle::MerkleTree;
 use crate::proof::ProofScheme;
 
 use merkletree::store::StoreConfig;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub struct PublicParams {

--- a/storage-proofs/src/proof.rs
+++ b/storage-proofs/src/proof.rs
@@ -1,8 +1,10 @@
 use std::time::Instant;
 
-use crate::error::Result;
+use log::info;
 use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
+
+use crate::error::Result;
 
 /// The ProofScheme trait provides the methods that any proof scheme needs to implement.
 pub trait ProofScheme<'a> {

--- a/storage-proofs/src/rational_post.rs
+++ b/storage-proofs/src/rational_post.rs
@@ -1,10 +1,9 @@
 use std::collections::{BTreeMap, HashSet};
 use std::marker::PhantomData;
 
-use anyhow::Context;
+use anyhow::{bail, ensure, Context};
 use byteorder::{ByteOrder, LittleEndian};
-use serde::de::Deserialize;
-use serde::ser::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::drgraph::graph_height;
 use crate::error::{Error, Result};

--- a/storage-proofs/src/sector.rs
+++ b/storage-proofs/src/sector.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeSet;
 use std::fmt;
 
 use byteorder::ByteOrder;
+use serde::{Deserialize, Serialize};
 
 /// An ordered set of `SectorId`s.
 pub type OrderedSectorSet = BTreeSet<SectorId>;

--- a/storage-proofs/src/settings.rs
+++ b/storage-proofs/src/settings.rs
@@ -1,6 +1,8 @@
 use std::sync::Mutex;
 
 use config::{Config, ConfigError, Environment, File};
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
 
 lazy_static! {
     pub static ref SETTINGS: Mutex<Settings> =

--- a/storage-proofs/src/stacked/challenges.rs
+++ b/storage-proofs/src/stacked/challenges.rs
@@ -1,6 +1,7 @@
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use num_bigint::BigUint;
 use num_traits::cast::ToPrimitive;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::error::Result;

--- a/storage-proofs/src/stacked/column.rs
+++ b/storage-proofs/src/stacked/column.rs
@@ -1,5 +1,8 @@
 use std::marker::PhantomData;
 
+use anyhow::ensure;
+use serde::{Deserialize, Serialize};
+
 use crate::error::Result;
 use crate::hasher::pedersen::PedersenDomain;
 use crate::hasher::Hasher;

--- a/storage-proofs/src/stacked/column_proof.rs
+++ b/storage-proofs/src/stacked/column_proof.rs
@@ -1,5 +1,5 @@
-use serde::de::Deserialize;
-use serde::ser::Serialize;
+use log::trace;
+use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 use crate::hasher::pedersen::PedersenDomain;

--- a/storage-proofs/src/stacked/encoding_proof.rs
+++ b/storage-proofs/src/stacked/encoding_proof.rs
@@ -1,6 +1,8 @@
 use std::marker::PhantomData;
 
+use log::trace;
 use paired::bls12_381::Fr;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::encode::encode;

--- a/storage-proofs/src/stacked/graph.rs
+++ b/storage-proofs/src/stacked/graph.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::{Arc, RwLock};
 
-use anyhow::Context;
+use anyhow::{ensure, Context};
+use lazy_static::lazy_static;
+use log::info;
 
 use crate::crypto::feistel::{self, FeistelPrecomputed};
 use crate::drgraph::{BucketGraph, Graph, BASE_DEGREE};

--- a/storage-proofs/src/stacked/labeling_proof.rs
+++ b/storage-proofs/src/stacked/labeling_proof.rs
@@ -1,5 +1,7 @@
 use std::marker::PhantomData;
 
+use log::trace;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::error::Result;

--- a/storage-proofs/src/stacked/params.rs
+++ b/storage-proofs/src/stacked/params.rs
@@ -3,7 +3,8 @@ use std::fmt;
 use std::marker::PhantomData;
 use std::path::Path;
 
-use anyhow::Context;
+use anyhow::{ensure, Context};
+use log::trace;
 use merkletree::merkle::get_merkle_tree_leafs;
 use merkletree::store::{DiskStore, Store, StoreConfig};
 use serde::{Deserialize, Serialize};

--- a/storage-proofs/src/stacked/proof.rs
+++ b/storage-proofs/src/stacked/proof.rs
@@ -2,12 +2,14 @@ use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::sync::Mutex;
 
-use anyhow::Context;
+use anyhow::{ensure, Context};
 use generic_array::GenericArray;
+use log::{info, trace};
 use merkletree::merkle::FromIndexedParallelIterator;
 use merkletree::store::{DiskStore, StoreConfig};
 use paired::bls12_381::Fr;
 use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::drgraph::Graph;

--- a/storage-proofs/src/stacked/proof_scheme.rs
+++ b/storage-proofs/src/stacked/proof_scheme.rs
@@ -1,3 +1,6 @@
+use anyhow::ensure;
+use log::trace;
+
 use crate::error::Result;
 use crate::hasher::Hasher;
 use crate::proof::ProofScheme;

--- a/storage-proofs/src/util.rs
+++ b/storage-proofs/src/util.rs
@@ -1,3 +1,4 @@
+use anyhow::ensure;
 use bellperson::gadgets::boolean::{self, AllocatedBit, Boolean};
 use bellperson::{ConstraintSystem, SynthesisError};
 use paired::Engine;


### PR DESCRIPTION
This is partly better error handling, but mostly a refactoring.

Error handling: It is using `anyhow`'s `.context()` for wrapping error messages instead of transforming them:

Refactoring: I personally find those implicit macro imports confusing, hence I'm for using the Rust 2018 way of importing things.