### PR TITLE
fix: unify hash handling and fix up tests

### DIFF
--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, ensure, Context, Result};
 use merkletree::store::{StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};
-use storage_proofs::drgraph::DefaultTreeHasher;
 use storage_proofs::hasher::Hasher;
 use storage_proofs::porep::PoRep;
 use storage_proofs::sector::SectorId;
@@ -13,7 +12,7 @@ use tempfile::tempfile;
 
 use crate::api::util::as_safe_commitment;
 use crate::constants::{
-    DefaultPieceHasher,
+    DefaultPieceHasher, DefaultTreeHasher,
     MINIMUM_RESERVED_BYTES_FOR_PIECE_IN_FULLY_ALIGNED_SECTOR as MINIMUM_PIECE_SIZE,
 };
 use crate::fr32::{write_padded, write_unpadded};

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -13,7 +13,6 @@ use rayon::prelude::*;
 use storage_proofs::circuit::election_post::ElectionPoStCompound;
 use storage_proofs::circuit::multi_proof::MultiProof;
 use storage_proofs::compound_proof::{self, CompoundProof};
-use storage_proofs::drgraph::DefaultTreeHasher;
 use storage_proofs::election_post;
 use storage_proofs::fr32::bytes_into_fr;
 use storage_proofs::hasher::Hasher;
@@ -23,6 +22,7 @@ use storage_proofs::stacked::CacheKey;
 
 use crate::api::util::as_safe_commitment;
 use crate::caches::{get_post_params, get_post_verifying_key};
