### PR TITLE
Update election_post.rs

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/election_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/election_post.rs
@@ -74,10 +74,9 @@ pub fn run(sector_size: usize) -> anyhow::Result<()> {
 
     // Generate the data from which we will create a replica, we will then prove the continued
     // storage of that replica using the PoSt.
-    let piece_bytes: Vec<u8> = (0..usize::from(sector_size_unpadded_bytes_ammount))
-        .map(|_| rand::random::<u8>())
-        .collect();
-
+    let mut piece_bytes = vec![0u8; usize::from(sector_size_unpadded_bytes_ammount)];
+    rand::Rng::fill(&mut rand::thread_rng(), &mut piece_bytes[..]);
+    
     let mut piece_file = NamedTempFile::new()?;
     piece_file.write_all(&piece_bytes)?;
     piece_file.as_file_mut().sync_all()?;


### PR DESCRIPTION
Improve performance.

Bench code:
```rust
#![feature(test)]

#[cfg(test)]
extern crate test;
extern crate rand;

fn main() {
    const LEN: usize = 256*1024*1024;
    let mut rng = rand::thread_rng();

    println!("random {:?} bytes ...", LEN);

    let now = std::time::Instant::now();
    let mut data: Vec<u8> = vec![0u8; LEN];
    rand::Rng::fill(&mut rng, &mut data[..]);
    println!("fill bytes duration: {:?}ms", now.elapsed().as_millis());

    let now = std::time::Instant::now();
    let data2 = (0..LEN).map(|_| rand::random::<u8>()).collect::<Vec<u8>>();
    println!("collect bytes duration: {:?}ms", now.elapsed().as_millis());
}
```
Output:
```text
random 268435456 bytes ...
fill bytes duration: 23801ms
collect bytes duration: 134430ms
```