### PR TITLE
feat(filecoin-proofs): improve parampublish

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -50,7 +50,7 @@ gperftools = { version = "0.2", optional = true }
 phase2 = { package = "phase21", version = "0.4.0" }
 simplelog = "0.7.4"
 rand_chacha = "0.2.1"
-dialoguer = "0.5.0"
+dialoguer = "0.6.2"
 generic-array = "0.13.2"
 structopt = "0.3.12"
 

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -53,6 +53,7 @@ rand_chacha = "0.2.1"
 dialoguer = "0.6.2"
 generic-array = "0.13.2"
 structopt = "0.3.12"
+humansize = "1.1.0"
 
 [dependencies.reqwest]
 version = "0.9"

--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -111,6 +111,14 @@ fn publish(matches: &ArgMatches) -> Result<()> {
         filenames.truncate(filenames.len() - counter);
     }
 
+    if parameter_ids.is_empty() {
+        println!(
+            "No valid parameters in directory {:?} found.",
+            parameter_cache_dir()
+        );
+        std::process::exit(1)
+    }
+
     // build a mapping from parameter id to metadata
     let meta_map = parameter_id_to_metadata_map(&filenames)?;
 

--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -10,7 +10,11 @@ use anyhow::{ensure, Context, Result};
 use clap::{App, Arg, ArgMatches};
 use itertools::Itertools;
 