+use crate::constants::DefaultTreeHasher;
 use crate::parameters::post_setup_params;
 use crate::types::{
     ChallengeSeed, Commitment, PersistentAux, PoStConfig, ProverId, SectorSize, Tree,

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -12,7 +12,7 @@ use paired::bls12_381::{Bls12, Fr};
 use storage_proofs::circuit::multi_proof::MultiProof;
 use storage_proofs::circuit::stacked::StackedCompound;
 use storage_proofs::compound_proof::{self, CompoundProof};
-use storage_proofs::drgraph::{DefaultTreeHasher, Graph};
+use storage_proofs::drgraph::Graph;
 use storage_proofs::hasher::{Domain, Hasher};
 use storage_proofs::measurements::{measure_op, Operation::CommD};
 use storage_proofs::merkle::create_merkle_tree;
@@ -25,7 +25,9 @@ use storage_proofs::stacked::{
 
 use crate::api::util::{as_safe_commitment, commitment_from_fr};
 use crate::caches::{get_stacked_params, get_stacked_verifying_key};
-use crate::constants::{DefaultPieceHasher, POREP_MINIMUM_CHALLENGES, SINGLE_PARTITION_PROOF_LEN};
+use crate::constants::{
+    DefaultPieceHasher, DefaultTreeHasher, POREP_MINIMUM_CHALLENGES, SINGLE_PARTITION_PROOF_LEN,
+};
 use crate::parameters::setup_params;
 pub use crate::pieces;
 pub use crate::pieces::verify_pieces;

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -11,11 +11,10 @@ use storage_proofs::circuit::election_post::ElectionPoStCircuit;
 use storage_proofs::circuit::election_post::ElectionPoStCompound;
 use storage_proofs::circuit::stacked::StackedCompound;
 use storage_proofs::compound_proof::CompoundProof;
-use storage_proofs::drgraph::DefaultTreeHasher;
 use storage_proofs::election_post::ElectionPoSt;
 use storage_proofs::stacked::StackedDrg;
 
-use crate::constants::DefaultPieceHasher;
+use crate::constants::{DefaultPieceHasher, DefaultTreeHasher};
 use crate::parameters::{post_public_params, public_params};
 use crate::types::*;
 

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -42,4 +42,4 @@ pub const MIN_PIECE_SIZE: UnpaddedBytesAmount = UnpaddedBytesAmount(127);
 /// The hasher used for creating comm_d.
 pub type DefaultPieceHasher = storage_proofs::hasher::Sha256Hasher;
 
-pub use storage_proofs::drgraph::{DefaultTreeDomain, DefaultTreeHasher};
+pub use storage_proofs::hasher::{DefaultTreeDomain, DefaultTreeHashFunction, DefaultTreeHasher};

--- a/filecoin-proofs/src/parameters.rs
+++ b/filecoin-proofs/src/parameters.rs
@@ -1,13 +1,12 @@
 use std::sync::atomic::Ordering;
 
 use anyhow::{ensure, Result};
-use storage_proofs::drgraph::DefaultTreeHasher;
 use storage_proofs::election_post::{self, ElectionPoSt};
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::stacked::{self, LayerChallenges, StackedDrg};
 
 use crate::constants::{
-    DefaultPieceHasher, DRG_DEGREE, EXP_DEGREE, LAYERS, POREP_MINIMUM_CHALLENGES,
+    DefaultPieceHasher, DefaultTreeHasher, DRG_DEGREE, EXP_DEGREE, LAYERS, POREP_MINIMUM_CHALLENGES,
 };
 use crate::types::{PaddedBytesAmount, PoStConfig};
 

--- a/filecoin-proofs/src/types/porep_config.rs
+++ b/filecoin-proofs/src/types/porep_config.rs
@@ -4,10 +4,9 @@ use anyhow::Result;
 
 use paired::bls12_381::Bls12;
 use storage_proofs::circuit::stacked::{StackedCircuit, StackedCompound};
-use storage_proofs::drgraph::DefaultTreeHasher;
 use storage_proofs::parameter_cache::{self, CacheableParameters};
 
-use crate::constants::DefaultPieceHasher;
+use crate::constants::{DefaultPieceHasher, DefaultTreeHasher};
 use crate::types::*;
 
 #[derive(Clone, Copy, Debug)]

--- a/filecoin-proofs/src/types/post_config.rs
+++ b/filecoin-proofs/src/types/post_config.rs
@@ -4,9 +4,9 @@ use anyhow::Result;
 
 use paired::bls12_381::Bls12;
 use storage_proofs::circuit::election_post::{ElectionPoStCircuit, ElectionPoStCompound};
-use storage_proofs::drgraph::DefaultTreeHasher;
 use storage_proofs::parameter_cache::{self, CacheableParameters};
 
+use crate::constants::DefaultTreeHasher;
 use crate::types::*;
 
 #[derive(Clone, Copy, Debug)]

--- a/storage-proofs/src/circuit/drgporep.rs
+++ b/storage-proofs/src/circuit/drgporep.rs
@@ -662,7 +662,7 @@ mod tests {
 
         assert!(cs.is_satisfied(), "constraints not satisfied");
         assert_eq!(cs.num_inputs(), 18, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 149607, "wrong number of constraints");
+        assert_eq!(cs.num_constraints(), 149_703, "wrong number of constraints");
 
         assert_eq!(cs.get_input(0, "ONE"), Fr::one());
 
@@ -719,7 +719,7 @@ mod tests {
         .expect("failed to synthesize circuit");
 
         assert_eq!(cs.num_inputs(), 18, "wrong number of inputs");
-        assert_eq!(cs.num_constraints(), 380439, "wrong number of constraints");
+        assert_eq!(cs.num_constraints(), 381_039, "wrong number of constraints");
     }
 
     #[test]

--- a/storage-proofs/src/circuit/por.rs
+++ b/storage-proofs/src/circuit/por.rs
@@ -186,10 +186,10 @@ impl<'a, E: JubjubEngine + PoseidonEngine, H: Hasher> Circuit<E> for PoRCircuit<
                 // Compute the new subtree value
                 cur = H::Function::hash_leaf_circuit(
                     cs.namespace(|| "computation of commitment hash"),
+                    params,
+                    Some(i),
                     &xl,
                     &xr,
-                    i,
-                    params,
                 )?;
                 auth_path_bits.push(cur_is_right);
             }
@@ -335,7 +335,7 @@ mod tests {
 
     #[test]
     fn test_por_input_circuit_with_bls12_381_pedersen() {
-        test_por_input_circuit_with_bls12_381::<PedersenHasher>(4125);
+        test_por_input_circuit_with_bls12_381::<PedersenHasher>(4134);
     }
 
     #[test]
@@ -592,7 +592,7 @@ mod tests {
             assert!(cs.is_satisfied(), "constraints not satisfied");
 
             assert_eq!(cs.num_inputs(), 2, "wrong number of inputs");
-            assert_eq!(cs.num_constraints(), 4124, "wrong number of constraints");
+            assert_eq!(cs.num_constraints(), 4133, "wrong number of constraints");
 
             let auth_path_bits: Vec<bool> = proof
                 .proof

--- a/storage-proofs/src/circuit/stacked/hash.rs
+++ b/storage-proofs/src/circuit/stacked/hash.rs
@@ -4,61 +4,8 @@ use bellperson::gadgets::{
     {multipack, num},
 };
 use bellperson::{ConstraintSystem, SynthesisError};
-use ff::{Field, PrimeField};
+use ff::PrimeField;
 use fil_sapling_crypto::jubjub::JubjubEngine;
-
-use crate::circuit::pedersen::{pedersen_compression_num as pedersen, pedersen_md_no_padding};
-use crate::crypto::pedersen::PEDERSEN_BLOCK_SIZE;
-
-/// Hash two elements together.
-pub fn hash2<E, CS>(
-    mut cs: CS,
-    params: &E::Params,
-    first: &[Boolean],
-    second: &[Boolean],
-) -> Result<num::AllocatedNum<E>, SynthesisError>
-where
-    E: JubjubEngine,
-    CS: ConstraintSystem<E>,
-{
-    let mut values = Vec::new();
-    values.extend_from_slice(first);
-
-    // pad to full bytes
-    while values.len() % 8 > 0 {
-        values.push(Boolean::Constant(false));
-    }
-
-    values.extend_from_slice(second);
-    // pad to full bytes
-    while values.len() % 8 > 0 {
-        values.push(Boolean::Constant(false));
-    }
-
-    hash1(cs.namespace(|| "hash2"), params, &values)
-}
-
-/// Hash a list of bits.
-pub fn hash1<E, CS>(
-    mut cs: CS,
-    params: &E::Params,
-    values: &[Boolean],
-) -> Result<num::AllocatedNum<E>, SynthesisError>
-where
-    E: JubjubEngine,
-    CS: ConstraintSystem<E>,
-{
-    assert!(values.len() % 32 == 0, "input must be a multiple of 32bits");
-
-    if values.is_empty() {
-        // can happen with small layers
-        num::AllocatedNum::alloc(cs.namespace(|| "hash1"), || Ok(E::Fr::zero()))
-    } else if values.len() > PEDERSEN_BLOCK_SIZE {
-        pedersen_md_no_padding(cs.namespace(|| "hash1"), params, values)
-    } else {
-        pedersen(cs.namespace(|| "hash1"), params, values)
-    }
-}
 
 /// Hash a list of bits.
 pub fn hash_single_column<E, CS>(
@@ -121,8 +68,8 @@ where
 mod tests {
     use super::*;
 
-    use bellperson::gadgets::boolean::Boolean;
     use bellperson::ConstraintSystem;
+    use ff::Field;
     use paired::bls12_381::{Bls12, Fr};
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
@@ -130,10 +77,8 @@ mod tests {
     use crate::circuit::test::TestConstraintSystem;
     use crate::crypto::pedersen::JJ_PARAMS;
     use crate::fr32::fr_into_bytes;
-    use crate::stacked::hash::{
-        hash2 as vanilla_hash2, hash_single_column as vanilla_hash_single_column,
-    };
-    use crate::util::bytes_into_boolean_vec;
+    use crate::hasher::{pedersen::*, HashFunction};
+    use crate::stacked::hash::hash_single_column as vanilla_hash_single_column;
 
     #[test]
     fn test_hash2_circuit() {
@@ -142,26 +87,34 @@ mod tests {
         for _ in 0..10 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a_bytes = fr_into_bytes::<Bls12>(&Fr::random(rng));
-            let b_bytes = fr_into_bytes::<Bls12>(&Fr::random(rng));
+            let a = Fr::random(rng);
+            let b = Fr::random(rng);
+            let a_bytes = fr_into_bytes::<Bls12>(&a);
+            let b_bytes = fr_into_bytes::<Bls12>(&b);
 
-            let a_bits: Vec<Boolean> = {
-                let mut cs = cs.namespace(|| "a");
-                bytes_into_boolean_vec(&mut cs, Some(a_bytes.as_slice()), a_bytes.len()).unwrap()
+            let a_num = {
+                let cs = cs.namespace(|| "a");
+                num::AllocatedNum::alloc(cs, || Ok(a)).unwrap()
             };
 
-            let b_bits: Vec<Boolean> = {
-                let mut cs = cs.namespace(|| "b");
-                bytes_into_boolean_vec(&mut cs, Some(b_bytes.as_slice()), b_bytes.len()).unwrap()
+            let b_num = {
+                let cs = cs.namespace(|| "b");
+                num::AllocatedNum::alloc(cs, || Ok(b)).unwrap()
             };
 
-            let out = hash2(cs.namespace(|| "hash2"), &JJ_PARAMS, &a_bits, &b_bits)
-                .expect("hash2 function failed");
+            let out = PedersenFunction::hash_leaf_circuit(
+                cs.namespace(|| "hash2"),
+                &JJ_PARAMS,
+                None,
+                &a_num,
+                &b_num,
+            )
+            .expect("hash2 function failed");
 
             assert!(cs.is_satisfied(), "constraints not satisfied");
-            assert_eq!(cs.num_constraints(), 1376);
+            assert_eq!(cs.num_constraints(), 1374);
 
-            let expected: Fr = vanilla_hash2(&a_bytes, &b_bytes).into();
+            let expected: Fr = PedersenFunction::hash2(&a_bytes, &b_bytes).into();
 
             assert_eq!(
                 expected,

--- a/storage-proofs/src/circuit/stacked/proof.rs
+++ b/storage-proofs/src/circuit/stacked/proof.rs
@@ -6,16 +6,13 @@ use fil_sapling_crypto::jubjub::JubjubEngine;
 use paired::bls12_381::{Bls12, Fr};
 
 use crate::circuit::por::PoRCompound;
-use crate::circuit::{
-    constraint,
-    stacked::{hash::hash2, params::Proof},
-};
+use crate::circuit::{constraint, stacked::params::Proof};
 use crate::compound_proof::{CircuitComponent, CompoundProof};
 use crate::crypto::pedersen::JJ_PARAMS;
 use crate::drgraph::Graph;
 use crate::error::Result;
 use crate::fr32::fr_into_bytes;
-use crate::hasher::Hasher;
+use crate::hasher::{HashFunction, Hasher};
 use crate::merklepor;
 use crate::parameter_cache::{CacheableParameters, ParameterSetMetadata};
 use crate::proof::ProofScheme;
@@ -131,9 +128,6 @@ impl<'a, H: Hasher, G: Hasher> Circuit<Bls12> for StackedCircuit<'a, Bls12, H, G
                 .ok_or_else(|| SynthesisError::AssignmentMissing)
         })?;
 
-        // Allocate comm_r_last as booleans
-        let comm_r_last_bits = comm_r_last_num.to_bits_le(cs.namespace(|| "comm_r_last_bits"))?;
-
         // Allocate comm_c as Fr
         let comm_c_num = num::AllocatedNum::alloc(cs.namespace(|| "comm_c"), || {
             comm_c
@@ -141,16 +135,14 @@ impl<'a, H: Hasher, G: Hasher> Circuit<Bls12> for StackedCircuit<'a, Bls12, H, G
                 .ok_or_else(|| SynthesisError::AssignmentMissing)
         })?;
 
-        // Allocate comm_c as booleans
-        let comm_c_bits = comm_c_num.to_bits_le(cs.namespace(|| "comm_c_bits"))?;
-
         // Verify comm_r = H(comm_c || comm_r_last)
         {
-            let hash_num = hash2(
+            let hash_num = H::Function::hash_leaf_circuit(
                 cs.namespace(|| "H_comm_c_comm_r_last"),
                 params,
-                &comm_c_bits,
-                &comm_r_last_bits,
+                None,
+                &comm_c_num,
+                &comm_r_last_num,
             )?;
 
             // Check actual equality
@@ -318,7 +310,7 @@ mod tests {
     use crate::compound_proof;
     use crate::drgraph::{new_seed, BASE_DEGREE};
     use crate::fr32::fr_into_bytes;
-    use crate::hasher::{Hasher, PedersenHasher, Sha256Hasher};
+    use crate::hasher::{Hasher, PedersenHasher, PoseidonHasher, Sha256Hasher};
     use crate::porep::PoRep;
     use crate::proof::ProofScheme;
     use crate::stacked::{
@@ -331,7 +323,16 @@ mod tests {
     use rand_xorshift::XorShiftRng;
 
     #[test]
-    fn stacked_input_circuit_with_bls12_381() {
+    fn stacked_input_circuit_with_bls12_381_pedersen() {
+        stacked_input_circuit_with_bls12_381::<PedersenHasher>(2_480_781);
+    }
+
+    #[test]
+    fn stacked_input_circuit_with_bls12_381_poseidon() {
+        stacked_input_circuit_with_bls12_381::<PoseidonHasher>(2_434_329);
+    }
+
+    fn stacked_input_circuit_with_bls12_381<H: Hasher + 'static>(expected_constraints: usize) {
         let nodes = 8;
         let degree = BASE_DEGREE;
         let expansion_degree = EXP_DEGREE;
@@ -365,8 +366,8 @@ mod tests {
             DEFAULT_CACHED_ABOVE_BASE_LAYER,
         );
 
-        let pp = StackedDrg::<PedersenHasher, Sha256Hasher>::setup(&sp).expect("setup failed");
-        let (tau, (p_aux, t_aux)) = StackedDrg::<PedersenHasher, Sha256Hasher>::replicate(
+        let pp = StackedDrg::<H, Sha256Hasher>::setup(&sp).expect("setup failed");
+        let (tau, (p_aux, t_aux)) = StackedDrg::<H, Sha256Hasher>::replicate(
             &pp,
             &replica_id.into(),
             (&mut data_copy[..]).into(),
@@ -378,31 +379,26 @@ mod tests {
 
         let seed = rng.gen();
 
-        let pub_inputs =
-            PublicInputs::<<PedersenHasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Domain> {
-                replica_id: replica_id.into(),
-                seed,
-                tau: Some(tau.into()),
-                k: None,
-            };
+        let pub_inputs = PublicInputs::<<H as Hasher>::Domain, <Sha256Hasher as Hasher>::Domain> {
+            replica_id: replica_id.into(),
+            seed,
+            tau: Some(tau.into()),
+            k: None,
+        };
 
         // Convert TemporaryAux to TemporaryAuxCache, which instantiates all
         // elements based on the configs stored in TemporaryAux.
         use crate::stacked::TemporaryAuxCache;
         let t_aux = TemporaryAuxCache::new(&t_aux).expect("failed to restore contents of t_aux");
 
-        let priv_inputs = PrivateInputs::<PedersenHasher, Sha256Hasher> {
+        let priv_inputs = PrivateInputs::<H, Sha256Hasher> {
             p_aux: p_aux.into(),
             t_aux: t_aux.into(),
         };
 
-        let proofs = StackedDrg::<PedersenHasher, Sha256Hasher>::prove_all_partitions(
-            &pp,
-            &pub_inputs,
-            &priv_inputs,
-            1,
-        )
-        .expect("failed to generate partition proofs");
+        let proofs =
+            StackedDrg::<H, Sha256Hasher>::prove_all_partitions(&pp, &pub_inputs, &priv_inputs, 1)
+                .expect("failed to generate partition proofs");
 
         let proofs_are_valid = StackedDrg::verify_all_partitions(&pp, &pub_inputs, &proofs)
             .expect("failed to verify partition proofs");
@@ -410,7 +406,6 @@ mod tests {
         assert!(proofs_are_valid);
 
         let expected_inputs = 20;
-        let expected_constraints = 2_480_637;
 
         {
             // Verify that MetricCS returns the same metrics as TestConstraintSystem.
@@ -418,7 +413,7 @@ mod tests {
 
             StackedCompound::circuit(
                 &pub_inputs,
-                <StackedCircuit<Bls12, PedersenHasher, Sha256Hasher> as CircuitComponent>::ComponentPrivateInputs::default(),
+                <StackedCircuit<Bls12, H, Sha256Hasher> as CircuitComponent>::ComponentPrivateInputs::default(),
                 &proofs[0],
                 &pp,
             )
@@ -437,7 +432,7 @@ mod tests {
 
         StackedCompound::circuit(
             &pub_inputs,
-            <StackedCircuit<Bls12, PedersenHasher, Sha256Hasher> as CircuitComponent>::ComponentPrivateInputs::default(),
+            <StackedCircuit<Bls12, H, Sha256Hasher> as CircuitComponent>::ComponentPrivateInputs::default(),
             &proofs[0],
             &pp,
         )
@@ -457,7 +452,7 @@ mod tests {
 
         let generated_inputs = <StackedCompound as CompoundProof<
             _,
-            StackedDrg<PedersenHasher, Sha256Hasher>,
+            StackedDrg<H, Sha256Hasher>,
             _,
         >>::generate_public_inputs(&pub_inputs, &pp, None)
         .expect("failed to generate public inputs");
@@ -484,7 +479,13 @@ mod tests {
 
     #[test]
     #[ignore] // Slow test – run only when compiled for release.
-    fn test_stacked_compound_blake2s() {
+    fn test_stacked_compound_poseidon() {
+        stacked_test_compound::<PoseidonHasher>();
+    }
+
+    #[test]
+    #[ignore] // Slow test – run only when compiled for release.
+    fn test_stacked_compound_sha256() {
         stacked_test_compound::<Sha256Hasher>();
     }
 

--- a/storage-proofs/src/drgraph.rs
+++ b/storage-proofs/src/drgraph.rs
@@ -8,15 +8,10 @@ use sha2::{Digest, Sha256};
 
 use crate::error::*;
 use crate::fr32::bytes_into_fr_repr_safe;
-use crate::hasher::poseidon::PoseidonHasher;
 use crate::hasher::Hasher;
 use crate::merkle::{create_merkle_tree, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node_offset, NODE_SIZE};
-
-/// The default hasher currently in use.
-pub type DefaultTreeHasher = PoseidonHasher;
-pub type DefaultTreeDomain = <DefaultTreeHasher as Hasher>::Domain;
 
 pub const PARALLEL_MERKLE: bool = true;
 

--- a/storage-proofs/src/election_post.rs
+++ b/storage-proofs/src/election_post.rs
@@ -13,13 +13,12 @@ use crate::crypto::pedersen::{pedersen_md_no_padding_bits, Bits};
 use crate::drgraph::graph_height;
 use crate::error::{Error, Result};
 use crate::fr32::fr_into_bytes;
-use crate::hasher::{Domain, Hasher};
+use crate::hasher::{Domain, HashFunction, Hasher};
 use crate::measurements::{measure_op, Operation};
 use crate::merkle::{MerkleProof, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::proof::{NoRequirements, ProofScheme};
 use crate::sector::*;
-use crate::stacked::hash::hash2;
 use crate::util::NODE_SIZE;
 
 #[derive(Debug, Clone)]
@@ -376,7 +375,9 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for ElectionPoSt<'a, H> {
         let comm_c = proof.comm_c;
         let comm_r = &pub_inputs.comm_r;
 
-        if AsRef::<[u8]>::as_ref(&hash2(comm_c, comm_r_last)) != AsRef::<[u8]>::as_ref(comm_r) {
+        if AsRef::<[u8]>::as_ref(&H::Function::hash2(comm_c, comm_r_last))
+            != AsRef::<[u8]>::as_ref(comm_r)
+        {
             return Ok(false);
         }
 
@@ -460,7 +461,7 @@ mod tests {
         let tree = trees.remove(&candidate.sector_id).unwrap();
         let comm_r_last = tree.root();
         let comm_c = H::Domain::random(rng);
-        let comm_r = Fr::from(hash2(comm_c, comm_r_last)).into();
+        let comm_r = H::Function::hash2(comm_c, comm_r_last);
 
         let pub_inputs = PublicInputs {
             randomness,

--- a/storage-proofs/src/hasher/mod.rs
+++ b/storage-proofs/src/hasher/mod.rs
@@ -11,3 +11,8 @@ pub use self::blake2s::Blake2sHasher;
 pub use self::pedersen::PedersenHasher;
 pub use self::poseidon::PoseidonHasher;
 pub use self::sha256::Sha256Hasher;
+
+/// The default hasher currently in use.
+pub type DefaultTreeHasher = PoseidonHasher;
+pub type DefaultTreeDomain = <DefaultTreeHasher as Hasher>::Domain;
+pub type DefaultTreeHashFunction = <DefaultTreeHasher as Hasher>::Function;

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -74,6 +74,8 @@ pub trait HashFunction<T: Domain>:
 {
     fn hash(data: &[u8]) -> T;
 
+    fn hash2<S: AsRef<[u8]>, U: AsRef<[u8]>>(a: S, b: U) -> T;
+
     fn hash_leaf(data: &dyn LightHashable<Self>) -> T {
         let mut a = Self::default();
         data.hash(&mut a);
@@ -89,10 +91,10 @@ pub trait HashFunction<T: Domain>:
 
     fn hash_leaf_circuit<E: JubjubEngine + PoseidonEngine, CS: ConstraintSystem<E>>(
         mut cs: CS,
+        params: &E::Params,
+        height: Option<usize>,
         left: &num::AllocatedNum<E>,
         right: &num::AllocatedNum<E>,
-        height: usize,
-        params: &E::Params,
     ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
         let left_bits = left.to_bits_le(cs.namespace(|| "left num into bits"))?;
         let right_bits = right.to_bits_le(cs.namespace(|| "right num into bits"))?;
@@ -104,17 +106,11 @@ pub trait HashFunction<T: Domain>:
         _cs: CS,
         _left: &[boolean::Boolean],
         _right: &[boolean::Boolean],
-        _height: usize,
+        _height: Option<usize>,
         _params: &E::Params,
     ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
         unimplemented!();
     }
-
-    fn hash_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
-        cs: CS,
-        bits: &[boolean::Boolean],
-        params: &E::Params,
-    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError>;
 }
 
 pub trait Hasher: Clone + ::std::fmt::Debug + Eq + Default + Send + Sync {

--- a/storage-proofs/src/rational_post.rs
+++ b/storage-proofs/src/rational_post.rs
@@ -7,12 +7,11 @@ use serde::{Deserialize, Serialize};
 
 use crate::drgraph::graph_height;
 use crate::error::{Error, Result};
-use crate::hasher::{Domain, Hasher};
+use crate::hasher::{Domain, HashFunction, Hasher};
 use crate::merkle::{MerkleProof, MerkleTree};
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::proof::{NoRequirements, ProofScheme};
 use crate::sector::*;
-use crate::stacked::hash::hash2;
 use crate::util::NODE_SIZE;
 
 #[derive(Debug, Clone)]
@@ -191,7 +190,8 @@ impl<'a, H: 'a + Hasher> ProofScheme<'a> for RationalPoSt<'a, H> {
             // comm_r_last is the root of the proof
             let comm_r_last = merkle_proof.root();
 
-            if AsRef::<[u8]>::as_ref(&hash2(comm_c, comm_r_last)) != AsRef::<[u8]>::as_ref(&comm_r)
+            if AsRef::<[u8]>::as_ref(&H::Function::hash2(comm_c, comm_r_last))
+                != AsRef::<[u8]>::as_ref(&comm_r)
             {
                 return Ok(false);
             }
@@ -355,7 +355,7 @@ mod tests {
         let comm_rs: Vec<H::Domain> = comm_cs
             .iter()
             .zip(comm_r_lasts.iter())
-            .map(|(comm_c, comm_r_last)| Fr::from(hash2(comm_c, comm_r_last)).into())
+            .map(|(comm_c, comm_r_last)| H::Function::hash2(comm_c, comm_r_last))
             .collect();
 
         let pub_inputs = PublicInputs {
@@ -446,7 +446,7 @@ mod tests {
         let comm_rs: Vec<H::Domain> = comm_cs
             .iter()
             .zip(comm_r_lasts.iter())
-            .map(|(comm_c, comm_r_last)| Fr::from(hash2(comm_c, comm_r_last)).into())
+            .map(|(comm_c, comm_r_last)| H::Function::hash2(comm_c, comm_r_last))
             .collect();
 
         let pub_inputs = PublicInputs::<H::Domain> {
@@ -525,7 +525,7 @@ mod tests {
         let comm_rs: Vec<H::Domain> = comm_cs
             .iter()
             .zip(comm_r_lasts.iter())
-            .map(|(comm_c, comm_r_last)| Fr::from(hash2(comm_c, comm_r_last)).into())
+            .map(|(comm_c, comm_r_last)| H::Function::hash2(comm_c, comm_r_last))
             .collect();
 
         let pub_inputs = PublicInputs {
@@ -553,7 +553,7 @@ mod tests {
         let comm_rs: Vec<H::Domain> = comm_cs
             .iter()
             .zip(comm_r_lasts.iter())
-            .map(|(comm_c, comm_r_last)| Fr::from(hash2(comm_c, comm_r_last)).into())
+            .map(|(comm_c, comm_r_last)| H::Function::hash2(comm_c, comm_r_last))
             .collect();
 
         let different_pub_inputs = PublicInputs {

--- a/storage-proofs/src/stacked/hash.rs
+++ b/storage-proofs/src/stacked/hash.rs
@@ -1,12 +1,6 @@
 use sha2::Digest;
 
-use crate::crypto::pedersen::{pedersen_md_no_padding_bits, Bits};
 use crate::hasher::{pedersen::PedersenDomain, Domain};
-
-/// Hash 2 individual elements.
-pub fn hash2<S: AsRef<[u8]>, T: AsRef<[u8]>>(a: S, b: T) -> PedersenDomain {
-    hash1(Bits::new_many(vec![a.as_ref(), b.as_ref()].into_iter()))
-}
 
 /// Hash all elements in the given column.
 pub fn hash_single_column<T: AsRef<[u8]>>(column: &[T]) -> PedersenDomain {
@@ -17,9 +11,4 @@ pub fn hash_single_column<T: AsRef<[u8]>>(column: &[T]) -> PedersenDomain {
     let mut res = hasher.result();
     res[31] &= 0b0011_1111;
     PedersenDomain::try_from_bytes(&res).unwrap()
-}
-
-/// Hash all elements in the given buffer
-pub fn hash1<'a, S: Iterator<Item = &'a [u8]>>(data: Bits<&'a [u8], S>) -> PedersenDomain {
-    pedersen_md_no_padding_bits(data).into()
 }

--- a/storage-proofs/src/stacked/proof.rs
+++ b/storage-proofs/src/stacked/proof.rs
@@ -4,14 +4,13 @@ use std::marker::PhantomData;
 use log::{info, trace};
 use merkletree::merkle::FromIndexedParallelIterator;
 use merkletree::store::{DiskStore, StoreConfig};
-use paired::bls12_381::Fr;
 use rayon::prelude::*;
 use sha2::{Digest, Sha256};
 
 use crate::drgraph::Graph;
 use crate::encode::{decode, encode};
 use crate::error::Result;
-use crate::hasher::{Domain, Hasher};
+use crate::hasher::{Domain, HashFunction, Hasher};
 use crate::measurements::{
     measure_op,
     Operation::{CommD, EncodeWindowTimeAll, GenerateTreeC, GenerateTreeRLast},
@@ -23,7 +22,6 @@ use crate::stacked::{
     challenges::LayerChallenges,
     column::Column,
     graph::StackedBucketGraph,
-    hash::hash2,
     params::{
         get_node, CacheKey, Labels, LabelsCache, PersistentAux, Proof, PublicInputs, PublicParams,
         ReplicaColumnProof, Tau, TemporaryAux, TemporaryAuxCache, TransformedLayers, Tree,
@@ -494,7 +492,7 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
         data.drop_data();
 
         // comm_r = H(comm_c || comm_r_last)
-        let comm_r: H::Domain = Fr::from(hash2(tree_c.root(), tree_r_last.root())).into();
+        let comm_r = H::Function::hash2(tree_c.root(), tree_r_last.root());
 
         assert_eq!(tree_d.len(), tree_r_last.len());
         assert_eq!(tree_d.len(), tree_c.len());
@@ -623,7 +621,7 @@ mod tests {
     use super::*;
 
     use ff::Field;
-    use paired::bls12_381::Bls12;
+    use paired::bls12_381::{Bls12, Fr};
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 

--- a/storage-proofs/src/stacked/proof_scheme.rs
+++ b/storage-proofs/src/stacked/proof_scheme.rs
@@ -1,16 +1,14 @@
 use anyhow::ensure;
 use log::trace;
-use paired::bls12_381::Fr;
 use rayon::prelude::*;
 
 use crate::drgraph::Graph;
 use crate::error::Result;
-use crate::hasher::Hasher;
+use crate::hasher::{HashFunction, Hasher};
 use crate::proof::ProofScheme;
 use crate::stacked::{
     challenges::ChallengeRequirements,
     graph::StackedBucketGraph,
-    hash::hash2,
     params::{PrivateInputs, Proof, PublicInputs, PublicParams, SetupParams},
     proof::StackedDrg,
 };
@@ -103,7 +101,7 @@ impl<'a, 'c, H: 'static + Hasher, G: 'static + Hasher> ProofScheme<'a> for Stack
             let actual_comm_r: H::Domain = {
                 let comm_c = proofs[0].comm_c();
                 let comm_r_last = proofs[0].comm_r_last();
-                Fr::from(hash2(comm_c, comm_r_last)).into()
+                H::Function::hash2(comm_c, comm_r_last)
             };
 
             if expected_comm_r != &actual_comm_r {


### PR DESCRIPTION
- poseidon tests fail, can't measure yet, this seems to be an issue with the circuit in neptune
- Currently this changes pedersen hashing to add padding to full bytes in all cases, as that was simpler to make happen. Should decide if we are okay with that or not. 


```
---- circuit::stacked::proof::tests::test_stacked_compound_poseidon stdout ----
thread 'circuit::stacked::proof::tests::test_stacked_compound_poseidon' panicked at 'called `Result::unwrap()` on an `Err` value: AssignmentMissing', /Users/dignifiedquire/.cargo/registry/src/github.com-1ecc6299db9ec823/neptune-0.2.1/src/circuit.rs:399:29
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```