### PR TITLE
feat: add md hash and implement for Poseidon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           no_output_timeout: 30m
       - restore_cache:
           keys:
-            - cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: rustup component add rustfmt-preview
@@ -40,7 +40,7 @@ jobs:
           paths:
             - Cargo.lock
       - save_cache:
-          key: cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
             - /root/.cargo
             - /root/.rustup
@@ -56,7 +56,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (stable)
@@ -85,7 +85,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (stable) in release profile
@@ -111,7 +111,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test ignored in release profile
@@ -134,7 +134,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (nightly)
@@ -153,7 +153,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Benchmarks (nightly)
@@ -241,7 +241,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
@@ -258,7 +258,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v23-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v23-a-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo clippy
           command: cargo +$(cat rust-toolchain) clippy --all
@@ -315,7 +315,7 @@ commands:
   save_parameter_cache:
     steps:
       - save_cache:
-          key: proof-params-v23-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+          key: proof-params-v23-a-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
           paths:
             - "~/paramcache.awesome"
             - "~/filecoin-proof-parameters/"
@@ -324,7 +324,7 @@ commands:
       - configure_environment_variables
       - restore_cache:
           keys:
-            - proof-params-v23-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+            - proof-params-v23-a-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
   configure_environment_variables:
     steps:
       - run:

