### PR TITLE
refactor(filecoin-proofs): pad_reader::PadReader fr32_reader::Fr32Reader

### DIFF
--- a/filecoin-proofs/benches/preprocessing.rs
+++ b/filecoin-proofs/benches/preprocessing.rs
@@ -2,6 +2,7 @@ use std::io::{self, Read};
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion, ParameterizedBenchmark, Throughput};
+use filecoin_proofs::fr32_reader::Fr32Reader;
 use rand::{thread_rng, Rng};
 
 #[cfg(feature = "cpu-profile")]
@@ -48,7 +49,7 @@ fn preprocessing_benchmark(c: &mut Criterion) {
 
                 start_profile(&format!("write_padded_{}", *size));
                 b.iter(|| {
-                    let mut reader = filecoin_proofs::PadReader::new(io::Cursor::new(&data));
+                    let mut reader = Fr32Reader::new(io::Cursor::new(&data));
                     reader.read_to_end(&mut buf).unwrap();
                     assert!(buf.len() >= data.len());
                 });

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -141,10 +141,10 @@ pub fn generate_piece_commitment<T: std::io::Read>(
 
         // send the source through the preprocessor
         let source = std::io::BufReader::new(source);
-        let mut pad_reader = crate::pad_reader::PadReader::new(source);
+        let mut fr32_reader = crate::fr32_reader::Fr32Reader::new(source);
 
         let commitment = generate_piece_commitment_bytes_from_source::<DefaultPieceHasher>(
-            &mut pad_reader,
+            &mut fr32_reader,
             PaddedBytesAmount::from(piece_size).into(),
         )?;
 
@@ -189,7 +189,7 @@ where
 
         let written_bytes = crate::pieces::sum_piece_bytes_with_alignment(&piece_lengths);
         let piece_alignment = crate::pieces::get_piece_alignment(written_bytes, piece_size);
-        let pad_reader = crate::pad_reader::PadReader::new(source);
+        let pad_reader = crate::fr32_reader::Fr32Reader::new(source);
 
         // write left alignment
         for _ in 0..usize::from(PaddedBytesAmount::from(piece_alignment.left_bytes)) {

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -189,14 +189,14 @@ where
 
         let written_bytes = crate::pieces::sum_piece_bytes_with_alignment(&piece_lengths);
         let piece_alignment = crate::pieces::get_piece_alignment(written_bytes, piece_size);
-        let pad_reader = crate::fr32_reader::Fr32Reader::new(source);
+        let fr32_reader = crate::fr32_reader::Fr32Reader::new(source);
 
         // write left alignment
         for _ in 0..usize::from(PaddedBytesAmount::from(piece_alignment.left_bytes)) {
             target.write_all(&[0u8][..])?;
         }
 
-        let mut commitment_reader = CommitmentReader::new(pad_reader);
+        let mut commitment_reader = CommitmentReader::new(fr32_reader);
         let n = std::io::copy(&mut commitment_reader, &mut target)
             .context("failed to write and preprocess bytes")?;
 

--- a/filecoin-proofs/src/commitment_reader.rs
+++ b/filecoin-proofs/src/commitment_reader.rs
@@ -93,16 +93,16 @@ mod tests {
     fn test_commitment_reader() {
         let piece_size = 127 * 8;
         let source = vec![255u8; piece_size];
-        let mut pad_reader = crate::pad_reader::PadReader::new(io::Cursor::new(&source));
+        let mut fr32_reader = crate::fr32_reader::Fr32Reader::new(io::Cursor::new(&source));
 
         let commitment1 = generate_piece_commitment_bytes_from_source::<DefaultPieceHasher>(
-            &mut pad_reader,
+            &mut fr32_reader,
             PaddedBytesAmount::from(UnpaddedBytesAmount(piece_size as u64)).into(),
         )
         .unwrap();
 
-        let pad_reader = crate::pad_reader::PadReader::new(io::Cursor::new(&source));
-        let mut commitment_reader = CommitmentReader::new(pad_reader);
+        let fr32_reader = crate::fr32_reader::Fr32Reader::new(io::Cursor::new(&source));
+        let mut commitment_reader = CommitmentReader::new(fr32_reader);
         io::copy(&mut commitment_reader, &mut io::sink()).unwrap();
 
         let commitment2 = commitment_reader.finish().unwrap();

--- a/filecoin-proofs/src/fr32.rs
+++ b/filecoin-proofs/src/fr32.rs
@@ -970,7 +970,7 @@ mod tests {
         let len = 1016; // Use a multiple of 254.
         let data = vec![255u8; len];
         let mut padded = Vec::new();
-        let mut reader = crate::pad_reader::PadReader::new(io::Cursor::new(&data));
+        let mut reader = crate::fr32_reader::Fr32Reader::new(io::Cursor::new(&data));
         reader.read_to_end(&mut padded).unwrap();
 
         assert_eq!(
@@ -995,7 +995,7 @@ mod tests {
         let data: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
 
         let mut padded = Vec::new();
-        let mut reader = crate::pad_reader::PadReader::new(io::Cursor::new(&data));
+        let mut reader = crate::fr32_reader::Fr32Reader::new(io::Cursor::new(&data));
         reader.read_to_end(&mut padded).unwrap();
 
         {

--- a/filecoin-proofs/src/lib.rs
+++ b/filecoin-proofs/src/lib.rs
@@ -6,7 +6,7 @@ mod commitment_reader;
 
 pub mod constants;
 pub mod fr32;
-pub mod pad_reader;
+pub mod fr32_reader;
 pub mod param;
 pub mod parameters;
 pub mod pieces;
@@ -17,7 +17,6 @@ pub mod types;
 pub use self::api::*;
 pub use self::commitment_reader::*;
 pub use self::constants::SINGLE_PARTITION_PROOF_LEN;
-pub use self::pad_reader::*;
 pub use self::param::{ParameterData, ParameterMap};
 pub use self::types::*;
 

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -33,7 +33,7 @@ lazy_static! {
     static ref COMMITMENTS: Mutex<HashMap<SectorSize, Commitment>> = Mutex::new(HashMap::new());
 }
 use crate::commitment_reader::CommitmentReader;
-use crate::pad_reader::PadReader;
+use crate::fr32_reader::Fr32Reader;
 
 #[derive(Debug, Clone)]
 struct EmptySource {
@@ -63,8 +63,8 @@ fn empty_comm_d(sector_size: SectorSize) -> Commitment {
 
     *map.entry(sector_size).or_insert_with(|| {
         let size: UnpaddedBytesAmount = sector_size.into();
-        let pad_reader = PadReader::new(EmptySource::new(size.into()));
-        let mut commitment_reader = CommitmentReader::new(pad_reader);
+        let fr32_reader = Fr32Reader::new(EmptySource::new(size.into()));
+        let mut commitment_reader = CommitmentReader::new(fr32_reader);
         io::copy(&mut commitment_reader, &mut io::sink()).unwrap();
 
         let mut comm = [0u8; 32];


### PR DESCRIPTION
For clarity, since padding input data to achieve correct ^2 output size prior to CommP calculation is also required.

Ref #1061 

tbh I've been messing with and around Fr32 padding for a couple of months now but I still don't know what it stands for, is it an acronym? Therefore, I don't know for sure that using the name "Fr32Reader" makes as much sense as it could.

Is this "feat", "fix", "chore", or something else? It's a breaking change but it was only exposed publicly a couple of days ago so maybe a "fix"?