### PR TITLE
feat: use LevelCacheStore for restoring tree_r_last from disk

### DIFF
--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -39,7 +39,7 @@ blake2s_simd = "0.5.6"
 fil_logger = "0.1"
 log = "0.4.8"
 uom = "0.26"
-merkletree = { git = "https://github.com/filecoin-project/merkle_light.git", branch = "external-reader" }
+merkletree = { git = "https://github.com/filecoin-project/merkle_light.git" }
 bincode = "1.1.2"
 anyhow = "1.0.23"
 ff = { version = "0.2.0", package = "fff" }

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -39,7 +39,7 @@ blake2s_simd = "0.5.6"
 fil_logger = "0.1"
 log = "0.4.8"
 uom = "0.26"
-merkletree = { git = "https://github.com/filecoin-project/merkle_light.git" }
+merkletree = "0.15.2"
 bincode = "1.1.2"
 anyhow = "1.0.23"
 ff = { version = "0.2.0", package = "fff" }

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -39,7 +39,7 @@ blake2s_simd = "0.5.6"
 fil_logger = "0.1"
 log = "0.4.8"
 uom = "0.26"
-merkletree = "0.14.0"
+merkletree = { git = "https://github.com/filecoin-project/merkle_light.git", branch = "external-reader" }
 bincode = "1.1.2"
 anyhow = "1.0.23"
 ff = { version = "0.2.0", package = "fff" }

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -41,7 +41,7 @@ blake2s_simd = "0.5.8"
 hex = "0.4.0"
 tee = "0.1.0"
 os_pipe = "0.9.1"
-merkletree = "0.14.0"
+merkletree = { git = "https://github.com/filecoin-project/merkle_light.git", branch = "external-reader" }
 bincode = "1.1.2"
 anyhow = "1.0.23"
 rand_xorshift = "0.2.0"

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -41,7 +41,7 @@ blake2s_simd = "0.5.8"
 hex = "0.4.0"
 tee = "0.1.0"
 os_pipe = "0.9.1"
-merkletree = { git = "https://github.com/filecoin-project/merkle_light.git", branch = "external-reader" }
+merkletree = { git = "https://github.com/filecoin-project/merkle_light.git"}
 bincode = "1.1.2"
 anyhow = "1.0.23"
 rand_xorshift = "0.2.0"

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -41,7 +41,7 @@ blake2s_simd = "0.5.8"
 hex = "0.4.0"
 tee = "0.1.0"
 os_pipe = "0.9.1"
-merkletree = { git = "https://github.com/filecoin-project/merkle_light.git"}
+merkletree = "0.15.2"
 bincode = "1.1.2"
 anyhow = "1.0.23"
 rand_xorshift = "0.2.0"

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -7,7 +7,7 @@ use anyhow::{anyhow, ensure, Context, Result};
 use bincode::deserialize;
 use log::info;
 use merkletree::merkle::get_merkle_tree_leafs;
-use merkletree::store::{LevelCacheStore, Store, StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};
+use merkletree::store::{LevelCacheStore, Store, StoreConfig};
 use paired::bls12_381::Bls12;
 use rayon::prelude::*;
 use storage_proofs::circuit::election_post::ElectionPoStCompound;
