### PR TITLE
docs: add OpenCL to the build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Configure to use nightly:
 
 **NOTE:** `rust-fil-proofs` can only be built for and run on 64-bit platforms; building will panic if the target architecture is not 64-bits.
 
+Before building you will need OpenCL to be installed, on Ubuntu this can be achieved with `apt install ocl-icd-opencl-dev`.
+
 ```
 > cargo build --release --all
 ```


### PR DESCRIPTION
After cloning the repository `cargo build` fails if the system does not have OpenCL installed.

Add comment as such, including Ubuntu command to install OpenCL.