### PR TITLE
fix: improve paramcache

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -54,6 +54,7 @@ dialoguer = "0.6.2"
 generic-array = "0.13.2"
 structopt = "0.3.12"
 humansize = "1.1.0"
+indicatif = "0.14.0"
 
 [dependencies.reqwest]
 version = "0.9"


### PR DESCRIPTION
When no sizes are given as input, you get a multiselect dialog on
the terminal.

Also the parameter generation now has a spinning indicator while
parameters are generated.