### PR TITLE
feat: add gpu-cpu mover test tool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
   "storage-proofs",
   "fil-proofs-tooling",
 ]
+
+[patch.crates-io]
+bellperson = { git = "https://github.com/finalitylabs/bellman", branch="fil-lock" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,6 @@ members = [
 ]
 
 [patch.crates-io]
-bellperson = { git = "https://github.com/finalitylabs/bellman", branch="fil-lock" }
+#bellperson = { git = "https://github.com/finalitylabs/bellman", branch="fil-lock" }
+bellperson = { git = "https://github.com/vmx/bellman", branch="gpu-lock-plus-fixes" }
+#bellperson = { git = "https://github.com/vmx/bellman", branch="gpu-lock" }

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -42,6 +42,7 @@ uom = "0.26"
 merkletree = "0.14.0"
 bincode = "1.1.2"
 anyhow = "1.0.23"
+flexi_logger = "0.14.5"
 
 [features]
 default = ["gpu"]

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -23,7 +23,7 @@ regex = "1.1.6"
 commandspec = "0.12.2"
 chrono = { version = "0.4.7", features = ["serde"] }
 memmap = "0.7.0"
-bellperson = "0.4.1"
+bellperson = "0.5.0"
 paired = "0.16.0"
 fil-sapling-crypto = "0.2.1"
 rand = "0.7"

--- a/fil-proofs-tooling/src/bin/gpu-cpu-test/election_post.rs
+++ b/fil-proofs-tooling/src/bin/gpu-cpu-test/election_post.rs
@@ -1,0 +1,167 @@
+use std::collections::BTreeMap;
+use std::io::{Seek, SeekFrom, Write};
+use std::path::Path;
+
+use filecoin_proofs::constants::{DEFAULT_POREP_PROOF_PARTITIONS, SECTOR_SIZE_16_MIB};
+use filecoin_proofs::types::{
+    PaddedBytesAmount, PieceInfo, PoRepConfig, PoRepProofPartitions, PoStConfig,
+    SealPreCommitOutput, SectorSize, UnpaddedBytesAmount,
+};
+use filecoin_proofs::Candidate;
+use filecoin_proofs::{
+    add_piece, generate_candidates, generate_piece_commitment, generate_post, seal_commit,
+    seal_pre_commit, PrivateReplicaInfo,
+};
+use storage_proofs::sector::SectorId;
+use tempfile::NamedTempFile;
+
+// The seed for the rng used to generate which sectors to challenge.
+const CHALLENGE_SEED: [u8; 32] = [0; 32];
+const PROVER_ID: [u8; 32] = [0; 32];
+const SECTOR_ID: u64 = 0;
+const N_PARTITIONS: PoRepProofPartitions = DEFAULT_POREP_PROOF_PARTITIONS;
+const SECTOR_SIZE: u64 = SECTOR_SIZE_16_MIB;
+//const SECTOR_SIZE: u64 = SECTOR_SIZE_ONE_KIB;
+const POREP_CONFIG: PoRepConfig = PoRepConfig {
+    sector_size: SectorSize(SECTOR_SIZE),
+    partitions: N_PARTITIONS,
+};
+const SEED: [u8; 32] = [0; 32];
+const TICKET: [u8; 32] = [0; 32];
+const CHALLENGE_COUNT: u64 = 1;
+const POST_CONFIG: PoStConfig = PoStConfig {
+    sector_size: SectorSize(SECTOR_SIZE),
+};
+
+fn generate_piece_infos(mut staged_file: &NamedTempFile) -> Vec<PieceInfo> {
+    let sector_size_unpadded_bytes_amount =
+        UnpaddedBytesAmount::from(PaddedBytesAmount(SECTOR_SIZE));
+    // Generate the data from which we will create a replica, we will then prove the continued
+    // storage of that replica using the PoSt.
+    let piece_bytes: Vec<u8> = (0..usize::from(sector_size_unpadded_bytes_amount))
+        .map(|_| rand::random::<u8>())
+        .collect();
+
+    let mut piece_file = NamedTempFile::new().expect("could not create piece file");
+    piece_file
+        .write_all(&piece_bytes)
+        .expect("could not write into piece file");
+    piece_file
+        .as_file_mut()
+        .sync_all()
+        .expect("could not sync price file");
+    piece_file
+        .as_file_mut()
+        .seek(SeekFrom::Start(0))
+        .expect("could not seek piece file");
+
+    let piece_info =
+        generate_piece_commitment(piece_file.as_file_mut(), sector_size_unpadded_bytes_amount)
+            .expect("could not generate piece commitment");
+    piece_file
+        .as_file_mut()
+        .seek(SeekFrom::Start(0))
+        .expect("could not seek piece file");
+
+    add_piece(
+        &mut piece_file,
+        &mut staged_file,
+        sector_size_unpadded_bytes_amount,
+        &[],
+    )
+    .expect("could not add pice file to stages file");
+
+    vec![piece_info]
+}
+
+pub fn generate_seal_fixture(cache_dir_path: &Path) -> (SealPreCommitOutput, Vec<PieceInfo>) {
+    let staged_file = NamedTempFile::new().expect("could not create temp file for staged sector");
+    let sealed_file = NamedTempFile::new().expect("could not create temp file for sealed sector");
+
+    let piece_infos = generate_piece_infos(&staged_file);
+
+    let seal_pre_commit_output = seal_pre_commit(
+        POREP_CONFIG,
+        cache_dir_path,
+        staged_file.path(),
+        sealed_file.path(),
+        PROVER_ID,
+        SectorId::from(SECTOR_ID),
+        TICKET,
+        &piece_infos,
+    )
+    .expect("could not pre seal commit");
+
+    (seal_pre_commit_output, piece_infos)
+}
+
+pub fn do_generate_seal(
+    cache_dir_path: &Path,
+    seal_pre_commit_output: SealPreCommitOutput,
+    piece_infos: &[PieceInfo],
+) {
+    seal_commit(
+        POREP_CONFIG,
+        cache_dir_path,
+        PROVER_ID,
+        SectorId::from(SECTOR_ID),
+        TICKET,
+        SEED,
+        seal_pre_commit_output,
+        &piece_infos,
+    )
+    .expect("could not seal commit");
+}
+
+pub fn generate_priv_replica_info_fixture() -> BTreeMap<SectorId, PrivateReplicaInfo> {
+    let cache_dir = tempfile::tempdir().expect("could not create temp dir for cache");
+
+    let (seal_pre_commit_output, piece_infos) = generate_seal_fixture(cache_dir.path());
+    let comm_r = seal_pre_commit_output.comm_r;
+    do_generate_seal(cache_dir.path(), seal_pre_commit_output, &piece_infos);
+
+    let sealed_file = NamedTempFile::new().expect("could not create temp file for sealed sector");
+    let sealed_path_string = sealed_file
+        .path()
+        .to_str()
+        .expect("file name is not a UTF-8 string")
+        .to_string();
+    let priv_replica_info =
+        PrivateReplicaInfo::new(sealed_path_string, comm_r, cache_dir.into_path())
+            .expect("could not create private replica info");
+
+    let mut priv_replica_infos: BTreeMap<SectorId, PrivateReplicaInfo> = BTreeMap::new();
+    priv_replica_infos.insert(SectorId::from(SECTOR_ID), priv_replica_info);
+    priv_replica_infos
+}
+
+pub fn generate_candidates_fixture(
+    priv_replica_info: &BTreeMap<SectorId, PrivateReplicaInfo>,
+) -> Vec<Candidate> {
+    generate_candidates(
+        POST_CONFIG,
+        &CHALLENGE_SEED,
+        CHALLENGE_COUNT,
+        &priv_replica_info,
+        PROVER_ID,
+    )
+    .expect("failed to generate candidates")
+}
+
+pub fn do_generate_post(
+    priv_replica_info: &BTreeMap<SectorId, PrivateReplicaInfo>,
+    candidates: &[Candidate],
+) {
+    generate_post(
+        POST_CONFIG,
+        &CHALLENGE_SEED,
+        &priv_replica_info,
+        candidates
+            .iter()
+            .cloned()
+            .map(Into::into)
+            .collect::<Vec<_>>(),
+        PROVER_ID,
+    )
+    .expect("failed to generate PoSt");
+}

--- a/fil-proofs-tooling/src/bin/gpu-cpu-test/election_post.rs
+++ b/fil-proofs-tooling/src/bin/gpu-cpu-test/election_post.rs
@@ -7,10 +7,9 @@ use filecoin_proofs::types::{
     PaddedBytesAmount, PieceInfo, PoRepConfig, PoRepProofPartitions, PoStConfig,
     SealPreCommitOutput, SectorSize, UnpaddedBytesAmount,
 };
-use filecoin_proofs::Candidate;
 use filecoin_proofs::{
     add_piece, generate_candidates, generate_piece_commitment, generate_post, seal_commit,
-    seal_pre_commit, PrivateReplicaInfo,
+    seal_pre_commit, Candidate, PrivateReplicaInfo,
 };
 use storage_proofs::sector::SectorId;
 use tempfile::NamedTempFile;

--- a/fil-proofs-tooling/src/bin/gpu-cpu-test/main.rs
+++ b/fil-proofs-tooling/src/bin/gpu-cpu-test/main.rs
@@ -1,0 +1,188 @@
+use std::sync::mpsc::{self, TryRecvError};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use bellperson::gpu;
+use clap::{value_t, App, Arg};
+use log::{debug, info, trace};
+
+mod election_post;
+
+const TIMEOUT: u64 = 5 * 60;
+
+#[derive(Debug)]
+struct RunInfo {
+    elapsed: Duration,
+    iterations: u8,
+}
+
+pub fn colored_with_thread(
+    writer: &mut dyn std::io::Write,
+    now: &mut flexi_logger::DeferredNow,
+    record: &flexi_logger::Record,
+) -> Result<(), std::io::Error> {
+    let level = record.level();
+    write!(
+        writer,
+        "{} {} {} {} > {}",
+        now.now().format("%Y-%m-%dT%H:%M:%S%.3f"),
+        thread::current()
+            .name()
+            .unwrap_or(&format!("{:?}", thread::current().id())),
+        flexi_logger::style(level, level),
+        record.module_path().unwrap_or("<unnamed>"),
+        record.args(),
+    )
+}
+
+fn main() {
+    flexi_logger::Logger::with_env()
+        .format(colored_with_thread)
+        .start()
+        .expect("Initializing logger failed. Was another logger already initialized?");
+
+    let matches = App::new("gpu-cpu-test")
+        .version("0.1")
+        .about("Tests if moving proofs from GPU to CPU works")
+        .arg(
+            Arg::with_name("parallel")
+                .long("parallel")
+                .help("Run proofs in parallel.")
+                .default_value("true"),
+        )
+        .arg(
+            Arg::with_name("gpu-stealing")
+                .long("gpu-stealing")
+                .help("Force high priority proof on the GPU and let low priority one continue on CPU.")
+                .default_value("true"),
+        )
+        .get_matches();
+
+    let parallel = value_t!(matches, "parallel", bool).unwrap();
+    if parallel {
+        info!("Running high and low priority proofs in parallel")
+    } else {
+        info!("Running high priority proofs only")
+    }
+    let gpu_stealing = value_t!(matches, "gpu-stealing", bool).unwrap();
+    if gpu_stealing {
+        info!("Force low piority proofs to CPU")
+    } else {
+        info!("Let everyone queue up to run on GPU")
+    }
+
+    // All channels we send a termination message to
+    let mut senders = Vec::new();
+    // All thread handles that get terminated
+    let mut threads: Vec<Option<thread::JoinHandle<_>>> = Vec::new();
+
+    // Create fixtures only once for both threads
+    let priv_replica_info = election_post::generate_priv_replica_info_fixture();
+    let candidates = election_post::generate_candidates_fixture(&priv_replica_info);
+
+    // Put each proof into it's own scope (the other one is due to the if statement
+    {
+        let priv_replica_info_clone = priv_replica_info.clone();
+        let candidates_clone = candidates.clone();
+
+        let (high_tx, high_rx) = mpsc::channel();
+        senders.push(high_tx);
+
+        let high_timing = Instant::now();
+        let thread_config = thread::Builder::new().name("HighPrio".to_string());
+        let high_handler = thread_config
+            .spawn(move || -> RunInfo {
+                let mut iteration = 0;
+                while iteration < std::u8::MAX {
+                    info!("high iter {}", iteration);
+
+                    // This is the higher priority proof, get it on the GPU even if there is one running
+                    // already there
+                    if gpu_stealing {
+                        let gpu_lock = gpu::acquire_gpu().unwrap();
+                        info!("Trying to acquire GPU lock");
+                        while !gpu::gpu_is_available().unwrap_or(false) {
+                            thread::sleep(Duration::from_millis(100));
+                            trace!("Trying to acquire GPU lock");
+                        }
+                        debug!("Acquired GPU lock, dropping it again");
+                        gpu::drop_acquire_lock(gpu_lock);
+                    }
+
+                    // Run the actual proof
+                    election_post::do_generate_post(&priv_replica_info_clone, &candidates_clone);
+
+                    // Waiting for this thread to be killed
+                    match high_rx.try_recv() {
+                        Ok(_) | Err(TryRecvError::Disconnected) => {
+                            debug!("High priority proofs received kill message");
+                            break;
+                        }
+                        Err(TryRecvError::Empty) => (),
+                    }
+                    iteration += 1;
+                }
+                RunInfo {
+                    elapsed: high_timing.elapsed(),
+                    iterations: iteration,
+                }
+            })
+            .expect("cannot spawn high priority proofs thread");
+        threads.push(Some(high_handler));
+    }
+
+    if parallel {
+        let priv_replica_info_clone = priv_replica_info;
+        let candidates_clone = candidates;
+
+        let (low_tx, low_rx) = mpsc::channel();
+        senders.push(low_tx);
+
+        let low_timing = Instant::now();
+        let thread_config = thread::Builder::new().name("LowPrio".to_string());
+        let low_handler = thread_config
+            .spawn(move || -> RunInfo {
+                let mut iteration = 0;
+                while iteration < std::u8::MAX {
+                    info!("low iter {}", iteration);
+
+                    election_post::do_generate_post(&priv_replica_info_clone, &candidates_clone);
+
+                    match low_rx.try_recv() {
+                        Ok(_) | Err(TryRecvError::Disconnected) => {
+                            debug!("Low priority proofs received kill message");
+                            break;
+                        }
+                        Err(TryRecvError::Empty) => (),
+                    }
+                    iteration += 1;
+                }
+                RunInfo {
+                    elapsed: low_timing.elapsed(),
+                    iterations: iteration,
+                }
+            })
+            .expect("cannot spawn low priority proofs thread");
+        threads.push(Some(low_handler));
+    }
+
+    // Terminate all threads after that amount of time
+    let timeout = Duration::from_secs(TIMEOUT);
+    thread::sleep(timeout);
+    info!("Waited long enough to kill all threads");
+    for tx in senders {
+        tx.send(()).unwrap();
+    }
+
+    for thread in &mut threads {
+        if let Some(handler) = thread.take() {
+            let thread_name = handler
+                .thread()
+                .name()
+                .unwrap_or(&format!("{:?}", handler.thread().id()))
+                .to_string();
+            let run_info = handler.join().unwrap();
+            info!("Thread {} info: {:?}", thread_name, run_info);
+        }
+    }
+}

--- a/fil-proofs-tooling/src/bin/gpu-cpu-test/main.rs
+++ b/fil-proofs-tooling/src/bin/gpu-cpu-test/main.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
-use std::process::{Child, Command, Stdio};
+use std::process::{self, Child, Command, Stdio};
 use std::str;
 use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 use std::thread;
@@ -37,8 +37,9 @@ pub fn colored_with_thread(
     let level = record.level();
     write!(
         writer,
-        "{} {} {} {} > {}",
+        "{} {} {} {} {} > {}",
         now.now().format("%Y-%m-%dT%H:%M:%S%.3f"),
+        process::id(),
         thread::current()
             .name()
             .unwrap_or(&format!("{:?}", thread::current().id())),


### PR DESCRIPTION
Proofs can be forced to run on the CPU instead of the GPU. This is used to
run some proofs with higher priority.

The `gpu-cpu-test` tool tests if this actually works. It spawns two threads
which run proofs. Those get killed after 5 minutes of running. The overall
test runs longer as some input data needs to be generated. By default one
thread will always be prioritized to run on the GPU. The other one might be
moved to the CPU.

When running:

    cd fil-proofs-tooling
    RUST_LOG=trace cargo run --release --bin gpu-cpu-test

The return values of the tests might look like:

    2019-12-11T18:13:19.518 main INFO gpu_cpu_test > Thread HighPrio info: RunInfo { elapsed: 303.366942495s, iterations: 28 }
    2019-12-11T18:13:25.981 main INFO gpu_cpu_test > Thread LowPrio info: RunInfo { elapsed: 309.829930518s, iterations: 15 }

Clearly the high priority thread got more work done.

When running without the "GPU stealing" feature, where one tread demands to
run on the GPU:

    RUST_LOG=trace cargo run --release --bin gpu-cpu-test -- --gpu-stealing false

The return values indicate that both threads got the same amount of time on the GPU:

    2019-12-11T18:30:16.868 main INFO gpu_cpu_test > Thread HighPrio info: RunInfo { elapsed: 307.388469955s, iterations: 23 }
    2019-12-11T18:30:16.868 main INFO gpu_cpu_test > Thread LowPrio info: RunInfo { elapsed: 300.893010419s, iterations: 22 }

This PR depends on https://github.com/filecoin-project/bellman/pull/35.