### PR TITLE
feat: allow runtime switch for disk vs memory replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ While replicating and generating the Merkle Trees (MT) for the proof at the same
 One of the most computational expensive operations during replication (besides the encoding itself) is the generation of the indexes of the (expansion) parents in the Stacked graph, implemented through a Feistel cipher (used as a pseudorandom permutation). To reduce that time we provide a caching mechanism to generate them only once and reuse them throughout replication (across the different layers). Already built into the system it can be activated with the environmental variable
 
 ```
-FIL_PROOFS_MAXIMIZE_CACHING=1
+FIL_PROOFS_CACHE_GRAPH=1
 ```
 
 To check that it's working you can inspect the replication log to find `using parents cache of unlimited size`. As the log indicates, we don't have a fine grain control at the moment so it either stores all parents or none. This cache can add almost an entire sector size to the memory used during replication, if you can spare it though this setting is _very recommended_ as it has a considerable impact on replication time.

--- a/storage-proofs/src/settings.rs
+++ b/storage-proofs/src/settings.rs
@@ -14,23 +14,19 @@ const SETTINGS_PATH: &str = "./rust-fil-proofs.config.toml";
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
-    pub maximize_caching: bool,
-    pub merkle_tree_path: String,
-    pub num_proving_threads: usize,
-    pub replicated_trees_dir: String,
+    /// Caches the DRG and Expander Graph nodes in memory.
+    pub cache_graph: bool,
     pub pedersen_hash_exp_window_size: u32,
-    // Generating MTs in parallel optimizes for speed while generating them
-    // in sequence (`false`) optimizes for memory.
+    /// If true, tries to offload as much as possible to disk, during replication.
+    pub replicate_on_disk: bool,
 }
 
 impl Default for Settings {
     fn default() -> Self {
         Settings {
-            maximize_caching: false,
-            merkle_tree_path: "/tmp/merkle-trees".into(),
-            num_proving_threads: 1,
-            replicated_trees_dir: "".into(),
+            cache_graph: true,
             pedersen_hash_exp_window_size: 16,
+            replicate_on_disk: false,
         }
     }
 }

--- a/storage-proofs/src/stacked/graph.rs
+++ b/storage-proofs/src/stacked/graph.rs
@@ -5,6 +5,7 @@ use std::sync::{Arc, RwLock};
 use anyhow::ensure;
 use lazy_static::lazy_static;
 use log::info;
+use merkletree::store::Store;
 use rayon::prelude::*;
 
 use crate::crypto::feistel::{self, FeistelPrecomputed};
@@ -13,7 +14,7 @@ use crate::error::Result;
 use crate::hasher::Hasher;
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::settings;
-use crate::util::{data_at_node_offset, NODE_SIZE};
+use crate::util::NODE_SIZE;
 
 /// The expansion degree used for Stacked Graphs.
 pub const EXP_DEGREE: usize = 8;
@@ -133,53 +134,51 @@ where
         Ok(res)
     }
 
