### PR TITLE
ci(packet): use new env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,7 @@ jobs:
             mkdir -p ~/.ssh/
             if [[ ! -f ~/.ssh/known_hosts ]] || ! grep "${BENCHMARK_SERVER_IP_ADDR}" ~/.ssh/known_hosts; then
               echo "
-            ${BENCHMARK_SERVER_RSA_FINGERPRINT}
+            ${BENCHMARK_SERVER_KNOWN_HOSTS_ENTRY}
               " >> ~/.ssh/known_hosts
             fi
       - checkout


### PR DESCRIPTION
## What's in this PR?

We rebuilt our benchmarking box and needed to update various configs. Most of that was done in CircleCI and on the benchmarking box. The last piece is to change this environment variable name.