### PR TITLE
fix: uom 0.26 needs at least heim 0.0.9

### DIFF
--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -32,7 +32,7 @@ filecoin-proofs = { path = "../filecoin-proofs"}
 tempfile = "3.0.8"
 cpu-time = "1.0.0"
 git2 = "0.10.1"
-heim = "0.0"
+heim = "0.0.9"
 futures-preview = "0.3.0-alpha.17"
 raw-cpuid = "7.0.3"
 blake2s_simd = "0.5.6"


### PR DESCRIPTION
Without using heim version 0.0.9 explicitly, version 0.0.7 will be used implicitly,
which results in a broken build.

The error message prior to this fix is:

```
   Compiling fil-proofs-tooling v0.6.1 (/tmp/rust-fil-proofs/fil-proofs-tooling)
error[E0277]: the trait bound `uom::si::information::byte: uom::si::information::Unit` is not satisfied
   --> fil-proofs-tooling/src/metadata.rs:110:48
    |
110 |             memory_total_bytes: memory.total().get::<uom::si::information::byte>(),
    |                                                ^^^ the trait `uom::si::information::Unit` is not implemented for `uom::si::information::byte`

error[E0277]: the trait bound `uom::si::information::byte: uom::Conversion<u64>` is not satisfied
   --> fil-proofs-tooling/src/metadata.rs:110:48
    |
110 |             memory_total_bytes: memory.total().get::<uom::si::information::byte>(),
    |                                                ^^^ the trait `uom::Conversion<u64>` is not implemented for `uom::si::information::byte`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0277`.
error: could not compile `fil-proofs-tooling`.
warning: build failed, waiting for other jobs to finish...
error: build failed
```