### PR TITLE
ci: fix file descriptor limits on macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,8 @@ jobs:
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update
       - run: cargo fetch
-      - run: ulimit -n 512
+      - run: sudo ulimit -n 20000
+      - run: sudo ulimit -u 20000
       - run:
           name: Test (nightly, Darwin)
           command: cargo +$(cat rust-toolchain) test --release --verbose --all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,10 +278,13 @@ jobs:
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update
       - run: cargo fetch
-      - run: sudo ulimit -n 49000
       - run:
           name: Test (nightly, Darwin)
-          command: cargo +$(cat rust-toolchain) test --release --verbose --all
+          command: |
+            sudo ulimit -n 20000
+            sudo ulimit -u 20000
+            ulimit -n 20000
+            cargo +$(cat rust-toolchain) test --release --verbose --all
           no_output_timeout: 2h
 
   validate_commit_msg:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,7 @@ jobs:
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update
       - run: cargo fetch
+      - run: ulimit -n 512
       - run:
           name: Test (nightly, Darwin)
           command: cargo +$(cat rust-toolchain) test --release --verbose --all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,8 +278,7 @@ jobs:
       - run: rustup default $(cat rust-toolchain)
       - run: cargo update
       - run: cargo fetch
-      - run: sudo ulimit -n 20000
-      - run: sudo ulimit -u 20000
+      - run: sudo ulimit -n 49000
       - run:
           name: Test (nightly, Darwin)
           command: cargo +$(cat rust-toolchain) test --release --verbose --all


### PR DESCRIPTION
fixes errors in CircleCI mac builds, such as
```
---- fallback::vanilla::tests::fallback_post_poseidon_two_partitions_smaller_top_8_8_2 stdout ----
thread 'fallback::vanilla::tests::fallback_post_poseidon_two_partitions_smaller_top_8_8_2' panicked at 'called `Result::unwrap()` on an `Err` value: Too many open files (os error 24)', /Users/distiller/crate/storage-proofs/core/src/merkle/builders.rs:411:13
```

Fix sets ulimit for system, users (`sudo ulimit` calls) and then user sets ulimit (without `sudo`)