### PR TITLE
fix: check updated store path on verify after precommit phase1

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/election_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/election_post.rs
@@ -103,7 +103,7 @@ pub fn run(sector_size: usize) -> anyhow::Result<()> {
     let cache_dir = tempfile::tempdir().unwrap();
     let sector_id = SectorId::from(SECTOR_ID);
 
-    let phase1_output = seal_pre_commit_phase1(
+    let mut phase1_output = seal_pre_commit_phase1(
         porep_config,
         cache_dir.path(),
         staged_file.path(),
@@ -114,7 +114,7 @@ pub fn run(sector_size: usize) -> anyhow::Result<()> {
         &piece_infos,
     )?;
 
-    validate_cache_for_precommit_phase2(cache_dir.path(), sealed_file.path(), &phase1_output)?;
+    validate_cache_for_precommit_phase2(cache_dir.path(), sealed_file.path(), &mut phase1_output)?;
 
     let seal_pre_commit_output = seal_pre_commit_phase2(
         porep_config,

--- a/fil-proofs-tooling/src/bin/benchy/shared.rs
+++ b/fil-proofs-tooling/src/bin/benchy/shared.rs
@@ -167,8 +167,8 @@ pub fn create_replicas(
         phase1s
             .into_iter()
             .enumerate()
-            .map(|(i, phase1)| {
-                validate_cache_for_precommit_phase2(&cache_dirs[i], &sealed_files[i], &phase1)?;
+            .map(|(i, mut phase1)| {
+                validate_cache_for_precommit_phase2(&cache_dirs[i], &sealed_files[i], &mut phase1)?;
                 seal_pre_commit_phase2(porep_config, phase1, &cache_dirs[i], &sealed_files[i])
             })
             .collect::<Result<Vec<_>, _>>()

--- a/fil-proofs-tooling/src/bin/gpu-cpu-test/election_post.rs
+++ b/fil-proofs-tooling/src/bin/gpu-cpu-test/election_post.rs
@@ -88,7 +88,7 @@ pub fn generate_seal_fixture(
             *POREP_PARTITIONS.read().unwrap().get(&SECTOR_SIZE).unwrap(),
         ),
     };
-    let phase1_output = seal_pre_commit_phase1(
+    let mut phase1_output = seal_pre_commit_phase1(
         porep_config,
         cache_dir_path,
         staged_file.path(),
@@ -100,7 +100,7 @@ pub fn generate_seal_fixture(
     )
     .expect("could not pre seal commit phase1");
 
-    validate_cache_for_precommit_phase2(cache_dir_path, replica_path, &phase1_output)
+    validate_cache_for_precommit_phase2(cache_dir_path, replica_path, &mut phase1_output)
         .expect("could not validate cache for precommit phase2");
 
     let seal_pre_commit_output =

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -314,7 +314,15 @@ where
         .labels
         .verify_stores(verify_store, &cache)?;
 
-    verify_store(&seal_precommit_phase1_output.config, BINARY_ARITY)
+    // Update the previous phase store path to the current cache_path.
+    let mut config = StoreConfig::from_config(
+        &seal_precommit_phase1_output.config,
+        &seal_precommit_phase1_output.config.id,
+        seal_precommit_phase1_output.config.size,
+    );
+    config.path = cache_path.as_ref().into();
+
+    verify_store(&config, BINARY_ARITY)
 }
 
 // Checks for the existence of the replica data and t_aux, which in

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -183,12 +183,13 @@ where
 
     let SealPreCommitPhase1Output {
         mut labels,
-        config,
+        mut config,
         comm_d,
         ..
     } = phase1_output;
 
     labels.update_root(cache_path.as_ref());
+    config.path = cache_path.as_ref().into();
 
     let f_data = OpenOptions::new()
         .read(true)
@@ -224,12 +225,10 @@ where
             tree_leafs,
             StoreConfig::default_cached_above_base_layer(tree_leafs, BINARY_ARITY)
         );
-        let mut config = StoreConfig::new(
-            cache_path.as_ref(),
-            CacheKey::CommDTree.to_string(),
-            StoreConfig::default_cached_above_base_layer(tree_leafs, BINARY_ARITY),
+        ensure!(
+            config.levels == StoreConfig::default_cached_above_base_layer(tree_leafs, BINARY_ARITY),
+            "Invalid cache size specified"
         );
-        config.size = Some(tree_size);
 
         let store: DiskStore<<DefaultPieceHasher as Hasher>::Domain> =
             DiskStore::new_from_disk(tree_size, BINARY_ARITY, &config)?;


### PR DESCRIPTION
Alternative to https://github.com/filecoin-project/rust-fil-proofs/pull/1070

Updates phase1 output in place by setting the new cache_dir specified during the validate (in addition to the precommit phase 2, as validate isn't required to be called).