--- a/filecoin-proofs/src/api/util.rs
+++ b/filecoin-proofs/src/api/util.rs
@@ -7,7 +7,7 @@ use storage_proofs::hasher::Domain;
 use crate::types::{Commitment, SectorSize};
 
 pub(crate) fn as_safe_commitment<H: Domain, T: AsRef<str>>(
-    comm: &Commitment,
+    comm: &[u8; 32],
     commitment_name: T,
 ) -> Result<H> {
     bytes_into_fr::<Bls12>(comm)

--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -55,7 +55,7 @@ generic-array = "0.13.2"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
 cpu-time = "1.0.0"
-neptune = "0.4.0"
+neptune = "0.4.1"
 
 [features]
 default = ["gpu"]

--- a/storage-proofs/src/circuit/mod.rs
+++ b/storage-proofs/src/circuit/mod.rs
@@ -1,4 +1,4 @@
-mod constraint;
+pub mod constraint;
 mod insertion;
 
 pub mod create_label;

--- a/storage-proofs/src/election_post.rs
+++ b/storage-proofs/src/election_post.rs
@@ -209,7 +209,7 @@ fn generate_candidate<H: Hasher>(
     .into();
 
     // ticket = sha256(partial_ticket)
-    let ticket = finalize_ticket(&partial_ticket.into());
+    let ticket = finalize_ticket(&partial_ticket);
 
     Ok(Candidate {
         sector_challenge_index,

--- a/storage-proofs/src/hasher/poseidon.rs
+++ b/storage-proofs/src/hasher/poseidon.rs
@@ -336,7 +336,7 @@ impl HashFunction<PoseidonDomain> for PoseidonFunction {
                 preimage[i + 1] = elt.clone();
             }
             // any terminal padding
-            #[deny(clippy::needless_range_loop)]
+            #[allow(clippy::needless_range_loop)]
             for i in (elts.len() + 1)..arity {
                 preimage[i] =
                     num::AllocatedNum::alloc(cs.namespace(|| format!("padding {}", i)), || {
@@ -627,6 +627,5 @@ mod tests {
         assert_eq!(expected_constraints, actual_constraints);
 
         assert_eq!(hashed_fr, circuit_hashed.get_value().unwrap());
-        panic!();
     }
 }

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -203,20 +203,12 @@ pub trait HashFunction<T: Domain>:
         typenum::Add1<Arity>: generic_array::ArrayLength<E::Fr>;
 
     fn hash_md_circuit<
-        Arity: 'static,
-        E: JubjubEngine + PoseidonEngine<Arity>,
+        E: JubjubEngine + PoseidonEngine<PoseidonMDArity>,
         CS: ConstraintSystem<E>,
     >(
         _cs: &mut CS,
         _elements: &[num::AllocatedNum<E>],
-        _params: &PoseidonConstants<E, Arity>,
-    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError>
-    where
-        Arity: typenum::Unsigned
-            + std::ops::Add<typenum::B1>
-            + std::ops::Add<typenum::UInt<typenum::UTerm, typenum::B1>>,
-        typenum::Add1<Arity>: generic_array::ArrayLength<E::Fr>,
-    {
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError> {
         unimplemented!();
     }
 

--- a/storage-proofs/src/hasher/types.rs
+++ b/storage-proofs/src/hasher/types.rs
@@ -5,7 +5,7 @@ use bellperson::gadgets::{boolean, num};
 use bellperson::{ConstraintSystem, SynthesisError};
 use fil_sapling_crypto::jubjub::JubjubEngine;
 use generic_array::typenum;
-use generic_array::typenum::{U1, U11, U2, U4, U8};
+use generic_array::typenum::{U1, U11, U16, U2, U24, U36, U4, U8};
 use merkletree::hash::{Algorithm as LightAlgorithm, Hashable as LightHashable};
 use merkletree::merkle::Element;
 use neptune::poseidon::PoseidonConstants;
@@ -18,6 +18,9 @@ pub type PoseidonBinaryArity = U2;
 pub type PoseidonQuadArity = U4;
 pub type PoseidonOctArity = U8;
 
+/// Arity to use by default for `hash_md` with poseidon.
+pub type PoseidonMDArity = U36;
+
 /// Arity to use for hasher implementations (Poseidon) which are specialized at compile time.
 /// Must match PoseidonArity
 pub const MERKLE_TREE_ARITY: usize = 2;
@@ -27,7 +30,15 @@ lazy_static! {
     pub static ref POSEIDON_CONSTANTS_2: PoseidonConstants::<Bls12, U2> = PoseidonConstants::new();
     pub static ref POSEIDON_CONSTANTS_4: PoseidonConstants::<Bls12, U4> = PoseidonConstants::new();
     pub static ref POSEIDON_CONSTANTS_8: PoseidonConstants::<Bls12, U8> = PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_16: PoseidonConstants::<Bls12, U16> =
+        PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_24: PoseidonConstants::<Bls12, U24> =
+        PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_36: PoseidonConstants::<Bls12, U36> =
+        PoseidonConstants::new();
     pub static ref POSEIDON_CONSTANTS_11: PoseidonConstants::<Bls12, U11> =
+        PoseidonConstants::new();
+    pub static ref POSEIDON_MD_CONSTANTS: PoseidonConstants::<Bls12, PoseidonMDArity> =
         PoseidonConstants::new();
 }
 
@@ -71,6 +82,22 @@ impl PoseidonArity<Bls12> for U8 {
 impl PoseidonArity<Bls12> for U11 {
     fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
         &*POSEIDON_CONSTANTS_11
+    }
+}
+
+impl PoseidonArity<Bls12> for U16 {
+    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+        &*POSEIDON_CONSTANTS_16
+    }
+}
+impl PoseidonArity<Bls12> for U24 {
+    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+        &*POSEIDON_CONSTANTS_24
+    }
+}
+impl PoseidonArity<Bls12> for U36 {
+    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+        &*POSEIDON_CONSTANTS_36
     }
 }
 
@@ -127,6 +154,14 @@ pub trait HashFunction<T: Domain>:
 {
     fn hash(data: &[u8]) -> T;
     fn hash2(a: &T, b: &T) -> T;
+    fn hash_md(input: &[T]) -> T {
+        // Default to binary.
+        assert!(input.len() > 1, "hash_md needs more than one element.");
+        input
+            .iter()
+            .skip(1)
+            .fold(input[0], |acc, elt| Self::hash2(&acc, elt))
+    }
 
     fn hash_leaf(data: &dyn LightHashable<Self>) -> T {
         let mut a = Self::default();
@@ -166,6 +201,24 @@ pub trait HashFunction<T: Domain>:
     ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError>
     where
         typenum::Add1<Arity>: generic_array::ArrayLength<E::Fr>;
+
+    fn hash_md_circuit<
+        Arity: 'static,
+        E: JubjubEngine + PoseidonEngine<Arity>,
+        CS: ConstraintSystem<E>,
+    >(
+        _cs: &mut CS,
+        _elements: &[num::AllocatedNum<E>],
+        _params: &PoseidonConstants<E, Arity>,
+    ) -> std::result::Result<num::AllocatedNum<E>, SynthesisError>
+    where
+        Arity: typenum::Unsigned
+            + std::ops::Add<typenum::B1>
+            + std::ops::Add<typenum::UInt<typenum::UTerm, typenum::B1>>,
+        typenum::Add1<Arity>: generic_array::ArrayLength<E::Fr>,
+    {
+        unimplemented!();
+    }
 
     fn hash_leaf_bits_circuit<E: JubjubEngine, CS: ConstraintSystem<E>>(
         _cs: CS,

--- a/storage-proofs/src/sector.rs
+++ b/storage-proofs/src/sector.rs
@@ -2,6 +2,8 @@ use std::collections::BTreeSet;
 use std::fmt;
 
 use byteorder::ByteOrder;
+use ff::PrimeField;
+use paired::bls12_381::{Fr, FrRepr};
 use serde::{Deserialize, Serialize};
 
 /// An ordered set of `SectorId`s.
@@ -22,6 +24,12 @@ impl From<u64> for SectorId {
 impl From<SectorId> for u64 {
     fn from(n: SectorId) -> Self {
         n.0
+    }
+}
+
+impl From<SectorId> for Fr {
+    fn from(n: SectorId) -> Self {
+        Fr::from_repr(FrRepr::from(n.0)).unwrap()
     }
 }
 


### PR DESCRIPTION
Add just enough support for Merkle-Damgard construction to use with Poseidon.

- Add `hash_md` and `hash_md_circuit` methods to `HashFunction` trait.
- Default `hash_md` implementation in terms of `hash2` (untested).
- No default implementation for `hash_md_circuit`.
- Implement both for `PoseidonDomain`.
- Use arity 36 by default.
- NOTE: Arity is a program-wide constant, 'PoseidonMDArity`.
