### PR TITLE
Feat/poseidon integration exp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
       - run:
           name: Calculate dependencies
           command: cargo generate-lockfile
+          no_output_timeout: 30m
       - restore_cache:
           keys:
             - cargo-v14-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}

--- a/fil-proofs-tooling/src/bin/benchy/merkleproofs.rs
+++ b/fil-proofs-tooling/src/bin/benchy/merkleproofs.rs
@@ -7,6 +7,7 @@ use rayon::prelude::*;
 use storage_proofs::hasher::{Domain, Hasher, PedersenHasher};
 use storage_proofs::util::NODE_SIZE;
 
+#[allow(clippy::type_complexity)]
 fn generate_tree<R: Rng>(
     rng: &mut R,
     size: usize,
@@ -19,7 +20,7 @@ fn generate_tree<R: Rng>(
 > {
     let el = <PedersenHasher as Hasher>::Domain::random(rng);
     info!("create tree {} KiB", (size * NODE_SIZE) / 1024);
-    MerkleTree::from_par_iter((0..size).into_par_iter().map(|_| el.clone()))
+    MerkleTree::from_par_iter((0..size).into_par_iter().map(|_| el))
 }
 
 pub fn run(size: usize, proofs_count: usize) -> Result<()> {

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -42,4 +42,4 @@ pub const MIN_PIECE_SIZE: UnpaddedBytesAmount = UnpaddedBytesAmount(127);
 /// The hasher used for creating comm_d.
 pub type DefaultPieceHasher = storage_proofs::hasher::Sha256Hasher;
 
-pub use storage_proofs::drgraph::DefaultTreeHasher;
+pub use storage_proofs::drgraph::{DefaultTreeDomain, DefaultTreeHasher};

--- a/filecoin-proofs/src/types/mod.rs
+++ b/filecoin-proofs/src/types/mod.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use storage_proofs::hasher::pedersen::{PedersenDomain, PedersenHasher};
 use storage_proofs::hasher::Hasher;
 use storage_proofs::merkle::MerkleTree;
 use storage_proofs::stacked;
@@ -24,11 +23,17 @@ pub use self::sector_size::*;
 
 pub type Commitment = [u8; 32];
 pub type ChallengeSeed = [u8; 32];
-pub type PersistentAux = stacked::PersistentAux<PedersenDomain>;
-pub type TemporaryAux = stacked::TemporaryAux<PedersenHasher, crate::constants::DefaultPieceHasher>;
+pub type PersistentAux = stacked::PersistentAux<crate::constants::DefaultTreeDomain>;
+pub type TemporaryAux = stacked::TemporaryAux<
+    crate::constants::DefaultTreeHasher,
+    crate::constants::DefaultPieceHasher,
+>;
 pub type ProverId = [u8; 32];
 pub type Ticket = [u8; 32];
-pub type Tree = MerkleTree<PedersenDomain, <PedersenHasher as Hasher>::Function>;
+pub type Tree = MerkleTree<
+    crate::constants::DefaultTreeDomain,
+    <crate::constants::DefaultTreeHasher as Hasher>::Function,
+>;
 
 #[derive(Debug, Clone)]
 pub struct SealPreCommitOutput {

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -54,7 +54,7 @@ generic-array = "0.12"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
 cpu-time = "1.0.0"
-neptune = "0.2.0"
+neptune = { path = "../../neptune" }
 
 [features]
 default = ["gpu"]

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -54,7 +54,7 @@ generic-array = "0.12"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
 cpu-time = "1.0.0"
-neptune = { path = "../../neptune" }
+neptune = "0.2.1"
 
 [features]
 default = ["gpu"]

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -54,7 +54,7 @@ generic-array = "0.12"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
 cpu-time = "1.0.0"
-neptune = "0.2.1"
+neptune = "0.2.3"
 
 [features]
 default = ["gpu"]

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -54,7 +54,7 @@ generic-array = "0.12"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
 cpu-time = "1.0.0"
-gperftools = "0.2.0"
+neptune = "0.2.0"
 
 [features]
 default = ["gpu"]

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -50,11 +50,13 @@ num_cpus = "1.10.1"
 rand_xorshift = "0.2.0"
 rand_chacha = "0.2.1"
 hex = "0.4.0"
-generic-array = "0.12"
+generic-array = "0.13.2"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
 cpu-time = "1.0.0"
-neptune = "0.2.3"
+# neptune = "0.2.3"
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "multiple-arities" }
+
 
 [features]
 default = ["gpu"]

--- a/storage-proofs/src/circuit/election_post.rs
+++ b/storage-proofs/src/circuit/election_post.rs
@@ -20,6 +20,7 @@ use crate::drgraph;
 use crate::election_post::{self, ElectionPoSt};
 use crate::error::Result;
 use crate::fr32::fr_into_bytes;
+use crate::hasher::types::PoseidonEngine;
 use crate::hasher::Hasher;
 use crate::merklepor;
 use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
@@ -179,7 +180,7 @@ where
     }
 }
 
-impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for ElectionPoStCircuit<'a, E, H> {
+impl<'a, E: JubjubEngine + PoseidonEngine, H: Hasher> Circuit<E> for ElectionPoStCircuit<'a, E, H> {
     fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let params = self.params;
         let comm_r = self.comm_r;

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -182,14 +182,11 @@ impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for PoRCircuit<'a, E, H> {
                     &cur_is_right,
                 )?;
 
-                let xl_bits = xl.to_bits_le(cs.namespace(|| "xl into bits"))?;
-                let xr_bits = xr.to_bits_le(cs.namespace(|| "xr into bits"))?;
-
                 // Compute the new subtree value
                 cur = H::Function::hash_leaf_circuit(
                     cs.namespace(|| "computation of pedersen hash"),
-                    &xl_bits,
-                    &xr_bits,
+                    &xl,
+                    &xr,
                     i,
                     params,
                 )?;

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -184,7 +184,7 @@ impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for PoRCircuit<'a, E, H> {
 
                 // Compute the new subtree value
                 cur = H::Function::hash_leaf_circuit(
-                    cs.namespace(|| "computation of pedersen hash"),
+                    cs.namespace(|| "computation of commitment hash"),
                     &xl,
                     &xr,
                     i,
@@ -253,7 +253,7 @@ mod tests {
     use crate::crypto::pedersen::JJ_PARAMS;
     use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::{bytes_into_fr, fr_into_bytes};
-    use crate::hasher::{Blake2sHasher, Domain, Hasher, PedersenHasher};
+    use crate::hasher::{Blake2sHasher, Domain, Hasher, PedersenHasher, PoseidonHasher};
     use crate::merklepor;
     use crate::proof::ProofScheme;
     use crate::util::data_at_node;
@@ -340,6 +340,11 @@ mod tests {
     #[test]
     fn test_por_input_circuit_with_bls12_381_blake2s() {
         test_por_input_circuit_with_bls12_381::<Blake2sHasher>(64566);
+    }
+
+    #[test]
+    fn test_por_input_circuit_with_bls12_381_poseidon() {
+        test_por_input_circuit_with_bls12_381::<PoseidonHasher>(1290);
     }
 
     fn test_por_input_circuit_with_bls12_381<H: Hasher>(num_constraints: usize) {

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -12,6 +12,7 @@ use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::crypto::pedersen::JJ_PARAMS;
 use crate::drgraph::graph_height;
 use crate::error::Result;
+use crate::hasher::types::PoseidonEngine;
 use crate::hasher::{HashFunction, Hasher};
 use crate::merklepor::MerklePoR;
 use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
@@ -128,7 +129,7 @@ where
     }
 }
 
-impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for PoRCircuit<'a, E, H> {
+impl<'a, E: JubjubEngine + PoseidonEngine, H: Hasher> Circuit<E> for PoRCircuit<'a, E, H> {
     /// # Public Inputs
     ///
     /// This circuit expects the following public inputs.
@@ -212,7 +213,7 @@ impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for PoRCircuit<'a, E, H> {
     }
 }
 
-impl<'a, E: JubjubEngine, H: Hasher> PoRCircuit<'a, E, H> {
+impl<'a, E: JubjubEngine + PoseidonEngine, H: Hasher> PoRCircuit<'a, E, H> {
     pub fn synthesize<CS>(
         mut cs: CS,
         params: &E::Params,

--- a/storage-proofs/src/circuit/rational_post.rs
+++ b/storage-proofs/src/circuit/rational_post.rs
@@ -14,6 +14,7 @@ use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::crypto::pedersen::JJ_PARAMS;
 use crate::drgraph;
 use crate::error::Result;
+use crate::hasher::types::PoseidonEngine;
 use crate::hasher::Hasher;
 use crate::merklepor;
 use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
@@ -160,7 +161,7 @@ where
     }
 }
 
-impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for RationalPoStCircuit<'a, E, H> {
+impl<'a, E: JubjubEngine + PoseidonEngine, H: Hasher> Circuit<E> for RationalPoStCircuit<'a, E, H> {
     fn synthesize<CS: ConstraintSystem<E>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let params = self.params;
         let comm_rs = self.comm_rs;
@@ -243,7 +244,7 @@ impl<'a, E: JubjubEngine, H: Hasher> Circuit<E> for RationalPoStCircuit<'a, E, H
     }
 }
 
-impl<'a, E: JubjubEngine, H: Hasher> RationalPoStCircuit<'a, E, H> {
+impl<'a, E: JubjubEngine + PoseidonEngine, H: Hasher> RationalPoStCircuit<'a, E, H> {
     #[allow(clippy::type_complexity)]
     pub fn synthesize<CS: ConstraintSystem<E>>(
         cs: &mut CS,

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -8,14 +8,15 @@ use sha2::{Digest, Sha256};
 
 use crate::error::*;
 use crate::fr32::bytes_into_fr_repr_safe;
-use crate::hasher::pedersen::PedersenHasher;
+use crate::hasher::poseidon::PoseidonHasher;
 use crate::hasher::Hasher;
 use crate::merkle::{create_merkle_tree, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node_offset, NODE_SIZE};
 
 /// The default hasher currently in use.
-pub type DefaultTreeHasher = PedersenHasher;
+pub type DefaultTreeHasher = PoseidonHasher;
+pub type DefaultTreeDomain = <DefaultTreeHasher as Hasher>::Domain;
 
 pub const PARALLEL_MERKLE: bool = true;
 
@@ -232,7 +233,7 @@ mod tests {
     use memmap::MmapOptions;
 
     use crate::drgraph::new_seed;
-    use crate::hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher};
+    use crate::hasher::{Blake2sHasher, PedersenHasher, PoseidonHasher, Sha256Hasher};
 
     // Create and return an object of MmapMut backed by in-memory copy of data.
     pub fn mmap_from(data: &[u8]) -> MmapMut {
@@ -310,6 +311,11 @@ mod tests {
     #[test]
     fn gen_proof_pedersen() {
         gen_proof::<PedersenHasher>();
+    }
+
+    #[test]
+    fn gen_proof_poseidon() {
+        gen_proof::<PoseidonHasher>();
     }
 
     #[test]

--- a/storage-proofs/src/hasher/blake2s.rs
+++ b/storage-proofs/src/hasher/blake2s.rs
@@ -214,7 +214,7 @@ impl HashFunction<Blake2sDomain> for Blake2sFunction {
             .into()
     }
 
-    fn hash_leaf_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+    fn hash_leaf_bits_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
         cs: CS,
         left: &[boolean::Boolean],
         right: &[boolean::Boolean],

--- a/storage-proofs/src/hasher/mod.rs
+++ b/storage-proofs/src/hasher/mod.rs
@@ -1,5 +1,6 @@
 pub mod blake2s;
 pub mod pedersen;
+pub mod poseidon;
 pub mod sha256;
 
 mod types;
@@ -8,4 +9,5 @@ pub use self::types::{Domain, HashFunction, Hasher};
 
 pub use self::blake2s::Blake2sHasher;
 pub use self::pedersen::PedersenHasher;
+pub use self::poseidon::PoseidonHasher;
 pub use self::sha256::Sha256Hasher;

--- a/storage-proofs/src/hasher/mod.rs
+++ b/storage-proofs/src/hasher/mod.rs
@@ -3,7 +3,7 @@ pub mod pedersen;
 pub mod poseidon;
 pub mod sha256;
 
-mod types;
+pub mod types;
 
 pub use self::types::{Domain, HashFunction, Hasher};
 

--- a/storage-proofs/src/hasher/pedersen.rs
+++ b/storage-proofs/src/hasher/pedersen.rs
@@ -211,7 +211,7 @@ impl HashFunction<PedersenDomain> for PedersenFunction {
         pedersen::pedersen_md_no_padding(data).into()
     }
 
-    fn hash_leaf_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+    fn hash_leaf_bits_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
         cs: CS,
         left: &[boolean::Boolean],
         right: &[boolean::Boolean],

--- a/storage-proofs/src/hasher/poseidon.rs
+++ b/storage-proofs/src/hasher/poseidon.rs
@@ -3,7 +3,7 @@ use std::hash::Hasher as StdHasher;
 use super::types::MERKLE_TREE_ARITY;
 use crate::crypto::{create_label, sloth};
 use crate::error::{Error, Result};
-use crate::hasher::types::{PoseidonEngine, POSEIDON_CONSTANTS};
+use crate::hasher::types::{PoseidonEngine, PoseidonWidth, POSEIDON_CONSTANTS};
 use crate::hasher::{Domain, HashFunction, Hasher};
 use anyhow::ensure;
 use bellperson::gadgets::{boolean, num};
@@ -237,7 +237,7 @@ impl HashFunction<PoseidonDomain> for PoseidonFunction {
     ) -> ::std::result::Result<num::AllocatedNum<E>, SynthesisError> {
         let preimage = vec![left.clone(), right.clone()];
 
-        poseidon_hash::<CS, E>(cs, preimage, E::PARAMETERS(MERKLE_TREE_ARITY))
+        poseidon_hash::<CS, E, PoseidonWidth>(cs, preimage, E::PARAMETERS(MERKLE_TREE_ARITY))
     }
 
     fn hash_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
@@ -322,6 +322,13 @@ mod tests {
         assert_eq!(*p.path(), vec![true, true]);
         assert_eq!(p.validate::<PoseidonFunction>(), true);
     }
+
+    // #[test]
+    // fn test_poseidon_quad() {
+    //     let leaves = [Fr::one(), Fr::zero(), Fr::zero(), Fr::one()];
+
+    //     assert_eq!(Fr::zero().into_repr(), shared_hash_frs(&leaves[..]).0);
+    // }
 
     #[test]
     fn test_poseidon_hasher() {

--- a/storage-proofs/src/hasher/poseidon.rs
+++ b/storage-proofs/src/hasher/poseidon.rs
@@ -1,0 +1,424 @@
+use std::hash::Hasher as StdHasher;
+
+use crate::crypto::{create_label, sloth};
+use crate::error::{Error, Result};
+use crate::hasher::{Domain, HashFunction, Hasher};
+use anyhow::ensure;
+use bellperson::gadgets::{boolean, num};
+use bellperson::{ConstraintSystem, SynthesisError};
+use ff::{Field, PrimeField, PrimeFieldRepr, ScalarEngine};
+use fil_sapling_crypto::jubjub::JubjubEngine;
+use merkletree::hash::{Algorithm as LightAlgorithm, Hashable};
+use merkletree::merkle::Element;
+use neptune::circuit::poseidon_hash_simple;
+use neptune::poseidon::poseidon;
+use paired::bls12_381::{Bls12, Fr, FrRepr};
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PoseidonHasher {}
+
+impl Hasher for PoseidonHasher {
+    type Domain = PoseidonDomain;
+    type Function = PoseidonFunction;
+
+    fn name() -> String {
+        "PoseidonHasher".into()
+    }
+
+    fn create_label(data: &[u8], m: usize) -> Result<Self::Domain> {
+        Ok(create_label::create_label(data, m)?.into())
+    }
+
+    #[inline]
+    fn sloth_encode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain> {
+        // Unrapping here is safe; `Fr` elements and hash domain elements are the same byte length.
+        let key = Fr::from_repr(key.0)?;
+        let ciphertext = Fr::from_repr(ciphertext.0)?;
+        Ok(sloth::encode::<Bls12>(&key, &ciphertext).into())
+    }
+
+    #[inline]
+    fn sloth_decode(key: &Self::Domain, ciphertext: &Self::Domain) -> Result<Self::Domain> {
+        // Unrapping here is safe; `Fr` elements and hash domain elements are the same byte length.
+        let key = Fr::from_repr(key.0)?;
+        let ciphertext = Fr::from_repr(ciphertext.0)?;
+
+        Ok(sloth::decode::<Bls12>(&key, &ciphertext).into())
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct PoseidonFunction(Fr);
+
+impl Default for PoseidonFunction {
+    fn default() -> PoseidonFunction {
+        PoseidonFunction(Fr::from_repr(FrRepr::default()).expect("failed default"))
+    }
+}
+
+impl Hashable<PoseidonFunction> for Fr {
+    fn hash(&self, state: &mut PoseidonFunction) {
+        let mut bytes = Vec::with_capacity(32);
+        self.into_repr().write_le(&mut bytes).unwrap();
+        state.write(&bytes);
+    }
+}
+
+impl Hashable<PoseidonFunction> for PoseidonDomain {
+    fn hash(&self, state: &mut PoseidonFunction) {
+        let mut bytes = Vec::with_capacity(32);
+        self.0
+            .write_le(&mut bytes)
+            .expect("Failed to write `FrRepr`");
+        state.write(&bytes);
+    }
+}
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+pub struct PoseidonDomain(pub FrRepr);
+
+impl AsRef<PoseidonDomain> for PoseidonDomain {
+    fn as_ref(&self) -> &PoseidonDomain {
+        self
+    }
+}
+
+impl std::hash::Hash for PoseidonDomain {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let raw: &[u64] = self.0.as_ref();
+        std::hash::Hash::hash(raw, state);
+    }
+}
+
+impl PartialEq for PoseidonDomain {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.as_ref() == other.0.as_ref()
+    }
+}
+
+impl Eq for PoseidonDomain {}
+
+impl Default for PoseidonDomain {
+    fn default() -> PoseidonDomain {
+        PoseidonDomain(FrRepr::default())
+    }
+}
+
+impl Ord for PoseidonDomain {
+    #[inline(always)]
+    fn cmp(&self, other: &PoseidonDomain) -> ::std::cmp::Ordering {
+        (self.0).cmp(&other.0)
+    }
+}
+
+impl PartialOrd for PoseidonDomain {
+    #[inline(always)]
+    fn partial_cmp(&self, other: &PoseidonDomain) -> Option<::std::cmp::Ordering> {
+        Some((self.0).cmp(&other.0))
+    }
+}
+
+impl AsRef<[u8]> for PoseidonDomain {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        as_ref(&(self.0).0)
+    }
+}
+
+// This is unsafe, and I wish it wasn't here, but I really need AsRef<[u8]> to work, without allocating.
+// https://internals.rust-lang.org/t/safe-trasnsmute-for-slices-e-g-u64-u32-particularly-simd-types/2871
+// https://github.com/briansmith/ring/blob/abb3fdfc08562f3f02e95fb551604a871fd4195e/src/polyfill.rs#L93-L110
+#[inline(always)]
+#[allow(clippy::needless_lifetimes)]
+fn as_ref<'a>(src: &'a [u64; 4]) -> &'a [u8] {
+    unsafe {
+        std::slice::from_raw_parts(
+            src.as_ptr() as *const u8,
+            src.len() * std::mem::size_of::<u64>(),
+        )
+    }
+}
+
+impl Domain for PoseidonDomain {
+    // QUESTION: When, if ever, should serialize and into_bytes return different results?
+    // The definitions here at least are equivalent.
+    // I'm taking one step toward resolving this by formalizing that equivalence while copying this base implementation from perdersen.rs. -porcuquine.
+    fn serialize(&self) -> Vec<u8> {
+        self.into_bytes()
+    }
+
+    fn into_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(PoseidonDomain::byte_len());
+        self.0.write_le(&mut out).unwrap();
+
+        out
+    }
+
+    fn try_from_bytes(raw: &[u8]) -> Result<Self> {
+        ensure!(raw.len() == PoseidonDomain::byte_len(), Error::BadFrBytes);
+        let mut res: FrRepr = Default::default();
+        res.read_le(raw)?;
+
+        Ok(PoseidonDomain(res))
+    }
+
+    fn write_bytes(&self, dest: &mut [u8]) -> Result<()> {
+        self.0.write_le(dest)?;
+        Ok(())
+    }
+
+    fn random<R: rand::RngCore>(rng: &mut R) -> Self {
+        // generating an Fr and converting it, to ensure we stay in the field
+        Fr::random(rng).into()
+    }
+}
+
+impl Element for PoseidonDomain {
+    fn byte_len() -> usize {
+        32
+    }
+
+    fn from_slice(bytes: &[u8]) -> Self {
+        match PoseidonDomain::try_from_bytes(bytes) {
+            Ok(res) => res,
+            Err(err) => panic!(err),
+        }
+    }
+
+    fn copy_to_slice(&self, bytes: &mut [u8]) {
+        bytes.copy_from_slice(&self.into_bytes());
+    }
+}
+
+impl StdHasher for PoseidonFunction {
+    #[inline]
+    fn write(&mut self, msg: &[u8]) {
+        self.0 = Fr::from_repr(poseidon_hash(msg).0).unwrap();
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        unimplemented!()
+    }
+}
+
+fn poseidon_hash(data: &[u8]) -> PoseidonDomain {
+    // FIXME: We shouldn't unwrap here, but doing otherwise will require an interface change.
+    // We could truncate so `bytes_into_frs` cannot fail, then ensure `data` is always `fr_safe`.
+    let preimage = data
+        .chunks(32)
+        .map(|ref chunk| {
+            <Bls12 as ff::ScalarEngine>::Fr::from_repr(PoseidonDomain::from_slice(chunk).0).unwrap()
+        })
+        .collect::<Vec<_>>();
+
+    let fr: <Bls12 as ScalarEngine>::Fr = poseidon::<Bls12>(&preimage);
+    fr.into()
+}
+
+impl HashFunction<PoseidonDomain> for PoseidonFunction {
+    //fn hash<E: JubjubEngine>(data: &[u8]) -> PoseidonDomain {
+    fn hash(data: &[u8]) -> PoseidonDomain {
+        poseidon_hash(data)
+    }
+
+    fn hash_leaf_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        cs: CS,
+        left: &num::AllocatedNum<E>,
+        right: &num::AllocatedNum<E>,
+        _height: usize,
+        _params: &E::Params,
+    ) -> ::std::result::Result<num::AllocatedNum<E>, SynthesisError> {
+        let preimage = vec![left.clone(), right.clone()];
+
+        poseidon_hash_simple::<CS, E>(cs, preimage)
+    }
+
+    fn hash_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        _cs: CS,
+        _bits: &[boolean::Boolean],
+        _params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
+        unimplemented!();
+    }
+}
+
+impl LightAlgorithm<PoseidonDomain> for PoseidonFunction {
+    #[inline]
+    fn hash(&mut self) -> PoseidonDomain {
+        self.0.into()
+    }
+
+    #[inline]
+    fn reset(&mut self) {
+        self.0 = Fr::from_repr(FrRepr::from(0)).expect("failed 0");
+    }
+
+    fn leaf(&mut self, leaf: PoseidonDomain) -> PoseidonDomain {
+        leaf
+    }
+
+    fn node(
+        &mut self,
+        left: PoseidonDomain,
+        right: PoseidonDomain,
+        _height: usize,
+    ) -> PoseidonDomain {
+        PoseidonDomain(
+            poseidon::<Bls12>(&[
+                <Bls12 as ff::ScalarEngine>::Fr::from_repr(left.0).unwrap(),
+                <Bls12 as ff::ScalarEngine>::Fr::from_repr(right.0).unwrap(),
+            ])
+            .into(),
+        )
+    }
+}
+
+impl From<Fr> for PoseidonDomain {
+    #[inline]
+    fn from(val: Fr) -> Self {
+        PoseidonDomain(val.into_repr())
+    }
+}
+
+impl From<FrRepr> for PoseidonDomain {
+    #[inline]
+    fn from(val: FrRepr) -> Self {
+        PoseidonDomain(val)
+    }
+}
+
+impl From<PoseidonDomain> for Fr {
+    #[inline]
+    fn from(val: PoseidonDomain) -> Self {
+        Fr::from_repr(val.0).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::mem;
+
+    use merkletree::hash::Hashable;
+
+    use crate::merkle::MerkleTree;
+
+    #[test]
+    fn test_path() {
+        let values = [
+            PoseidonDomain(Fr::one().into_repr()),
+            PoseidonDomain(Fr::one().into_repr()),
+            PoseidonDomain(Fr::one().into_repr()),
+            PoseidonDomain(Fr::one().into_repr()),
+        ];
+
+        let t =
+            MerkleTree::<PoseidonDomain, PoseidonFunction>::new(values.iter().map(|x| *x)).unwrap();
+
+        let p = t.gen_proof(0).unwrap(); // create a proof for the first value =k Fr::one()
+
+        assert_eq!(*p.path(), vec![true, true]);
+        assert_eq!(p.validate::<PoseidonFunction>(), true);
+    }
+
+    #[test]
+    fn test_poseidon_hasher() {
+        let leaves = [
+            PoseidonDomain(Fr::one().into_repr()),
+            PoseidonDomain(Fr::zero().into_repr()),
+            PoseidonDomain(Fr::zero().into_repr()),
+            PoseidonDomain(Fr::one().into_repr()),
+        ];
+
+        let t =
+            MerkleTree::<PoseidonDomain, PoseidonFunction>::new(leaves.iter().map(|x| *x)).unwrap();
+
+        assert_eq!(t.leafs(), 4);
+
+        let mut a = PoseidonFunction::default();
+
+        assert_eq!(t.read_at(0).unwrap(), leaves[0]);
+        assert_eq!(t.read_at(1).unwrap(), leaves[1]);
+        assert_eq!(t.read_at(2).unwrap(), leaves[2]);
+        assert_eq!(t.read_at(3).unwrap(), leaves[3]);
+
+        let i1 = a.node(leaves[0], leaves[1], 0);
+        a.reset();
+        let i2 = a.node(leaves[2], leaves[3], 0);
+        a.reset();
+
+        assert_eq!(t.read_at(4).unwrap(), i1);
+        assert_eq!(t.read_at(5).unwrap(), i2);
+
+        let root = a.node(i1, i2, 1);
+        a.reset();
+
+        assert_eq!(
+            t.read_at(4).unwrap().0,
+            FrRepr([
+                0x27667a53c9973ad5,
+                0x7e0295caba457e67,
+                0xa20c36b1b4f719a8,
+                0x25b81b8c404581d5
+            ])
+        );
+
+        let expected = FrRepr([
+            0x15f039c35270cef7,
+            0x66b6af463d76d9f6,
+            0x10b959b9478c32c7,
+            0x681da1446cf7b965,
+        ]);
+        let actual = t.read_at(6).unwrap().0;
+
+        assert_eq!(actual, expected);
+        assert_eq!(t.read_at(6).unwrap(), root);
+    }
+
+    #[test]
+    fn test_as_ref() {
+        let cases: Vec<[u64; 4]> = vec![
+            [0, 0, 0, 0],
+            [
+                14963070332212552755,
+                2414807501862983188,
+                16116531553419129213,
+                6357427774790868134,
+            ],
+        ];
+
+        for case in cases.into_iter() {
+            let repr = FrRepr(case);
+            let val = PoseidonDomain(repr);
+
+            for _ in 0..100 {
+                assert_eq!(val.into_bytes(), val.into_bytes());
+            }
+
+            let raw: &[u8] = val.as_ref();
+
+            for i in 0..4 {
+                assert_eq!(case[i], unsafe {
+                    let mut val = [0u8; 8];
+                    val.clone_from_slice(&raw[i * 8..(i + 1) * 8]);
+                    mem::transmute::<[u8; 8], u64>(val)
+                });
+            }
+        }
+    }
+
+    #[test]
+    fn test_serialize() {
+        let repr = FrRepr([1, 2, 3, 4]);
+        let val = PoseidonDomain(repr);
+
+        let ser = serde_json::to_string(&val)
+            .expect("Failed to serialize `PoseidonDomain` element to JSON string");
+        let val_back = serde_json::from_str(&ser)
+            .expect("Failed to deserialize JSON string to `PoseidonnDomain`");
+
+        assert_eq!(val, val_back);
+    }
+}

--- a/storage-proofs/src/hasher/poseidon.rs
+++ b/storage-proofs/src/hasher/poseidon.rs
@@ -358,18 +358,18 @@ mod tests {
         assert_eq!(
             t.read_at(4).unwrap().0,
             FrRepr([
-                0x27667a53c9973ad5,
-                0x7e0295caba457e67,
-                0xa20c36b1b4f719a8,
-                0x25b81b8c404581d5
+                0x86c43967576d8144,
+                0x02764fedd83eccdc,
+                0x8cf0fb1d8b18939c,
+                0x43c0481c01004590
             ])
         );
 
         let expected = FrRepr([
-            0x15f039c35270cef7,
-            0x66b6af463d76d9f6,
-            0x10b959b9478c32c7,
-            0x681da1446cf7b965,
+            0x1de61734210b19f0,
+            0x5fdd9de9aeba506d,
+            0x3132a2fdf41b894f,
+            0x5ed726de4d7e79d3,
         ]);
         let actual = t.read_at(6).unwrap().0;
 

--- a/storage-proofs/src/hasher/sha256.rs
+++ b/storage-proofs/src/hasher/sha256.rs
@@ -180,7 +180,7 @@ impl HashFunction<Sha256Domain> for Sha256Function {
         res
     }
 
-    fn hash_leaf_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+    fn hash_leaf_bits_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
         cs: CS,
         left: &[boolean::Boolean],
         right: &[boolean::Boolean],
@@ -302,7 +302,7 @@ mod tests {
     use rand_xorshift::XorShiftRng;
 
     #[test]
-    fn hash_leaf_circuit() {
+    fn hash_leaf_bits_circuit() {
         let mut cs = TestConstraintSystem::<Bls12>::new();
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
@@ -322,7 +322,7 @@ mod tests {
             bytes_into_boolean_vec(&mut cs, Some(right.as_slice()), 256).unwrap()
         };
 
-        let out = Sha256Function::hash_leaf_circuit(
+        let out = Sha256Function::hash_leaf_bits_circuit(
             cs.namespace(|| "hash_leaf_circuit"),
             &left_bits,
             &right_bits,

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -9,6 +9,9 @@ use serde::ser::Serialize;
 
 use crate::error::Result;
 
+/// Arity to use for hasher implementations (Poseidon) which are specialized at compile time.
+pub const MERKLE_TREE_ARITY: usize = 2;
+
 pub trait Domain:
     Ord
     + Copy

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -55,6 +55,19 @@ pub trait HashFunction<T: Domain>:
     }
 
     fn hash_leaf_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
+        mut cs: CS,
+        left: &num::AllocatedNum<E>,
+        right: &num::AllocatedNum<E>,
+        height: usize,
+        params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
+        let left_bits = left.to_bits_le(cs.namespace(|| "left num into bits"))?;
+        let right_bits = right.to_bits_le(cs.namespace(|| "right num into bits"))?;
+
+        Self::hash_leaf_bits_circuit(cs, &left_bits, &right_bits, height, params)
+    }
+
+    fn hash_leaf_bits_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
         cs: CS,
         left: &[boolean::Boolean],
         right: &[boolean::Boolean],

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -68,12 +68,14 @@ pub trait HashFunction<T: Domain>:
     }
 
     fn hash_leaf_bits_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
-        cs: CS,
-        left: &[boolean::Boolean],
-        right: &[boolean::Boolean],
-        height: usize,
-        params: &E::Params,
-    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError>;
+        _cs: CS,
+        _left: &[boolean::Boolean],
+        _right: &[boolean::Boolean],
+        _height: usize,
+        _params: &E::Params,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
+        unimplemented!();
+    }
 
     fn hash_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
         cs: CS,

--- a/storage-proofs/src/parameter_cache.rs
+++ b/storage-proofs/src/parameter_cache.rs
@@ -17,7 +17,7 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 /// Bump this when circuits change to invalidate the cache.
-pub const VERSION: usize = 21;
+pub const VERSION: usize = 22;
 
 pub const PARAMETER_CACHE_ENV_VAR: &str = "FIL_PROOFS_PARAMETER_CACHE";
 pub const PARAMETER_CACHE_DIR: &str = "/var/tmp/filecoin-proof-parameters/";

--- a/storage-proofs/src/stacked/proof.rs
+++ b/storage-proofs/src/stacked/proof.rs
@@ -536,6 +536,7 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
         Ok(labels)
     }
 
+    #[allow(clippy::type_complexity)]
     /// Phase2 of replication.
     pub fn replicate_phase2(
         pp: &'a PublicParams<H>,


### PR DESCRIPTION
This integrates `neptune` (our Poseidon library) and implements the `Hasher` trait. Tests pass for me locally. I tried to run `benchy flarp`, but it seems to just hang. However, that's the same behavior I see without these changes, so I think I just don't know to run it.

This should give much better SNARK size (fewer constraints), as can be seen in these `por.rs` tests:
```
    #[test]
    fn test_por_input_circuit_with_bls12_381_pedersen() {
        test_por_input_circuit_with_bls12_381::<PedersenHasher>(4125);
    }

    #[test]
    fn test_por_input_circuit_with_bls12_381_blake2s() {
        test_por_input_circuit_with_bls12_381::<Blake2sHasher>(64566);
    }

    #[test]
    fn test_por_input_circuit_with_bls12_381_poseidon() {
        test_por_input_circuit_with_bls12_381::<PoseidonHasher>(1290);
    }
```

I expect non-circuit hashing performance to be worse for now, and improving it is a non-goal of this integration step.

NOTE: CI is failing to generate groth parameters and killing the job, even after I increased the timeout to 30 minutes. I don't know what's up with that.