@@ -102,7 +102,7 @@ impl PrivateReplicaInfo {
         let mut config = StoreConfig::new(
             self.cache_dir_path(),
             CacheKey::CommRLastTree.to_string(),
-            2, //DEFAULT_CACHED_ABOVE_BASE_LAYER,
+            StoreConfig::default_cached_above_base_layer(tree_leafs),
         );
         config.size = Some(tree_size);
 

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -25,8 +25,7 @@ use crate::api::util::{as_safe_commitment, get_tree_size};
 use crate::caches::{get_post_params, get_post_verifying_key};
 use crate::parameters::post_setup_params;
 use crate::types::{
-    ChallengeSeed, Commitment, LCTree, PersistentAux, PoStConfig, ProverId, SectorSize,
-    TemporaryAux,
+    ChallengeSeed, Commitment, LCTree, PersistentAux, PoStConfig, ProverId, TemporaryAux,
 };
 
 pub use storage_proofs::election_post::Candidate;

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -422,6 +422,9 @@ pub fn seal_commit_phase2(
 
     let proof = MultiProof::new(groth_proofs, &groth_params.vk);
 
+    // Discard or compact cached MTs that are no longer needed.
+    TemporaryAux::<DefaultTreeHasher, DefaultPieceHasher>::compact(t_aux)?;
+
     let mut buf = Vec::with_capacity(
         SINGLE_PARTITION_PROOF_LEN * usize::from(PoRepProofPartitions::from(porep_config)),
     );

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -344,6 +344,9 @@ pub fn seal_commit_phase1<T: AsRef<Path>>(
     )?;
     ensure!(sanity_check, "Invalid vanilla proof generated");
 
+    // Discard or compact cached MTs that are no longer needed.
+    TemporaryAux::<DefaultTreeHasher, DefaultPieceHasher>::compact(t_aux)?;
+
     info!("seal_commit_phase1:end");
 
     Ok(SealCommitPhase1Output {
@@ -421,9 +424,6 @@ pub fn seal_commit_phase2(
     info!("snark_proof:finish");
 
     let proof = MultiProof::new(groth_proofs, &groth_params.vk);
-
-    // Discard or compact cached MTs that are no longer needed.
-    TemporaryAux::<DefaultTreeHasher, DefaultPieceHasher>::compact(t_aux)?;
 
     let mut buf = Vec::with_capacity(
         SINGLE_PARTITION_PROOF_LEN * usize::from(PoRepProofPartitions::from(porep_config)),

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -105,7 +105,7 @@ where
         let config = StoreConfig::new(
             cache_path.as_ref(),
             CacheKey::CommDTree.to_string(),
-            DEFAULT_CACHED_ABOVE_BASE_LAYER,
+            StoreConfig::default_cached_above_base_layer(sector_bytes),
         );
         let data_tree = create_merkle_tree::<DefaultPieceHasher>(
             Some(config.clone()),

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -652,7 +652,7 @@ mod tests {
         }
         assert_eq!(staged_sector.len(), u64::from(sector_size) as usize);
 
-        let data_tree = graph.merkle_tree(&staged_sector)?;
+        let data_tree = graph.merkle_tree(None, &staged_sector)?;
         let comm_d_root: Fr = data_tree.root().into();
         let comm_d = commitment_from_fr::<Bls12>(comm_d_root);
 

--- a/filecoin-proofs/src/types/mod.rs
+++ b/filecoin-proofs/src/types/mod.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use storage_proofs::hasher::pedersen::{PedersenDomain, PedersenHasher};
 use storage_proofs::hasher::Hasher;
-use storage_proofs::merkle::MerkleTree;
+use storage_proofs::merkle::{LCMerkleTree, MerkleTree};
 use storage_proofs::stacked;
 
 mod bytes_amount;
@@ -29,6 +29,7 @@ pub type TemporaryAux = stacked::TemporaryAux<PedersenHasher, crate::constants::
 pub type ProverId = [u8; 32];
 pub type Ticket = [u8; 32];
 pub type Tree = MerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function>;
+pub type LCTree = LCMerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function>;
 
 #[derive(Debug, Clone)]
 pub struct SealPreCommitOutput {

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 bitvec = "0.5"
 rand = "0.7"
 libc = "0.2"
-merkletree = "0.14.0"
+merkletree = { git = "https://github.com/filecoin-project/merkle_light.git", branch = "external-reader" }
 byteorder = "1"
 config = "0.9.3"
 crossbeam-utils = "0.6"
@@ -31,6 +31,7 @@ block-modes = "0.3"
 sha2 = { git = "https://github.com/dignifiedquire/hashes", branch = "sha2-intrinsics" }
 pbr = "1.0"
 tempfile = "3"
+tempdir = "0.3.7"
 fs2 = "0.4"
 rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 bitvec = "0.5"
 rand = "0.7"
 libc = "0.2"
-merkletree = { git = "https://github.com/filecoin-project/merkle_light.git" }
+merkletree = "0.15.2"
 byteorder = "1"
 config = "0.9.3"
 crossbeam-utils = "0.6"

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 bitvec = "0.5"
 rand = "0.7"
 libc = "0.2"
-merkletree = { git = "https://github.com/filecoin-project/merkle_light.git", branch = "external-reader" }
+merkletree = { git = "https://github.com/filecoin-project/merkle_light.git" }
 byteorder = "1"
 config = "0.9.3"
 crossbeam-utils = "0.6"

--- a/storage-proofs/benches/merkle.rs
+++ b/storage-proofs/benches/merkle.rs
@@ -26,7 +26,7 @@ fn merkle_benchmark(c: &mut Criterion) {
                 )
                 .unwrap();
 
-                b.iter(|| black_box(graph.merkle_tree(&data).unwrap()))
+                b.iter(|| black_box(graph.merkle_tree(None, &data).unwrap()))
             },
             params,
         )
@@ -41,7 +41,7 @@ fn merkle_benchmark(c: &mut Criterion) {
             )
             .unwrap();
 
-            b.iter(|| black_box(graph.merkle_tree(&data).unwrap()))
+            b.iter(|| black_box(graph.merkle_tree(None, &data).unwrap()))
         })
         .sample_size(20),
     );

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -529,7 +529,7 @@ mod tests {
     fn drgporep_input_circuit_with_bls12_381() {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
-        let nodes = 12;
+        let nodes = 16;
         let degree = BASE_DEGREE;
         let challenge = 2;
 
@@ -742,7 +742,7 @@ mod tests {
 
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
-        let nodes = 5;
+        let nodes = 8;
         let degree = BASE_DEGREE;
         let challenges = vec![1, 3];
 

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -270,7 +270,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&Fr::random(rng)))
             .collect();
         let graph = BucketGraph::<PedersenHasher>::new(leaves, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
 
         for i in 0..3 {
             let public_inputs = merklepor::PublicInputs {
@@ -358,7 +358,7 @@ mod tests {
                 .collect();
 
             let graph = BucketGraph::<H>::new(leaves, BASE_DEGREE, 0, new_seed()).unwrap();
-            let tree = graph.merkle_tree(data.as_slice()).unwrap();
+            let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
 
             // -- MerklePoR
 
@@ -460,7 +460,7 @@ mod tests {
             .flat_map(|_| fr_into_bytes::<Bls12>(&Fr::random(rng)))
             .collect();
         let graph = BucketGraph::<H>::new(leaves, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
 
         for i in 0..3 {
             let public_inputs = merklepor::PublicInputs {
@@ -536,7 +536,7 @@ mod tests {
 
             let graph =
                 BucketGraph::<PedersenHasher>::new(leaves, BASE_DEGREE, 0, new_seed()).unwrap();
-            let tree = graph.merkle_tree(data.as_slice()).unwrap();
+            let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
 
             // -- MerklePoR
 

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -265,7 +265,7 @@ mod tests {
     #[ignore] // Slow test – run only when compiled for release.
     fn por_test_compound() {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
-        let leaves = 6;
+        let leaves = 8;
         let data: Vec<u8> = (0..leaves)
             .flat_map(|_| fr_into_bytes::<Bls12>(&Fr::random(rng)))
             .collect();
@@ -348,9 +348,9 @@ mod tests {
     fn test_por_input_circuit_with_bls12_381<H: Hasher>(num_constraints: usize) {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
-        let leaves = 6;
+        let leaves = 8;
 
-        for i in 0..6 {
+        for i in 0..leaves {
             // -- Basic Setup
 
             let data: Vec<u8> = (0..leaves)
@@ -455,7 +455,7 @@ mod tests {
 
     fn private_por_test_compound<H: Hasher>() {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
-        let leaves = 6;
+        let leaves = 8;
         let data: Vec<u8> = (0..leaves)
             .flat_map(|_| fr_into_bytes::<Bls12>(&Fr::random(rng)))
             .collect();
@@ -525,9 +525,9 @@ mod tests {
     fn test_private_por_input_circuit_with_bls12_381() {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
-        let leaves = 6;
+        let leaves = 8;
 
-        for i in 0..6 {
+        for i in 0..leaves {
             // -- Basic Setup
 
             let data: Vec<u8> = (0..leaves)

--- a/storage-proofs/src/circuit/rational_post.rs
+++ b/storage-proofs/src/circuit/rational_post.rs
@@ -309,10 +309,10 @@ mod tests {
             .collect();
 
         let graph1 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree1 = graph1.merkle_tree(data1.as_slice()).unwrap();
+        let tree1 = graph1.merkle_tree(None, data1.as_slice()).unwrap();
 
         let graph2 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
+        let tree2 = graph2.merkle_tree(None, data2.as_slice()).unwrap();
 
         let faults = OrderedSectorSet::new();
         let mut sectors = OrderedSectorSet::new();
@@ -446,10 +446,10 @@ mod tests {
             .collect();
 
         let graph1 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree1 = graph1.merkle_tree(data1.as_slice()).unwrap();
+        let tree1 = graph1.merkle_tree(None, data1.as_slice()).unwrap();
 
         let graph2 = BucketGraph::<PedersenHasher>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
+        let tree2 = graph2.merkle_tree(None, data2.as_slice()).unwrap();
 
         let faults = OrderedSectorSet::new();
         let mut sectors = OrderedSectorSet::new();

--- a/storage-proofs/src/drgporep.rs
+++ b/storage-proofs/src/drgporep.rs
@@ -625,7 +625,7 @@ mod tests {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
         let replica_id: H::Domain = H::Domain::random(rng);
-        let data = vec![2u8; 32 * 3];
+        let data = vec![2u8; 32 * 4];
         // create a copy, so we can compare roundtrips
         let mut mmapped_data_copy = file_backed_mmap_from(&data);
 
@@ -698,7 +698,7 @@ mod tests {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
         let replica_id: H::Domain = H::Domain::random(rng);
-        let nodes = 3;
+        let nodes = 4;
         let data = vec![2u8; 32 * nodes];
 
         // create a copy, so we can compare roundtrips
@@ -974,25 +974,25 @@ mod tests {
         prove_verify {
             prove_verify_32_2_1(2, 1);
 
-            prove_verify_32_3_1(3, 1);
-            prove_verify_32_3_2(3, 2);
+            prove_verify_32_3_1(4, 1);
+            prove_verify_32_3_2(4, 2);
 
-            prove_verify_32_10_1(10, 1);
-            prove_verify_32_10_2(10, 2);
-            prove_verify_32_10_3(10, 3);
-            prove_verify_32_10_4(10, 4);
-            prove_verify_32_10_5(10, 5);
+            prove_verify_32_10_1(16, 1);
+            prove_verify_32_10_2(16, 2);
+            prove_verify_32_10_3(16, 3);
+            prove_verify_32_10_4(16, 4);
+            prove_verify_32_10_5(16, 5);
         }
     }
 
     #[test]
     fn test_drgporep_verifies_using_challenge() {
-        prove_verify_wrong_challenge(5, 1);
+        prove_verify_wrong_challenge(8, 1);
     }
 
     #[test]
     fn test_drgporep_verifies_parents() {
         // Challenge a node (3) that doesn't have all the same parents.
-        prove_verify_wrong_parents(7, 4);
+        prove_verify_wrong_parents(8, 5);
     }
 }

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -261,7 +261,7 @@ mod tests {
     fn graph_bucket<H: Hasher>() {
         let degree = BASE_DEGREE;
 
-        for size in vec![3, 10, 200, 2000] {
+        for size in vec![4, 16, 256, 2048] {
             let g = BucketGraph::<H>::new(size, degree, 0, new_seed()).unwrap();
 
             assert_eq!(g.size(), size, "wrong nodes count");
@@ -311,8 +311,8 @@ mod tests {
     }
 
     fn gen_proof<H: Hasher>(config: Option<StoreConfig>) {
-        let g = BucketGraph::<H>::new(5, BASE_DEGREE, 0, new_seed()).unwrap();
-        let data = vec![2u8; NODE_SIZE * 5];
+        let g = BucketGraph::<H>::new(8, BASE_DEGREE, 0, new_seed()).unwrap();
+        let data = vec![2u8; NODE_SIZE * 8];
 
         let mmapped = &mmap_from(&data);
         let tree = g.merkle_tree(config, mmapped).unwrap();

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -2,6 +2,7 @@ use std::cmp;
 use std::marker::PhantomData;
 
 use anyhow::ensure;
+use merkletree::store::StoreConfig;
 use rand::{rngs::OsRng, Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use sha2::{Digest, Sha256};
@@ -10,7 +11,7 @@ use crate::error::*;
 use crate::fr32::bytes_into_fr_repr_safe;
 use crate::hasher::pedersen::PedersenHasher;
 use crate::hasher::Hasher;
-use crate::merkle::{create_merkle_tree, MerkleTree};
+use crate::merkle::{create_lcmerkle_tree, create_merkle_tree, LCMerkleTree, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node_offset, NODE_SIZE};
 
@@ -34,8 +35,21 @@ pub trait Graph<H: Hasher>: ::std::fmt::Debug + Clone + PartialEq + Eq {
     }
 
     /// Builds a merkle tree based on the given data.
-    fn merkle_tree<'a>(&self, data: &'a [u8]) -> Result<MerkleTree<H::Domain, H::Function>> {
-        create_merkle_tree::<H>(None, self.size(), data)
+    fn merkle_tree<'a>(
+        &self,
+        config: Option<StoreConfig>,
+        data: &'a [u8],
+    ) -> Result<MerkleTree<H::Domain, H::Function>> {
+        create_merkle_tree::<H>(config, self.size(), data)
+    }
+
+    /// Builds a merkle tree based on the given level cache data.
+    fn lcmerkle_tree<'a>(
+        &self,
+        config: Option<StoreConfig>,
+        data: &'a [u8],
+    ) -> Result<LCMerkleTree<H::Domain, H::Function>> {
+        create_lcmerkle_tree::<H>(config, self.size(), data)
     }
 
     /// Returns the merkle tree depth.
@@ -296,12 +310,12 @@ mod tests {
         graph_bucket::<PedersenHasher>();
     }
 
-    fn gen_proof<H: Hasher>() {
+    fn gen_proof<H: Hasher>(config: Option<StoreConfig>) {
         let g = BucketGraph::<H>::new(5, BASE_DEGREE, 0, new_seed()).unwrap();
         let data = vec![2u8; NODE_SIZE * 5];
 
         let mmapped = &mmap_from(&data);
-        let tree = g.merkle_tree(mmapped).unwrap();
+        let tree = g.merkle_tree(config, mmapped).unwrap();
         let proof = tree.gen_proof(2).unwrap();
 
         assert!(proof.validate::<H::Function>());
@@ -309,16 +323,16 @@ mod tests {
 
     #[test]
     fn gen_proof_pedersen() {
-        gen_proof::<PedersenHasher>();
+        gen_proof::<PedersenHasher>(None);
     }
 
     #[test]
     fn gen_proof_sha256() {
-        gen_proof::<Sha256Hasher>();
+        gen_proof::<Sha256Hasher>(None);
     }
 
     #[test]
     fn gen_proof_blake2s() {
-        gen_proof::<Blake2sHasher>();
+        gen_proof::<Blake2sHasher>(None);
     }
 }

--- a/storage-proofs/src/election_post.rs
+++ b/storage-proofs/src/election_post.rs
@@ -15,7 +15,7 @@ use crate::error::{Error, Result};
 use crate::fr32::fr_into_bytes;
 use crate::hasher::{Domain, Hasher};
 use crate::measurements::{measure_op, Operation};
-use crate::merkle::{MerkleProof, MerkleTree};
+use crate::merkle::{LCMerkleTree, MerkleProof};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::proof::{NoRequirements, ProofScheme};
 use crate::sector::*;
@@ -65,7 +65,7 @@ pub struct PublicInputs<T: Domain> {
 
 #[derive(Debug, Clone)]
 pub struct PrivateInputs<H: Hasher> {
-    pub tree: MerkleTree<H::Domain, H::Function>,
+    pub tree: LCMerkleTree<H::Domain, H::Function>,
     pub comm_c: H::Domain,
     pub comm_r_last: H::Domain,
 }
@@ -139,7 +139,7 @@ where
 pub fn generate_candidates<H: Hasher>(
     pub_params: &PublicParams,
     challenged_sectors: &[SectorId],
-    trees: &BTreeMap<SectorId, MerkleTree<H::Domain, H::Function>>,
+    trees: &BTreeMap<SectorId, LCMerkleTree<H::Domain, H::Function>>,
     prover_id: &[u8; 32],
     randomness: &[u8; 32],
 ) -> Result<Vec<Candidate>> {
@@ -166,7 +166,7 @@ pub fn generate_candidates<H: Hasher>(
 
 fn generate_candidate<H: Hasher>(
     pub_params: &PublicParams,
-    tree: &MerkleTree<H::Domain, H::Function>,
+    tree: &LCMerkleTree<H::Domain, H::Function>,
     prover_id: &[u8; 32],
     sector_id: SectorId,
     randomness: &[u8; 32],
@@ -345,9 +345,11 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for ElectionPoSt<'a, H> {
                     (0..pub_params.challenged_nodes)
                         .into_par_iter()
                         .map(move |i| {
-                            Ok(MerkleProof::new_from_proof(
-                                &tree.gen_proof(challenged_leaf_start as usize + i)?,
-                            ))
+                            let (proof, _) = tree.gen_proof_and_partial_tree(
+                                challenged_leaf_start as usize + i,
+                                2,
+                            )?;
+                            Ok(MerkleProof::new_from_proof(&proof))
                         })
                 })
                 .collect::<Result<Vec<_>>>()
@@ -425,6 +427,8 @@ mod tests {
     use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
 
     fn test_election_post<H: Hasher>() {
+        use merkletree::store::{StoreConfig, StoreConfigDataVersion};
+
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
         let leaves = 32;
@@ -441,6 +445,16 @@ mod tests {
 
         let mut sectors: Vec<SectorId> = Vec::new();
         let mut trees = BTreeMap::new();
+
+        // Construct and store an MT using a named DiskStore.
+        let temp_dir = tempdir::TempDir::new("level_cache_tree_v1").unwrap();
+        let temp_path = temp_dir.path();
+        let config = StoreConfig::new(
+            &temp_path,
+            String::from("test-lc-tree-v1"),
+            2, //DEFAULT_CACHED_ABOVE_BASE_LAYER,
+        );
+
         for i in 0..5 {
             sectors.push(i.into());
             let data: Vec<u8> = (0..leaves)
@@ -448,8 +462,21 @@ mod tests {
                 .collect();
 
             let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-            let tree = graph.merkle_tree(data.as_slice()).unwrap();
-            trees.insert(i.into(), tree);
+
+            let cur_config =
+                StoreConfig::from_config(&config, format!("test-lc-tree-v1-{}", i), None);
+            let mut tree = graph
+                .merkle_tree(Some(cur_config.clone()), data.as_slice())
+                .unwrap();
+            let c = tree
+                .compact(cur_config.clone(), StoreConfigDataVersion::One as u32)
+                .unwrap();
+            assert_eq!(c, true);
+
+            let lctree = graph
+                .lcmerkle_tree(Some(cur_config), data.as_slice())
+                .unwrap();
+            trees.insert(i.into(), lctree);
         }
 
         let candidates =

--- a/storage-proofs/src/election_post.rs
+++ b/storage-proofs/src/election_post.rs
@@ -452,7 +452,7 @@ mod tests {
         let config = StoreConfig::new(
             &temp_path,
             String::from("test-lc-tree-v1"),
-            2, //DEFAULT_CACHED_ABOVE_BASE_LAYER,
+            StoreConfig::default_cached_above_base_layer(leaves as usize),
         );
 
         for i in 0..5 {

--- a/storage-proofs/src/election_post.rs
+++ b/storage-proofs/src/election_post.rs
@@ -63,7 +63,7 @@ pub struct PublicInputs<T: Domain> {
     pub sector_challenge_index: u64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct PrivateInputs<H: Hasher> {
     pub tree: LCMerkleTree<H::Domain, H::Function>,
     pub comm_c: H::Domain,

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -6,7 +6,7 @@ use anyhow::ensure;
 use merkletree::hash::Algorithm;
 use merkletree::merkle;
 use merkletree::proof;
-use merkletree::store::StoreConfig;
+use merkletree::store::{LevelCacheStore, StoreConfig};
 use paired::bls12_381::Fr;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -21,6 +21,7 @@ pub use merkletree::store::Store;
 
 type DiskStore<E> = merkletree::store::DiskStore<E>;
 pub type MerkleTree<T, A> = merkle::MerkleTree<T, A, DiskStore<T>>;
+pub type LCMerkleTree<T, A> = merkle::MerkleTree<T, A, LevelCacheStore<T, std::fs::File>>;
 pub type MerkleStore<T> = DiskStore<T>;
 
 /// Representation of a merkle proof.
@@ -247,6 +248,34 @@ pub fn create_merkle_tree<H: Hasher>(
     }
 }
 
+/// Construct a new level cache merkle tree.
+pub fn create_lcmerkle_tree<H: Hasher>(
+    config: Option<StoreConfig>,
+    size: usize,
+    data: &[u8],
+) -> Result<LCMerkleTree<H::Domain, H::Function>> {
+    ensure!(
+        data.len() == (NODE_SIZE * size) as usize,
+        Error::InvalidMerkleTreeArgs(data.len(), NODE_SIZE, size)
+    );
+
+    let f = |i| {
+        // TODO Replace `expect()` with `context()` (problem is the parallel iterator)
+        let d = data_at_node(&data, i).expect("data_at_node math failed");
+        // TODO/FIXME: This can panic. FOR NOW, let's leave this since we're experimenting with
+        // optimization paths. However, we need to ensure that bad input will not lead to a panic
+        // that isn't caught by the FPS API.
+        // Unfortunately, it's not clear how to perform this error-handling in the parallel
+        // iterator case.
+        H::Domain::try_from_bytes(d).expect("failed to convert node data to domain element")
+    };
+
+    match config {
+        Some(x) => LCMerkleTree::from_par_iter_with_config((0..size).into_par_iter().map(f), x),
+        None => LCMerkleTree::from_par_iter((0..size).into_par_iter().map(f)),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -268,7 +297,7 @@ mod tests {
             data.write(&bytes).unwrap();
         }
 
-        let tree = g.merkle_tree(data.as_slice()).unwrap();
+        let tree = g.merkle_tree(None, data.as_slice()).unwrap();
         for i in 0..10 {
             let proof = tree.gen_proof(i).unwrap();
 

--- a/storage-proofs/src/merkle.rs
+++ b/storage-proofs/src/merkle.rs
@@ -287,18 +287,18 @@ mod tests {
     use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
 
     fn merklepath<H: Hasher>() {
-        let g = BucketGraph::<H>::new(10, BASE_DEGREE, 0, new_seed()).unwrap();
+        let g = BucketGraph::<H>::new(16, BASE_DEGREE, 0, new_seed()).unwrap();
         let mut rng = rand::thread_rng();
         let node_size = 32;
         let mut data = Vec::new();
-        for _ in 0..10 {
+        for _ in 0..16 {
             let elt: H::Domain = H::Domain::random(&mut rng);
             let bytes = H::Domain::into_bytes(&elt);
             data.write(&bytes).unwrap();
         }
 
         let tree = g.merkle_tree(None, data.as_slice()).unwrap();
-        for i in 0..10 {
+        for i in 0..16 {
             let proof = tree.gen_proof(i).unwrap();
 
             assert!(proof.validate::<H::Function>());

--- a/storage-proofs/src/merklepor.rs
+++ b/storage-proofs/src/merklepor.rs
@@ -168,7 +168,7 @@ mod tests {
             .collect();
 
         let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {
             challenge: 3,
@@ -240,7 +240,7 @@ mod tests {
             .collect();
 
         let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {
             challenge: 3,
@@ -284,7 +284,7 @@ mod tests {
             .collect();
 
         let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {
             challenge: 3,

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -28,7 +28,7 @@ pub const VERIFYING_KEY_EXT: &str = "vk";
 #[derive(Debug)]
 struct LockedFile(File);
 
-// TODO: use in memory lock as well, as file locks do not guarantee exclusive access acros OSes.
+// TODO: use in memory lock as well, as file locks do not guarantee exclusive access across OSes.
 
 impl LockedFile {
     pub fn open_exclusive_read<P: AsRef<Path>>(p: P) -> io::Result<Self> {

--- a/storage-proofs/src/porep.rs
+++ b/storage-proofs/src/porep.rs
@@ -37,7 +37,7 @@ pub struct PrivateInputs<'a> {
     pub replica: &'a [u8],
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct ProverAux<H: Hasher> {
     pub tree_d: MerkleTree<H::Domain, H::Function>,
     pub tree_r: MerkleTree<H::Domain, H::Function>,

--- a/storage-proofs/src/rational_post.rs
+++ b/storage-proofs/src/rational_post.rs
@@ -316,8 +316,8 @@ mod tests {
 
         let graph1 = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
         let graph2 = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree1 = graph1.merkle_tree(data1.as_slice()).unwrap();
-        let tree2 = graph2.merkle_tree(data2.as_slice()).unwrap();
+        let tree1 = graph1.merkle_tree(None, data1.as_slice()).unwrap();
+        let tree2 = graph2.merkle_tree(None, data2.as_slice()).unwrap();
 
         let seed = (0..32).map(|_| rng.gen()).collect::<Vec<u8>>();
         let mut faults = OrderedSectorSet::new();
@@ -429,7 +429,7 @@ mod tests {
             .collect();
 
         let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
         let seed = (0..32).map(|_| rng.gen()).collect::<Vec<u8>>();
 
         let faults = OrderedSectorSet::new();
@@ -502,7 +502,7 @@ mod tests {
             .collect();
 
         let graph = BucketGraph::<H>::new(32, BASE_DEGREE, 0, new_seed()).unwrap();
-        let tree = graph.merkle_tree(data.as_slice()).unwrap();
+        let tree = graph.merkle_tree(None, data.as_slice()).unwrap();
         let seed = (0..32).map(|_| rng.gen()).collect::<Vec<u8>>();
         let mut faults = OrderedSectorSet::new();
         faults.insert(1.into());

--- a/storage-proofs/src/stacked/params.rs
+++ b/storage-proofs/src/stacked/params.rs
@@ -376,10 +376,7 @@ impl<H: Hasher, G: Hasher> TemporaryAux<H, G> {
             tree_d.delete(t_aux.tree_d_config).context("tree_d")?;
 
             // If tree_d still existed and we just deleted it, compact tree_r_last here.
-            ensure!(
-                cached(&t_aux.tree_r_last_config),
-                "TreeRLast does not exist"
-            );
+            assert!(cached(&t_aux.tree_r_last_config));
             let tree_r_last_size = t_aux
                 .tree_r_last_config
                 .size
@@ -404,19 +401,6 @@ impl<H: Hasher, G: Hasher> TemporaryAux<H, G> {
                 MerkleTree::from_data_store(tree_c_store, get_merkle_tree_leafs(tree_c_size))
                     .context("tree_c")?;
             tree_c.delete(t_aux.tree_c_config).context("tree_c")?;
-        }
-
-        if cached(&t_aux.tree_q_config) {
-            let tree_q_size = t_aux
-                .tree_q_config
-                .size
-                .context("tree_q config has no size")?;
-            let tree_q_store: DiskStore<H::Domain> =
-                DiskStore::new_from_disk(tree_q_size, &t_aux.tree_q_config).context("tree_q")?;
-            let tree_q: Tree<H> =
-                MerkleTree::from_data_store(tree_q_store, get_merkle_tree_leafs(tree_q_size))
-                    .context("tree_q")?;
-            tree_q.delete(t_aux.tree_q_config).context("tree_q")?;
         }
 
         for i in 0..t_aux.labels.labels.len() {

--- a/storage-proofs/src/stacked/params.rs
+++ b/storage-proofs/src/stacked/params.rs
@@ -356,38 +356,75 @@ impl<H: Hasher, G: Hasher> TemporaryAux<H, G> {
         self.labels.column(column_index)
     }
 
-    pub fn delete(t_aux: TemporaryAux<H, G>) -> Result<()> {
-        let tree_r_last_size = t_aux
-            .tree_r_last_config
-            .size
-            .context("tree_r_last config has no size")?;
-        let mut tree_r_last_store: DiskStore<G::Domain> =
-            DiskStore::new_from_disk(tree_r_last_size, &t_aux.tree_r_last_config)
-                .context("tree_r_last")?;
-        tree_r_last_store.compact(
-            t_aux.tree_r_last_config.clone(),
-            StoreConfigDataVersion::One as u32,
-        )?;
+    // "Compact" will discard all persisted data that is no longer
+    // required and compact the remaining "tree_r_last" merkle tree.
+    pub fn compact(t_aux: TemporaryAux<H, G>) -> Result<()> {
+        let cached = |config: &StoreConfig| {
+            Path::new(&StoreConfig::data_path(&config.path, &config.id)).exists()
+        };
 
-        let tree_d_size = t_aux
-            .tree_d_config
-            .size
-            .context("tree_d config has no size")?;
-        let tree_d_store: DiskStore<G::Domain> =
-            DiskStore::new_from_disk(tree_d_size, &t_aux.tree_d_config)?;
-        let tree_d: Tree<G> =
-            MerkleTree::from_data_store(tree_d_store, get_merkle_tree_leafs(tree_d_size))?;
-        tree_d.delete(t_aux.tree_d_config)?;
+        if cached(&t_aux.tree_d_config) {
+            let tree_d_size = t_aux
+                .tree_d_config
+                .size
+                .context("tree_d config has no size")?;
+            let tree_d_store: DiskStore<G::Domain> =
+                DiskStore::new_from_disk(tree_d_size, &t_aux.tree_d_config).context("tree_d")?;
+            let tree_d: Tree<G> =
+                MerkleTree::from_data_store(tree_d_store, get_merkle_tree_leafs(tree_d_size))
+                    .context("tree_d")?;
+            tree_d.delete(t_aux.tree_d_config).context("tree_d")?;
 
-        let tree_c_size = t_aux.tree_c_config.size.unwrap();
-        let tree_c_store: DiskStore<H::Domain> =
-            DiskStore::new_from_disk(tree_c_size, &t_aux.tree_c_config)?;
-        let tree_c: Tree<H> =
-            MerkleTree::from_data_store(tree_c_store, get_merkle_tree_leafs(tree_c_size))?;
-        tree_c.delete(t_aux.tree_c_config)?;
+            // If tree_d still existed and we just deleted it, compact tree_r_last here.
+            ensure!(
+                cached(&t_aux.tree_r_last_config),
+                "TreeRLast does not exist"
+            );
+            let tree_r_last_size = t_aux
+                .tree_r_last_config
+                .size
+                .context("tree_r_last config has no size")?;
+            let mut tree_r_last_store: DiskStore<G::Domain> =
+                DiskStore::new_from_disk(tree_r_last_size, &t_aux.tree_r_last_config)
+                    .context("tree_r_last")?;
+            tree_r_last_store.compact(
+                t_aux.tree_r_last_config.clone(),
+                StoreConfigDataVersion::One as u32,
+            )?;
+        }
+
+        if cached(&t_aux.tree_c_config) {
+            let tree_c_size = t_aux
+                .tree_c_config
+                .size
+                .context("tree_c config has no size")?;
+            let tree_c_store: DiskStore<H::Domain> =
+                DiskStore::new_from_disk(tree_c_size, &t_aux.tree_c_config).context("tree_c")?;
+            let tree_c: Tree<H> =
+                MerkleTree::from_data_store(tree_c_store, get_merkle_tree_leafs(tree_c_size))
+                    .context("tree_c")?;
+            tree_c.delete(t_aux.tree_c_config).context("tree_c")?;
+        }
+
+        if cached(&t_aux.tree_q_config) {
+            let tree_q_size = t_aux
+                .tree_q_config
+                .size
+                .context("tree_q config has no size")?;
+            let tree_q_store: DiskStore<H::Domain> =
+                DiskStore::new_from_disk(tree_q_size, &t_aux.tree_q_config).context("tree_q")?;
+            let tree_q: Tree<H> =
+                MerkleTree::from_data_store(tree_q_store, get_merkle_tree_leafs(tree_q_size))
+                    .context("tree_q")?;
+            tree_q.delete(t_aux.tree_q_config).context("tree_q")?;
+        }
 
         for i in 0..t_aux.labels.labels.len() {
-            DiskStore::<H::Domain>::delete(t_aux.labels.labels[i].clone())?;
+            let cur_config = t_aux.labels.labels[i].clone();
+            if cached(&cur_config) {
+                DiskStore::<H::Domain>::delete(cur_config)
+                    .with_context(|| format!("labels {}", i))?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
~~Happens to be built on top of the mmap params branch~~, but in any case, it's a start of the LevelCacheStore integration where we can compact `tree_r_last` and generate the proofs using partially built trees.