-use filecoin_proofs::param::*;
+use filecoin_proofs::param::{
+    choose_from, filename_to_parameter_id, get_digest_for_file_within_cache,
+    get_full_path_for_file_within_cache, has_extension, parameter_id_to_metadata_map,
+    ParameterData, ParameterMap,
+};
 use storage_proofs::parameter_cache::{
     parameter_cache_dir, CacheEntryMetadata, GROTH_PARAMETER_EXT, PARAMETER_CACHE_DIR,
     PARAMETER_METADATA_EXT, VERIFYING_KEY_EXT,

--- a/filecoin-proofs/src/bin/parampublish.rs
+++ b/filecoin-proofs/src/bin/parampublish.rs
@@ -72,14 +72,44 @@ Defaults to '{}'
 fn publish(matches: &ArgMatches) -> Result<()> {
     let ipfs_bin_path = matches.value_of("ipfs-bin").unwrap_or("ipfs");
 
-    let mut filenames = get_filenames_in_cache_dir()?
+    let (mut filenames, counter) = get_filenames_in_cache_dir()?
         .into_iter()
         .filter(|f| {
             has_extension(f, GROTH_PARAMETER_EXT)
                 || has_extension(f, VERIFYING_KEY_EXT)
                 || has_extension(f, PARAMETER_METADATA_EXT)
         })
-        .collect_vec();
+        .sorted()
+        // Don't take filenames into account, which don't have all three files, `.meta`,
+        // `.params and `.vk`
+        .fold((Vec::new(), 0), |(mut result, mut counter), filename| {
+            let parameter_id = filename_to_parameter_id(&filename).unwrap();
+            if !result.is_empty()
+                && parameter_id == filename_to_parameter_id(result.last().unwrap()).unwrap()
+            {
+                counter += 1
+            } else {
+                // There weren't three files for the same parameter ID, hence remove them from
+                // the list of filenames
+                if counter < 3 {
+                    result.truncate(result.len() - counter);
+                }
+
+                // It's a new parameter ID, hence reset the counter
+                counter = 1
+            }
+
+            // Always push the current filename to the result, if there aren't the three
+            // corresponding files, they will be removed later
+            result.push(filename);
+
+            (result, counter)
+        });
+
+    // There might be lef-overs from the last fold iterations
+    if counter < 3 {
+        filenames.truncate(filenames.len() - counter);
+    }
 
     // build a mapping from parameter id to metadata
     let meta_map = parameter_id_to_metadata_map(&filenames)?;

--- a/filecoin-proofs/src/bin/phase2.rs
+++ b/filecoin-proofs/src/bin/phase2.rs
@@ -368,9 +368,9 @@ fn create_initial_params<Tree: 'static + MerkleTreeTrait>(
 
 /// Prompt the user to mash on their keyboard to gather entropy.
 fn prompt_for_randomness() -> [u8; 32] {
-    use dialoguer::{theme::ColorfulTheme, PasswordInput};
+    use dialoguer::{theme::ColorfulTheme, Password};
 
-    let raw = PasswordInput::with_theme(&ColorfulTheme::default())
+    let raw = Password::with_theme(&ColorfulTheme::default())
         .with_prompt(
             "Please randomly press your keyboard for entropy (press Return/Enter when finished)",
         )

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -67,25 +67,26 @@ pub fn has_extension<S: AsRef<str>, P: AsRef<Path>>(filename: P, ext: S) -> bool
         .unwrap_or(false)
 }
 
-/// Builds a map from filename (in cache) to metadata.
-pub fn parameter_id_to_metadata_map<S: AsRef<str>>(
-    filenames: &[S],
+// Adds a file extension to the given filename
+pub fn add_extension(filename: &str, ext: &str) -> String {
+    format!("{}.{}", filename, ext)
+}
+
+/// Builds a map from a parameter_id (file in cache) to metadata.
+pub fn parameter_id_to_metadata_map(
+    parameter_ids: &[String],
 ) -> Result<BTreeMap<String, CacheEntryMetadata>> {
     let mut map: BTreeMap<String, CacheEntryMetadata> = Default::default();
 
-    for filename in filenames {
-        if has_extension(PathBuf::from(filename.as_ref()), PARAMETER_METADATA_EXT) {
-            let file_path = get_full_path_for_file_within_cache(filename.as_ref());
-            let file = File::open(&file_path)
-                .with_context(|| format!("could not open path={:?}", file_path))?;
+    for parameter_id in parameter_ids {
+        let filename = add_extension(parameter_id, PARAMETER_METADATA_EXT);
+        let file_path = get_full_path_for_file_within_cache(&filename);
+        let file = File::open(&file_path)
+            .with_context(|| format!("could not open path={:?}", file_path))?;
 
-            let meta = serde_json::from_reader(file)?;
+        let meta = serde_json::from_reader(file)?;
 
-            let p_id = filename_to_parameter_id(PathBuf::from(filename.as_ref()))
-                .context("could not map filename to parameter id")?;
-
-            map.insert(p_id, meta);
-        }
+        map.insert(parameter_id.to_string(), meta);
     }
 
     Ok(map)

--- a/filecoin-proofs/tests/parampublish/prompts_to_publish.rs
+++ b/filecoin-proofs/tests/parampublish/prompts_to_publish.rs
@@ -74,30 +74,12 @@ fn displays_sector_size_in_prompt() {
 }
 
 #[test]
-fn all_flag_disables_prompt() -> Result<(), FailureError> {
-    let filenames = vec!["aaa.vk", "aaa.params"];
-
-    let (mut session, _) = ParamPublishSessionBuilder::new()
-        .with_session_timeout_ms(1000)
-        .with_prompt_disabled()
-        .with_files(&filenames)
-        .with_metadata("aaa.meta", &CacheEntryMetadata { sector_size: 1234 })
-        .build();
-
-    session.exp_string("publishing 2 files")?;
-    session.exp_string("done")?;
-
-    Ok(())
-}
-
-#[test]
 fn no_assets_no_prompt() -> Result<(), FailureError> {
     let (mut session, _) = ParamPublishSessionBuilder::new()
         .with_session_timeout_ms(1000)
         .build();
 
-    session.exp_string("no files to publish")?;
-    session.exp_string("done")?;
+    session.exp_string("No valid parameters in directory")?;
 
     Ok(())
 }

--- a/filecoin-proofs/tests/parampublish/read_metadata_files.rs
+++ b/filecoin-proofs/tests/parampublish/read_metadata_files.rs
@@ -5,7 +5,7 @@ use crate::parampublish::support::session::ParamPublishSessionBuilder;
 #[test]
 fn fails_if_missing_metadata_file() -> Result<(), FailureError> {
     // missing the corresponding .meta file
-    let filenames = vec!["aaa.vk", "aaa.params"];
+    let filenames = vec!["v12-aaa.vk", "v12-aaa.params"];
 
     let (mut session, _) = ParamPublishSessionBuilder::new()
         .with_session_timeout_ms(1000)
@@ -14,7 +14,7 @@ fn fails_if_missing_metadata_file() -> Result<(), FailureError> {
         .build();
 
     // error!
-    session.exp_string("no metadata found for parameter id aaa")?;
+    session.exp_string("No valid parameters in directory")?;
 
     Ok(())
 }
@@ -25,8 +25,8 @@ fn fails_if_malformed_metadata_file() -> Result<(), FailureError> {
 
     let (mut session, _) = ParamPublishSessionBuilder::new()
         .with_session_timeout_ms(1000)
-        .with_files(&vec!["aaa.vk", "aaa.params"])
-        .with_file_and_bytes("aaa.meta", &mut malformed)
+        .with_files(&vec!["v11-aaa.vk", "v11-aaa.params"])
+        .with_file_and_bytes("v11-aaa.meta", &mut malformed)
         .with_prompt_disabled()
         .build();
 

--- a/filecoin-proofs/tests/parampublish/write_json_manifest.rs
+++ b/filecoin-proofs/tests/parampublish/write_json_manifest.rs
@@ -12,7 +12,7 @@ use crate::support::{tmp_manifest, FakeIpfsBin};
 
 #[test]
 fn writes_json_manifest() -> Result<(), FailureError> {
-    let filenames = vec!["aaa.vk", "aaa.params"];
+    let filenames = vec!["v10-aaa.vk", "v10-aaa.params"];
 
     let manifest_path = tmp_manifest(None)?;
 
@@ -21,7 +21,7 @@ fn writes_json_manifest() -> Result<(), FailureError> {
     let (mut session, files_in_cache) = ParamPublishSessionBuilder::new()
         .with_session_timeout_ms(1000)
         .with_files(&filenames)
-        .with_metadata("aaa.meta", &CacheEntryMetadata { sector_size: 1234 })
+        .with_metadata("v10-aaa.meta", &CacheEntryMetadata { sector_size: 1234 })
         .write_manifest_to(manifest_path.clone())
         .with_ipfs_bin(&ipfs)
         .with_prompt_disabled()
@@ -30,6 +30,14 @@ fn writes_json_manifest() -> Result<(), FailureError> {
     // compute checksums from files added to cache to compare with
     // manifest entries after publishing completes
     let cache_checksums = filename_to_checksum(&ipfs, files_in_cache.as_ref());
+
+    session.exp_string("Select a version")?;
+    // There is only one version of parameters, accept that one
+    session.send_line("")?;
+    //session.exp_regex(".*Select the sizes to publish.*")?;
+    session.exp_string("Select the sizes to publish")?;
+    // There is only one size, accept that one
+    session.send_line("")?;
 
     // wait for confirmation...
     session.exp_string("publishing 2 files")?;


### PR DESCRIPTION
This PR fixes parts of https://github.com/filecoin-project/rust-fil-proofs/issues/1079.

I originally misunderstood some of the requirements, hence it got fancier then probably anticipated. You can now select the sizes you want to publish, with having the defaults pre-selected.

This PR can also be reviewed commit per commit, I tried to make them self-contained (the commit message should explain some of the reasons for some of the changes).

@DrPeterVanNostrand I've added you for review as I updated dialoguer, which also needed a little change in the phase2 bin code. I just want to make sure you are aware of that change, in case something breaks (which I won't expect).

This PR supersedes #1090.