### PR TITLE
fix(benchmarking): clean temp directory on exit

### DIFF
--- a/fil-proofs-tooling/scripts/benchy-remote.sh
+++ b/fil-proofs-tooling/scripts/benchy-remote.sh
@@ -4,6 +4,7 @@ set -e
 
 CMDS=$(cat <<EOF
 cd \$(mktemp -d)
+to_clean=\$(pwd)
 git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
 git checkout -q $1
@@ -11,6 +12,8 @@ git checkout -q $1
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/with-dots.sh \
     ./fil-proofs-tooling/scripts/benchy.sh ${@:3}
+cd /tmp
+rm -rf \$to_clean
 EOF
 )
 

--- a/fil-proofs-tooling/scripts/micro-remote.sh
+++ b/fil-proofs-tooling/scripts/micro-remote.sh
@@ -4,6 +4,7 @@ set -e
 
 CMDS=$(cat <<EOF
 cd \$(mktemp -d)
+to_clean=\$(pwd)
 git clone https://github.com/filecoin-project/rust-fil-proofs.git
 cd rust-fil-proofs
 git checkout -q $1
@@ -11,6 +12,8 @@ git checkout -q $1
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/benchmark \
     ./fil-proofs-tooling/scripts/with-dots.sh \
     ./fil-proofs-tooling/scripts/micro.sh ${@:3}
+cd /tmp
+rm -rf \$to_clean
 EOF
 )
 


### PR DESCRIPTION
## Why does this PR exist?

The existing remote benchmarking code doesn't clean up the temp directory (in which it builds rust-fil-proofs), causing the host to run out of disk after a few days.

## What's in this PR?

This changeset removes the temporary directory after the benchmark completes.