### PR TITLE
tooling: refactor create_replicas()

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -8,7 +8,6 @@ use crate::prodbench::ProdbenchInputs;
 mod hash_fns;
 mod merkleproofs;
 mod prodbench;
-mod shared;
 mod stacked;
 mod window_post;
 mod winning_post;

--- a/fil-proofs-tooling/src/bin/benchy/prodbench.rs
+++ b/fil-proofs-tooling/src/bin/benchy/prodbench.rs
@@ -1,4 +1,5 @@
 use bellperson::Circuit;
+use fil_proofs_tooling::shared::{create_replicas, PROVER_ID, RANDOMNESS, TICKET_BYTES};
 use fil_proofs_tooling::{measure, Metadata};
 use filecoin_proofs::constants::{DefaultOctTree, POREP_PARTITIONS};
 use filecoin_proofs::types::PaddedBytesAmount;
@@ -22,8 +23,6 @@ use storage_proofs::measurements::Operation;
 use storage_proofs::measurements::OP_MEASUREMENTS;
 use storage_proofs::parameter_cache::CacheableParameters;
 use storage_proofs::proof::ProofScheme;
-
-use crate::shared::{create_replicas, PROVER_ID, RANDOMNESS, TICKET_BYTES};
 
 const SEED: [u8; 16] = [
     0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc, 0xe5,

--- a/fil-proofs-tooling/src/bin/benchy/prodbench.rs
+++ b/fil-proofs-tooling/src/bin/benchy/prodbench.rs
@@ -183,7 +183,11 @@ pub fn run(
 
     assert!(inputs.num_sectors > 0, "Missing num_sectors");
 
-    let (cfg, repls) = create_replicas(sector_size, inputs.num_sectors as usize, only_add_piece);
+    let (cfg, repls) = create_replicas::<DefaultOctLCTree>(
+        sector_size,
+        inputs.num_sectors as usize,
+        only_add_piece,
+    );
 
     if only_add_piece || only_replicate {
         augment_with_op_measurements(&mut outputs);

--- a/fil-proofs-tooling/src/bin/benchy/shared.rs
+++ b/fil-proofs-tooling/src/bin/benchy/shared.rs
@@ -60,6 +60,19 @@ pub fn create_piece(piece_bytes: UnpaddedBytesAmount) -> NamedTempFile {
     file
 }
 
+/// Create a replica for a single sector
+pub fn create_replica<Tree: 'static + MerkleTreeTrait>(
+    sector_size: u64,
+) -> (SectorId, PreCommitReplicaOutput<Tree>) {
+    let (_porep_config, result) = create_replicas::<Tree>(SectorSize(sector_size), 1, false);
+    // Extract the sector ID and replica output out of the result
+    result
+        .unwrap()
+        .0
+        .pop()
+        .expect("failed to create replica outputs")
+}
+
 #[allow(clippy::type_complexity)]
 pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
     sector_size: SectorSize,

--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::io::{stdout, Seek, SeekFrom, Write};
 
+use fil_proofs_tooling::shared::{PROVER_ID, RANDOMNESS, TICKET_BYTES};
 use fil_proofs_tooling::{measure, Metadata};
 use filecoin_proofs::constants::{
     POREP_PARTITIONS, WINDOW_POST_CHALLENGE_COUNT, WINDOW_POST_SECTOR_COUNT,
@@ -20,8 +21,6 @@ use serde::Serialize;
 use storage_proofs::merkle::MerkleTreeTrait;
 use storage_proofs::sector::SectorId;
 use tempfile::NamedTempFile;
-
-use crate::shared::{PROVER_ID, RANDOMNESS, TICKET_BYTES};
 
 const SECTOR_ID: u64 = 0;
 

--- a/fil-proofs-tooling/src/bin/benchy/winning_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/winning_post.rs
@@ -1,29 +1,18 @@
-use std::io::{stdout, Seek, SeekFrom, Write};
+use std::io::stdout;
 
+use anyhow::anyhow;
 use fil_proofs_tooling::{measure, Metadata};
-use filecoin_proofs::constants::{
-    POREP_PARTITIONS, WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT,
-};
-use filecoin_proofs::types::{
-    PaddedBytesAmount, PoRepConfig, PoRepProofPartitions, PoStConfig, SectorSize,
-    UnpaddedBytesAmount,
-};
+use filecoin_proofs::constants::{WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT};
+use filecoin_proofs::types::PoStConfig;
 use filecoin_proofs::{
-    add_piece, generate_piece_commitment, generate_winning_post,
-    generate_winning_post_sector_challenge, seal_commit_phase1, seal_commit_phase2,
-    seal_pre_commit_phase1, seal_pre_commit_phase2, validate_cache_for_commit,
-    validate_cache_for_precommit_phase2, verify_winning_post, with_shape, PoStType,
-    PrivateReplicaInfo, PublicReplicaInfo,
+    generate_winning_post, generate_winning_post_sector_challenge, verify_winning_post, with_shape,
+    PoStType,
 };
 use log::info;
 use serde::Serialize;
 use storage_proofs::merkle::MerkleTreeTrait;
-use storage_proofs::sector::SectorId;
-use tempfile::NamedTempFile;
 
-use crate::shared::{PROVER_ID, RANDOMNESS, TICKET_BYTES};
-
-const SECTOR_ID: u64 = 0;
+use crate::shared::{create_replica, PROVER_ID, RANDOMNESS};
 
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -60,114 +49,20 @@ impl Report {
 pub fn run_fallback_post_bench<Tree: 'static + MerkleTreeTrait>(
     sector_size: u64,
 ) -> anyhow::Result<()> {
-    let sector_size_unpadded_bytes_ammount =
-        UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size));
-
-    // Create files for the staged and sealed sectors.
-    let mut staged_file =
-        NamedTempFile::new().expect("could not create temp file for staged sector");
-
-    let sealed_file = NamedTempFile::new().expect("could not create temp file for sealed sector");
-
-    // Generate the data from which we will create a replica, we will then prove the continued
-    // storage of that replica using the PoSt.
-    let piece_bytes: Vec<u8> = (0..usize::from(sector_size_unpadded_bytes_ammount))
-        .map(|_| rand::random::<u8>())
-        .collect();
-
-    let mut piece_file = NamedTempFile::new()?;
-    piece_file.write_all(&piece_bytes)?;
-    piece_file.as_file_mut().sync_all()?;
-    piece_file.as_file_mut().seek(SeekFrom::Start(0))?;
-
-    let piece_info =
-        generate_piece_commitment(piece_file.as_file_mut(), sector_size_unpadded_bytes_ammount)?;
-    piece_file.as_file_mut().seek(SeekFrom::Start(0))?;
-
-    add_piece(
-        &mut piece_file,
-        &mut staged_file,
-        sector_size_unpadded_bytes_ammount,
-        &[],
-    )?;
-
-    let piece_infos = vec![piece_info];
-
-    // Replicate the staged sector, write the replica file to `sealed_path`.
-    let porep_config = PoRepConfig {
-        sector_size: SectorSize(sector_size),
-        partitions: PoRepProofPartitions(
-            *POREP_PARTITIONS
-                .read()
-                .unwrap()
-                .get(&(sector_size))
-                .unwrap(),
-        ),
-    };
-    let cache_dir = tempfile::tempdir().unwrap();
-    let sector_id = SectorId::from(SECTOR_ID);
-    let sector_count = WINNING_POST_SECTOR_COUNT;
-
-    let phase1_output = seal_pre_commit_phase1::<_, _, _, Tree>(
-        porep_config,
-        cache_dir.path(),
-        staged_file.path(),
-        sealed_file.path(),
-        PROVER_ID,
-        sector_id,
-        TICKET_BYTES,
-        &piece_infos,
-    )?;
-
-    validate_cache_for_precommit_phase2::<_, _, Tree>(
-        cache_dir.path(),
-        sealed_file.path(),
-        &phase1_output,
-    )?;
-
-    let seal_pre_commit_output = seal_pre_commit_phase2::<_, _, Tree>(
-        porep_config,
-        phase1_output,
-        cache_dir.path(),
-        sealed_file.path(),
-    )?;
-
-    let seed = [0u8; 32];
-    let comm_r = seal_pre_commit_output.comm_r;
-
-    validate_cache_for_commit::<_, _, Tree>(cache_dir.path(), sealed_file.path())?;
-
-    let phase1_output = seal_commit_phase1::<_, Tree>(
-        porep_config,
-        cache_dir.path(),
-        sealed_file.path(),
-        PROVER_ID,
-        sector_id,
-        TICKET_BYTES,
-        seed,
-        seal_pre_commit_output,
-        &piece_infos,
-    )?;
-
-    let _seal_commit_output =
-        seal_commit_phase2::<Tree>(porep_config, phase1_output, PROVER_ID, sector_id)?;
-
-    let pub_replica = PublicReplicaInfo::new(comm_r).expect("failed to create public replica info");
-
-    let priv_replica = PrivateReplicaInfo::<Tree>::new(
-        sealed_file.path().to_path_buf(),
-        comm_r,
-        cache_dir.into_path(),
-    )
-    .expect("failed to create private replica info");
+    if WINNING_POST_SECTOR_COUNT != 1 {
+        return Err(anyhow!(
+            "This benchmark only works with WINNING_POST_SECTOR_COUNT == 1"
+        ));
+    }
+    let (sector_id, replica_output) = create_replica::<Tree>(sector_size);
 
     // Store the replica's private and publicly facing info for proving and verifying respectively.
-    let pub_replica_info = vec![(sector_id, pub_replica)];
-    let priv_replica_info = vec![(sector_id, priv_replica)];
+    let pub_replica_info = vec![(sector_id, replica_output.public_replica_info)];
+    let priv_replica_info = vec![(sector_id, replica_output.private_replica_info)];
 
     let post_config = PoStConfig {
         sector_size: sector_size.into(),
-        sector_count,
+        sector_count: WINNING_POST_SECTOR_COUNT,
         challenge_count: WINNING_POST_CHALLENGE_COUNT,
         typ: PoStType::Winning,
         priority: true,
@@ -177,7 +72,7 @@ pub fn run_fallback_post_bench<Tree: 'static + MerkleTreeTrait>(
         generate_winning_post_sector_challenge::<Tree>(
             &post_config,
             &RANDOMNESS,
-            sector_count as u64,
+            WINNING_POST_SECTOR_COUNT as u64,
             PROVER_ID,
         )
     })

--- a/fil-proofs-tooling/src/bin/benchy/winning_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/winning_post.rs
@@ -1,6 +1,7 @@
 use std::io::stdout;
 
 use anyhow::anyhow;
+use fil_proofs_tooling::shared::{create_replica, PROVER_ID, RANDOMNESS};
 use fil_proofs_tooling::{measure, Metadata};
 use filecoin_proofs::constants::{WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT};
 use filecoin_proofs::types::PoStConfig;
@@ -11,8 +12,6 @@ use filecoin_proofs::{
 use log::info;
 use serde::Serialize;
 use storage_proofs::merkle::MerkleTreeTrait;
-
-use crate::shared::{create_replica, PROVER_ID, RANDOMNESS};
 
 #[derive(Serialize)]
 #[serde(rename_all = "kebab-case")]

--- a/fil-proofs-tooling/src/lib.rs
+++ b/fil-proofs-tooling/src/lib.rs
@@ -1,4 +1,6 @@
 pub mod measure;
 pub mod metadata;
+pub mod shared;
 pub use measure::{measure, FuncMeasurement};
 pub use metadata::Metadata;
+pub use shared::{create_replica, create_replicas};

--- a/fil-proofs-tooling/src/shared.rs
+++ b/fil-proofs-tooling/src/shared.rs
@@ -5,7 +5,6 @@ use rand::RngCore;
 use rayon::prelude::*;
 use tempfile::NamedTempFile;
 
-use fil_proofs_tooling::{measure, FuncMeasurement};
 use filecoin_proofs::constants::POREP_PARTITIONS;
 use filecoin_proofs::types::{
     MerkleTreeTrait, PaddedBytesAmount, PoRepConfig, SectorSize, UnpaddedBytesAmount,
@@ -16,9 +15,11 @@ use filecoin_proofs::{
 };
 use storage_proofs::sector::SectorId;
 
-pub(super) const PROVER_ID: [u8; 32] = [9; 32];
-pub(super) const RANDOMNESS: [u8; 32] = [44; 32];
-pub(super) const TICKET_BYTES: [u8; 32] = [1; 32];
+use crate::{measure, FuncMeasurement};
+
+pub const PROVER_ID: [u8; 32] = [9; 32];
+pub const RANDOMNESS: [u8; 32] = [44; 32];
+pub const TICKET_BYTES: [u8; 32] = [1; 32];
 
 pub struct PreCommitReplicaOutput<Tree: 'static + MerkleTreeTrait> {
     pub piece_info: Vec<PieceInfo>,


### PR DESCRIPTION
In the fil-proofs-tooling it's a common operation to create replicas. This creation is now properly refactored so that it can be used by several binaries.

This commit doesn't change any functionality it's a pure refactoring.

The commits are self-contained so this PR might be easier to review on a commit per commit basis.