### PR TITLE
fix: better IO errors

### DIFF
--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -62,8 +62,12 @@ impl PrivateReplicaInfo {
 
         let aux = {
             let mut aux_bytes = vec![];
-            let mut f_aux = File::open(cache_dir.join(CacheKey::PAux.to_string()))?;
-            f_aux.read_to_end(&mut aux_bytes)?;
+            let f_aux_path = cache_dir.join(CacheKey::PAux.to_string());
+            let mut f_aux = File::open(&f_aux_path)
+                .with_context(|| format!("could not open path={:?}", f_aux_path))?;
+            f_aux
+                .read_to_end(&mut aux_bytes)
+                .with_context(|| format!("could not read from path={:?}", f_aux_path))?;
 
             deserialize(&aux_bytes)
         }?;

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -32,7 +32,7 @@ pub fn get_full_path_for_file_within_cache(filename: &str) -> PathBuf {
 // Produces a BLAKE2b checksum for a file within the cache
 pub fn get_digest_for_file_within_cache(filename: &str) -> Result<String> {
     let path = get_full_path_for_file_within_cache(filename);
-    let mut file = File::open(path)?;
+    let mut file = File::open(&path).with_context(|| format!("could not open path={:?}", path))?;
     let mut hasher = Blake2b::new();
 
     std::io::copy(&mut file, &mut hasher)?;
@@ -75,7 +75,9 @@ pub fn parameter_id_to_metadata_map<S: AsRef<str>>(
 
     for filename in filenames {
         if has_extension(PathBuf::from(filename.as_ref()), PARAMETER_METADATA_EXT) {
-            let file = File::open(get_full_path_for_file_within_cache(filename.as_ref()))?;
+            let file_path = get_full_path_for_file_within_cache(filename.as_ref());
+            let file = File::open(&file_path)
+                .with_context(|| format!("could not open path={:?}", file_path))?;
 
             let meta = serde_json::from_reader(file)?;
 


### PR DESCRIPTION
IO errors do not contain much context about which file failed. Giving
this context should make debugging easier.