### PR TITLE
fix: lock 'quote' dependency to fix failure-derive

### DIFF
--- a/storage-proofs/Cargo.toml
+++ b/storage-proofs/Cargo.toml
@@ -56,6 +56,7 @@ anyhow = "1.0.23"
 thiserror = "1.0.6"
 cpu-time = "1.0.0"
 neptune = "0.5.1"
+quote = "=1.0.2"
 
 [features]
 default = ["gpu"]


### PR DESCRIPTION
More information:
https://users.rust-lang.org/t/failure-derive-compilation-error/39062