### PR TITLE
feat(filecoin-proofs): expose filecoin_proofs::pad_reader

### DIFF
--- a/filecoin-proofs/src/lib.rs
+++ b/filecoin-proofs/src/lib.rs
@@ -3,10 +3,10 @@
 mod api;
 mod caches;
 mod commitment_reader;
-mod pad_reader;
 
 pub mod constants;
 pub mod fr32;
+pub mod pad_reader;
 pub mod param;
 pub mod parameters;
 pub mod pieces;


### PR DESCRIPTION
Make pub so we can use it outside.

Additional request: can we change the name of this to `fr32_pad_reader::Fr32PadReader`? We've got naming confusion with the base2 size padding that's done prior to hand-off to `generate_piece_commitment()`, which now even has its own repo: https://github.com/filecoin-project/go-padreader (also of note is that this new repo's README talks as if it's bit padding and not zero-byte extended padding so confusion already abounds). It comes out of Lotus https://github.com/filecoin-project/lotus/blob/a1f676bf3047646750aa394281a328decd0dd7c4/lib/padreader/padreader.go, made its way to go-fil-markets and is now in its own repo. I'm also having to rename my Rust "PadReader" @ https://github.com/rvagg/rust-fil-commp-generate/blob/edb2a8a837d344bf2ae0eff4384e0fb82c3b665e/src/lib.rs#L34-L56 to accommodate this new "PadReader" which does something completely different.

Happy to update this PR with a name change if that's acceptable.

/cc @vmx