### PR TITLE
feat(parampublish): Select version

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -50,7 +50,7 @@ gperftools = { version = "0.2", optional = true }
 phase2 = { package = "phase21", version = "0.4.0" }
 simplelog = "0.7.4"
 rand_chacha = "0.2.1"
-dialoguer = "0.5.0"
+dialoguer = "0.6.2"
 generic-array = "0.13.2"
 structopt = "0.3.12"
 

--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -10,7 +10,11 @@ use anyhow::{ensure, Context, Result};
 use clap::{App, Arg, ArgMatches};
 use itertools::Itertools;
 
-use filecoin_proofs::param::*;
+use filecoin_proofs::param::{
+    choose_from, filename_to_parameter_id, get_digest_for_file_within_cache,
+    get_full_path_for_file_within_cache, has_extension, parameter_id_to_metadata_map,
+    ParameterData, ParameterMap,
+};
 use storage_proofs::parameter_cache::{
     parameter_cache_dir, CacheEntryMetadata, GROTH_PARAMETER_EXT, PARAMETER_CACHE_DIR,
     PARAMETER_METADATA_EXT, VERIFYING_KEY_EXT,


### PR DESCRIPTION
With the `--all` flag you now get a select menu to select which version
of parameters you want to publish.

That's just a part of https://github.com/filecoin-project/rust-fil-proofs/issues/1079, but it's a start.
I had hoped I would get further, but it makes sense to
do it properly, which takes longer than expected.