-    pub fn copy_parents_data(
+    pub fn copy_parents_data<S: Store<H::Domain>>(
         &self,
         node: u32,
-        base_data: &[u8],
-        exp_data: Option<&Vec<u8>>,
+        base_data: &S,
+        exp_data: Option<&S>,
         target: &mut [u8],
-    ) {
+    ) -> Result<()> {
         if self.use_cache {
             let cache_lock = PARENT_CACHE.read().unwrap();
             let cache = cache_lock
                 .get(&self.sector_size())
                 .expect("Invalid cache construction");
             let cache_parents = cache.read(node as u32);
-            self.copy_parents_data_inner(&cache_parents, base_data, exp_data, target);
+            self.copy_parents_data_inner(&cache_parents, base_data, exp_data, target)
         } else {
             let mut cache_parents = vec![0u32; self.degree()];
             self.parents(node as usize, &mut cache_parents).unwrap();
-            self.copy_parents_data_inner(&cache_parents, base_data, exp_data, target);
+            self.copy_parents_data_inner(&cache_parents, base_data, exp_data, target)
         }
     }
 
-    fn copy_parents_data_inner(
+    fn copy_parents_data_inner<S: Store<H::Domain>>(
         &self,
         cache_parents: &[u32],
-        base_data: &[u8],
-        exp_data: Option<&Vec<u8>>,
+        base_data: &S,
+        exp_data: Option<&S>,
         target: &mut [u8],
-    ) {
+    ) -> Result<()> {
         let base_degree = self.base_graph().degree();
 
         // Base parents
         for (i, parent) in cache_parents.iter().enumerate().take(base_degree) {
-            let node_off = data_at_node_offset(*parent as usize);
             let off = i * NODE_SIZE;
-            target[off..off + NODE_SIZE]
-                .copy_from_slice(&base_data[node_off..node_off + NODE_SIZE]);
+            base_data.read_into(*parent as usize, &mut target[off..off + NODE_SIZE])?;
         }
 
         // Expander parents
         if let Some(ref parents_data) = exp_data {
             for (i, parent) in cache_parents.iter().enumerate().skip(base_degree) {
-                let node_off = data_at_node_offset(*parent as usize);
                 let off = i * NODE_SIZE;
-                target[off..off + NODE_SIZE]
-                    .copy_from_slice(&parents_data[node_off..node_off + NODE_SIZE]);
+                parents_data.read_into(*parent as usize, &mut target[off..off + NODE_SIZE])?;
             }
         }
+
+        Ok(())
     }
 }
 

--- a/storage-proofs/src/stacked/graph.rs
+++ b/storage-proofs/src/stacked/graph.rs
@@ -95,7 +95,7 @@ where
         expansion_degree: usize,
         seed: [u8; 28],
     ) -> Result<Self> {
-        let use_cache = settings::SETTINGS.lock().unwrap().maximize_caching;
+        let use_cache = settings::SETTINGS.lock().unwrap().cache_graph;
 
         let base_graph = match base_graph {
             Some(graph) => graph,

--- a/storage-proofs/src/stacked/params.rs
+++ b/storage-proofs/src/stacked/params.rs
@@ -344,23 +344,23 @@ impl<H: Hasher, G: Hasher> TemporaryAux<H, G> {
         self.tree_c_config.path = cp;
     }
 
-    pub fn delete(t_aux: TemporaryAux<H, G>) -> Result<()> {
-        let tree_d_size = t_aux.tree_d_config.size.unwrap();
+    pub fn delete(&self) -> Result<()> {
+        let tree_d_size = self.tree_d_config.size.unwrap();
         let tree_d_store: DiskStore<G::Domain> =
-            DiskStore::new_from_disk(tree_d_size, &t_aux.tree_d_config)?;
+            DiskStore::new_from_disk(tree_d_size, &self.tree_d_config)?;
         let tree_d: Tree<G> =
             MerkleTree::from_data_store(tree_d_store, get_merkle_tree_leafs(tree_d_size))?;
-        tree_d.delete(t_aux.tree_d_config)?;
+        tree_d.delete(self.tree_d_config.clone())?;
 
-        let tree_c_size = t_aux.tree_c_config.size.unwrap();
+        let tree_c_size = self.tree_c_config.size.unwrap();
         let tree_c_store: DiskStore<H::Domain> =
-            DiskStore::new_from_disk(tree_c_size, &t_aux.tree_c_config)?;
+            DiskStore::new_from_disk(tree_c_size, &self.tree_c_config)?;
         let tree_c: Tree<H> =
             MerkleTree::from_data_store(tree_c_store, get_merkle_tree_leafs(tree_c_size))?;
-        tree_c.delete(t_aux.tree_c_config)?;
+        tree_c.delete(self.tree_c_config.clone())?;
 
-        for i in 0..t_aux.labels.labels.len() {
-            DiskStore::<H::Domain>::delete(t_aux.labels.labels[i].clone())?;
+        for i in 0..self.labels.labels.len() {
+            DiskStore::<H::Domain>::delete(self.labels.labels[i].clone())?;
         }
 
         Ok(())

--- a/storage-proofs/src/stacked/proof.rs
+++ b/storage-proofs/src/stacked/proof.rs
@@ -259,6 +259,7 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
         let in_memory = !crate::settings::SETTINGS.lock().unwrap().replicate_on_disk;
 
         if in_memory {
+            info!("generate_labels: memory");
             Self::generate_labels_inner::<merkletree::store::VecStore<H::Domain>>(
                 graph,
                 layer_challenges,
@@ -266,6 +267,7 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
                 config,
             )
         } else {
+            info!("generate_labels: disk");
             Self::generate_labels_inner::<DiskStore<H::Domain>>(
                 graph,
                 layer_challenges,
@@ -282,7 +284,6 @@ impl<'a, H: 'static + Hasher, G: 'static + Hasher> StackedDrg<'a, H, G> {
         replica_id: &<H as Hasher>::Domain,
         config: StoreConfig,
     ) -> Result<(LabelsCache<H>, Labels<H>)> {
-        info!("generate labels");
         let layers = layer_challenges.layers();
         // For now, we require it due to changes in encodings structure.
         let mut labels: Vec<DiskStore<H::Domain>> = Vec::with_capacity(layers);


### PR DESCRIPTION
new config options

- `FIL_PROOFS_REPLICATE_ON_DISK` when set will run replication using as much disk as possible (default: `false`)
- `FIL_PROOFS_CACHE_GRAPH` when set will cache the graph in memory (default: `true`) this option was previously known as `MAXIMIZE_CACHING`