### PR TITLE
feat: make SealPreCommitOutput clonable

### DIFF
--- a/filecoin-proofs/src/types/mod.rs
+++ b/filecoin-proofs/src/types/mod.rs
@@ -29,7 +29,7 @@ pub type ProverId = [u8; 32];
 pub type Ticket = [u8; 32];
 pub type Tree = MerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function>;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SealPreCommitOutput {
     pub comm_r: Commitment,
     pub comm_d: Commitment,


### PR DESCRIPTION
This is usefult for benchmarking if you want to seal several times with
the same input.

I don't know if the original behaviour is a bug or feature.