### PR TITLE
fix: avoid extra replica disk write where not required

### DIFF
--- a/storage-proofs/core/src/test_helper.rs
+++ b/storage-proofs/core/src/test_helper.rs
@@ -1,3 +1,25 @@
+use memmap::MmapMut;
+use memmap::MmapOptions;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+
+pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
+    let mut f = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(replica_path)
+        .expect("Failed to create replica");
+    f.write_all(data).expect("Failed to write data to replica");
+
+    unsafe {
+        MmapOptions::new()
+            .map_mut(&f)
+            .expect("Failed to back memory map with tempfile")
+    }
+}
+
 #[macro_export]
 macro_rules! table_tests {
     ($property_test_func:ident {

--- a/storage-proofs/porep/src/drg/circuit.rs
+++ b/storage-proofs/porep/src/drg/circuit.rs
@@ -307,15 +307,10 @@ mod tests {
 
     use ff::Field;
     use generic_array::typenum;
-    use memmap::MmapMut;
-    use memmap::MmapOptions;
     use merkletree::store::StoreConfig;
     use pretty_assertions::assert_eq;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    use std::path::Path;
     use storage_proofs_core::{
         cache_key::CacheKey,
         compound_proof,
@@ -325,6 +320,7 @@ mod tests {
         hasher::PedersenHasher,
         merkle::MerkleProofTrait,
         proof::ProofScheme,
+        test_helper::setup_replica,
         util::data_at_node,
     };
 
@@ -332,22 +328,6 @@ mod tests {
     use crate::drg;
     use crate::stacked::BINARY_ARITY;
     use crate::PoRep;
-
-    pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
-        let mut f = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(replica_path)
-            .expect("Failed to create replica");
-        f.write_all(data).expect("Failed to write data to replica");
-
-        unsafe {
-            MmapOptions::new()
-                .map_mut(&f)
-                .expect("Failed to back memory map with tempfile")
-        }
-    }
 
     #[test]
     fn drgporep_input_circuit_with_bls12_381() {

--- a/storage-proofs/porep/src/drg/circuit.rs
+++ b/storage-proofs/porep/src/drg/circuit.rs
@@ -307,10 +307,15 @@ mod tests {
 
     use ff::Field;
     use generic_array::typenum;
+    use memmap::MmapMut;
+    use memmap::MmapOptions;
     use merkletree::store::StoreConfig;
     use pretty_assertions::assert_eq;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::path::Path;
     use storage_proofs_core::{
         cache_key::CacheKey,
         compound_proof,
@@ -328,6 +333,22 @@ mod tests {
     use crate::stacked::BINARY_ARITY;
     use crate::PoRep;
 
+    pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
+        let mut f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(replica_path)
+            .expect("Failed to create replica");
+        f.write_all(data).expect("Failed to write data to replica");
+
+        unsafe {
+            MmapOptions::new()
+                .map_mut(&f)
+                .expect("Failed to back memory map with tempfile")
+        }
+    }
+
     #[test]
     fn drgporep_input_circuit_with_bls12_381() {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
@@ -338,15 +359,26 @@ mod tests {
 
         let replica_id: Fr = Fr::random(rng);
 
-        let mut data: Vec<u8> = (0..nodes)
+        let data: Vec<u8> = (0..nodes)
             .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
             .collect();
 
-        // TODO: don't clone everything
-        let original_data = data.clone();
+        // MT for original data is always named tree-d, and it will be
+        // referenced later in the process as such.
+        let cache_dir = tempfile::tempdir().unwrap();
+        let config = StoreConfig::new(
+            cache_dir.path(),
+            CacheKey::CommDTree.to_string(),
+            StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
+        );
+
+        // Generate a replica path.
+        let replica_path = cache_dir.path().join("replica-path");
+        let mut mmapped_data = setup_replica(&data, &replica_path);
+
         let data_node: Option<Fr> = Some(
             bytes_into_fr(
-                data_at_node(&original_data, challenge).expect("failed to read original data"),
+                data_at_node(&mmapped_data, challenge).expect("failed to read original data"),
             )
             .unwrap(),
         );
@@ -362,26 +394,12 @@ mod tests {
             challenges_count: 1,
         };
 
-        // MT for original data is always named tree-d, and it will be
-        // referenced later in the process as such.
-        let cache_dir = tempfile::tempdir().unwrap();
-        let config = StoreConfig::new(
-            cache_dir.path(),
-            CacheKey::CommDTree.to_string(),
-            StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
-        );
-
-        // Generate a replica path.
-        let temp_dir = tempdir::TempDir::new("drgporep-input-circuit-with-bls12-381").unwrap();
-        let temp_path = temp_dir.path();
-        let replica_path = temp_path.join("replica-path");
-
         let pp = drg::DrgPoRep::<PedersenHasher, BucketGraph<_>>::setup(&sp)
             .expect("failed to create drgporep setup");
         let (tau, aux) = drg::DrgPoRep::<PedersenHasher, _>::replicate(
             &pp,
             &replica_id.into(),
-            (&mut data[..]).into(),
+            (mmapped_data.as_mut()).into(),
             None,
             config,
             replica_path.clone(),
@@ -501,6 +519,8 @@ mod tests {
             expected_inputs.len() - 1,
             "inputs are not the same length"
         );
+
+        cache_dir.close().expect("Failed to remove cache dir");
     }
 
     #[test]

--- a/storage-proofs/porep/src/drg/compound.rs
+++ b/storage-proofs/porep/src/drg/compound.rs
@@ -282,15 +282,10 @@ mod tests {
     use super::*;
 
     use ff::Field;
-    use memmap::MmapMut;
-    use memmap::MmapOptions;
     use merkletree::store::StoreConfig;
     use pretty_assertions::assert_eq;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    use std::path::Path;
     use storage_proofs_core::{
         cache_key::CacheKey,
         compound_proof,
@@ -300,26 +295,11 @@ mod tests {
         hasher::{Hasher, PedersenHasher, PoseidonHasher},
         merkle::{BinaryMerkleTree, MerkleTreeTrait},
         proof::NoRequirements,
+        test_helper::setup_replica,
     };
 
     use crate::stacked::BINARY_ARITY;
     use crate::{drg, PoRep};
-
-    pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
-        let mut f = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(replica_path)
-            .expect("Failed to create replica");
-        f.write_all(data).expect("Failed to write data to replica");
-
-        unsafe {
-            MmapOptions::new()
-                .map_mut(&f)
-                .expect("Failed to back memory map with tempfile")
-        }
-    }
 
     #[test]
     #[ignore] // Slow test – run only when compiled for release.

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -620,14 +620,9 @@ mod tests {
     use super::*;
 
     use ff::Field;
-    use memmap::MmapMut;
-    use memmap::MmapOptions;
     use paired::bls12_381::Fr;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    use std::path::Path;
     use storage_proofs_core::{
         cache_key::CacheKey,
         drgraph::{new_seed, BucketGraph, BASE_DEGREE},
@@ -635,27 +630,12 @@ mod tests {
         hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher},
         merkle::{BinaryMerkleTree, MerkleTreeTrait},
         table_tests,
+        test_helper::setup_replica,
         util::data_at_node,
     };
     use tempfile;
 
     use crate::stacked::BINARY_ARITY;
-
-    pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
-        let mut f = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(replica_path)
-            .expect("Failed to create replica");
-        f.write_all(data).expect("Failed to write data to replica");
-
-        unsafe {
-            MmapOptions::new()
-                .map_mut(&f)
-                .expect("Failed to back memory map with tempfile")
-        }
-    }
 
     fn test_extract_all<Tree: MerkleTreeTrait>() {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -1,4 +1,3 @@
-use std::fs::OpenOptions;
 use std::marker::PhantomData;
 use std::path::PathBuf;
 
@@ -454,8 +453,6 @@ where
     ) -> Result<(Self::Tau, Self::ProverAux)> {
         use storage_proofs_core::cache_key::CacheKey;
 
-        use std::io::prelude::*;
-
         let tree_d = match data_tree {
             Some(tree) => tree,
             None => create_base_merkle_tree::<BinaryMerkleTree<H>>(
@@ -485,13 +482,6 @@ where
 
             encoded.write_bytes(&mut data.as_mut()[start..end])?;
         }
-
-        // Write out the encoded data here.
-        let mut f = OpenOptions::new()
-            .write(true)
-            .create(true)
-            .open(&replica_path)?;
-        f.write_all(&data.as_ref())?;
 
         let replica_config = ReplicaConfig {
             path: replica_path,
@@ -635,8 +625,9 @@ mod tests {
     use paired::bls12_381::Fr;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
-    use std::fs::File;
+    use std::fs::OpenOptions;
     use std::io::Write;
+    use std::path::Path;
     use storage_proofs_core::{
         cache_key::CacheKey,
         drgraph::{new_seed, BucketGraph, BASE_DEGREE},
@@ -650,15 +641,18 @@ mod tests {
 
     use crate::stacked::BINARY_ARITY;
 
-    pub fn file_backed_mmap_from(data: &[u8]) -> MmapMut {
-        let mut tmpfile: File = tempfile::tempfile().expect("Failed to create tempfile");
-        tmpfile
-            .write_all(data)
-            .expect("Failed to write data to tempfile");
+    pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
+        let mut f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(replica_path)
+            .expect("Failed to create replica");
+        f.write_all(data).expect("Failed to write data to replica");
 
         unsafe {
             MmapOptions::new()
-                .map_mut(&tmpfile)
+                .map_mut(&f)
                 .expect("Failed to back memory map with tempfile")
         }
     }
@@ -668,14 +662,25 @@ mod tests {
 
         let replica_id: <Tree::Hasher as Hasher>::Domain =
             <Tree::Hasher as Hasher>::Domain::random(rng);
-        let data = vec![2u8; 32 * 4];
+        let nodes = 4;
+        let data = vec![2u8; 32 * nodes];
 
-        // create a copy, so we can compare roundtrips
-        let mut mmapped_data_copy = file_backed_mmap_from(&data);
+        // MT for original data is always named tree-d, and it will be
+        // referenced later in the process as such.
+        let cache_dir = tempfile::tempdir().unwrap();
+        let config = StoreConfig::new(
+            cache_dir.path(),
+            CacheKey::CommDTree.to_string(),
+            StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
+        );
+
+        // Generate a replica path.
+        let replica_path = cache_dir.path().join("replica-path");
+        let mut mmapped_data = setup_replica(&data, &replica_path);
 
         let sp = SetupParams {
             drg: DrgParams {
-                nodes: data.len() / 32,
+                nodes,
                 degree: BASE_DEGREE,
                 expansion_degree: 0,
                 seed: new_seed(),
@@ -687,24 +692,10 @@ mod tests {
         let pp: PublicParams<Tree::Hasher, BucketGraph<Tree::Hasher>> =
             DrgPoRep::setup(&sp).expect("setup failed");
 
-        // MT for original data is always named tree-d, and it will be
-        // referenced later in the process as such.
-        let cache_dir = tempfile::tempdir().unwrap();
-        let config = StoreConfig::new(
-            cache_dir.path(),
-            CacheKey::CommDTree.to_string(),
-            StoreConfig::default_cached_above_base_layer(data.len() / 32, BINARY_ARITY),
-        );
-
-        // Generate a replica path.
-        let temp_dir = tempdir::TempDir::new("test-extract-all").unwrap();
-        let temp_path = temp_dir.path();
-        let replica_path = temp_path.join("replica-path");
-
         DrgPoRep::replicate(
             &pp,
             &replica_id,
-            (mmapped_data_copy.as_mut()).into(),
+            (mmapped_data.as_mut()).into(),
             None,
             config.clone(),
             replica_path.clone(),
@@ -712,13 +703,13 @@ mod tests {
         .expect("replication failed");
 
         let mut copied = vec![0; data.len()];
-        copied.copy_from_slice(&mmapped_data_copy);
+        copied.copy_from_slice(&mmapped_data);
         assert_ne!(data, copied, "replication did not change data");
 
         let decoded_data = DrgPoRep::<Tree::Hasher, _>::extract_all(
             &pp,
             &replica_id,
-            &mut mmapped_data_copy,
+            mmapped_data.as_mut(),
             Some(config.clone()),
         )
         .unwrap_or_else(|e| {
@@ -726,6 +717,8 @@ mod tests {
         });
 
         assert_eq!(data, decoded_data.as_slice(), "failed to extract data");
+
+        cache_dir.close().expect("Failed to remove cache dir");
     }
 
     #[test]
@@ -751,8 +744,18 @@ mod tests {
         let nodes = 4;
         let data = vec![2u8; 32 * nodes];
 
-        // create a copy, so we can compare roundtrips
-        let mut mmapped_data_copy = file_backed_mmap_from(&data);
+        // MT for original data is always named tree-d, and it will be
+        // referenced later in the process as such.
+        let cache_dir = tempfile::tempdir().unwrap();
+        let config = StoreConfig::new(
+            cache_dir.path(),
+            CacheKey::CommDTree.to_string(),
+            StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
+        );
+
+        // Generate a replica path.
+        let replica_path = cache_dir.path().join("replica-path");
+        let mut mmapped_data = setup_replica(&data, &replica_path);
 
         let sp = SetupParams {
             drg: DrgParams {
@@ -768,24 +771,10 @@ mod tests {
         let pp =
             DrgPoRep::<Tree::Hasher, BucketGraph<Tree::Hasher>>::setup(&sp).expect("setup failed");
 
-        // MT for original data is always named tree-d, and it will be
-        // referenced later in the process as such.
-        let cache_dir = tempfile::tempdir().unwrap();
-        let config = StoreConfig::new(
-            cache_dir.path(),
-            CacheKey::CommDTree.to_string(),
-            StoreConfig::default_cached_above_base_layer(data.len() / 32, BINARY_ARITY),
-        );
-
-        // Generate a replica path.
-        let temp_dir = tempdir::TempDir::new("test-extract").unwrap();
-        let temp_path = temp_dir.path();
-        let replica_path = temp_path.join("replica-path");
-
         DrgPoRep::replicate(
             &pp,
             &replica_id,
-            (mmapped_data_copy.as_mut()).into(),
+            (mmapped_data.as_mut()).into(),
             None,
             config.clone(),
             replica_path.clone(),
@@ -793,18 +782,13 @@ mod tests {
         .expect("replication failed");
 
         let mut copied = vec![0; data.len()];
-        copied.copy_from_slice(&mmapped_data_copy);
+        copied.copy_from_slice(&mmapped_data);
         assert_ne!(data, copied, "replication did not change data");
 
         for i in 0..nodes {
-            let decoded_data = DrgPoRep::extract(
-                &pp,
-                &replica_id,
-                &mmapped_data_copy,
-                i,
-                Some(config.clone()),
-            )
-            .expect("failed to extract node data from PoRep");
+            let decoded_data =
+                DrgPoRep::extract(&pp, &replica_id, &mmapped_data, i, Some(config.clone()))
+                    .expect("failed to extract node data from PoRep");
 
             let original_data = data_at_node(&data, i).unwrap();
 
@@ -852,8 +836,18 @@ mod tests {
                 .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
                 .collect();
 
-            // create a copy, so we can comare roundtrips
-            let mut mmapped_data_copy = file_backed_mmap_from(&data);
+            // MT for original data is always named tree-d, and it will be
+            // referenced later in the process as such.
+            let cache_dir = tempfile::tempdir().unwrap();
+            let config = StoreConfig::new(
+                cache_dir.path(),
+                CacheKey::CommDTree.to_string(),
+                StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
+            );
+
+            // Generate a replica path.
+            let replica_path = cache_dir.path().join("replica-path");
+            let mut mmapped_data = setup_replica(&data, &replica_path);
 
             let challenge = i;
 
@@ -870,24 +864,10 @@ mod tests {
 
             let pp = DrgPoRep::<Tree::Hasher, BucketGraph<_>>::setup(&sp).expect("setup failed");
 
-            // MT for original data is always named tree-d, and it will be
-            // referenced later in the process as such.
-            let cache_dir = tempfile::tempdir().unwrap();
-            let config = StoreConfig::new(
-                cache_dir.path(),
-                CacheKey::CommDTree.to_string(),
-                StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
-            );
-
-            // Generate a replica path.
-            let temp_dir = tempdir::TempDir::new("prove-verify-aux").unwrap();
-            let temp_path = temp_dir.path();
-            let replica_path = temp_path.join("replica-path");
-
             let (tau, aux) = DrgPoRep::<Tree::Hasher, _>::replicate(
                 &pp,
                 &replica_id,
-                (mmapped_data_copy.as_mut()).into(),
+                (mmapped_data.as_mut()).into(),
                 None,
                 config,
                 replica_path.clone(),
@@ -895,8 +875,7 @@ mod tests {
             .expect("replication failed");
 
             let mut copied = vec![0; data.len()];
-            copied.copy_from_slice(&mmapped_data_copy);
-
+            copied.copy_from_slice(&mmapped_data);
             assert_ne!(data, copied, "replication did not change data");
 
             let pub_inputs = PublicInputs::<<Tree::Hasher as Hasher>::Domain> {
@@ -1013,6 +992,8 @@ mod tests {
                     "failed to verify"
                 );
             }
+
+            cache_dir.close().expect("Failed to remove cache dir");
 
             // Normally, just run once.
             break;

--- a/storage-proofs/porep/src/stacked/circuit/params.rs
+++ b/storage-proofs/porep/src/stacked/circuit/params.rs
@@ -223,7 +223,7 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
             // verify inclusion of the encoded node
             enforce_inclusion(
                 cs.namespace(|| "comm_r_last_data_inclusion"),
-                comm_r_last_path.clone(),
+                comm_r_last_path,
                 comm_r_last,
                 &encoded_node,
             )?;
@@ -271,7 +271,7 @@ where
         Proof {
             comm_d_path: comm_d_proofs.as_options().into(),
             data_leaf,
-            challenge: Some(labeling_proofs[0].node.clone()),
+            challenge: Some(labeling_proofs[0].node),
             comm_r_last_path: comm_r_last_proof.as_options().into(),
             comm_c_path: c_x.inclusion_proof.as_options().into(),
             drg_parents_proofs: drg_parents.into_iter().map(|p| p.into()).collect(),

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -343,14 +343,9 @@ mod tests {
 
     use ff::Field;
     use generic_array::typenum::{U0, U2, U4, U8};
-    use memmap::MmapMut;
-    use memmap::MmapOptions;
     use merkletree::store::StoreConfig;
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    use std::path::Path;
     use storage_proofs_core::{
         cache_key::CacheKey,
         compound_proof,
@@ -360,6 +355,7 @@ mod tests {
         hasher::{Hasher, PedersenHasher, PoseidonHasher, Sha256Hasher},
         merkle::{get_base_tree_count, BinaryMerkleTree, DiskTree, MerkleTreeTrait},
         proof::ProofScheme,
+        test_helper::setup_replica,
     };
 
     use crate::stacked::{
@@ -367,22 +363,6 @@ mod tests {
         TemporaryAux, TemporaryAuxCache, BINARY_ARITY, EXP_DEGREE,
     };
     use crate::PoRep;
-
-    pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
-        let mut f = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(replica_path)
-            .expect("Failed to create replica");
-        f.write_all(data).expect("Failed to write data to replica");
-
-        unsafe {
-            MmapOptions::new()
-                .map_mut(&f)
-                .expect("Failed to back memory map with tempfile")
-        }
-    }
 
     #[test]
     fn stacked_input_circuit_pedersen_base_2() {

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -873,14 +873,9 @@ mod tests {
     use super::*;
 
     use ff::Field;
-    use memmap::MmapMut;
-    use memmap::MmapOptions;
     use paired::bls12_381::Fr;
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
-    use std::fs::OpenOptions;
-    use std::io::Write;
-    use std::path::Path;
     use storage_proofs_core::{
         drgraph::{new_seed, BASE_DEGREE},
         fr32::fr_into_bytes,
@@ -888,28 +883,13 @@ mod tests {
         merkle::MerkleTreeTrait,
         proof::ProofScheme,
         table_tests,
+        test_helper::setup_replica,
     };
 
     use crate::stacked::{PrivateInputs, SetupParams, EXP_DEGREE};
     use crate::PoRep;
 
     const DEFAULT_STACKED_LAYERS: usize = 11;
-
-    pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
-        let mut f = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .open(replica_path)
-            .expect("Failed to create replica");
-        f.write_all(data).expect("Failed to write data to replica");
-
-        unsafe {
-            MmapOptions::new()
-                .map_mut(&f)
-                .expect("Failed to back memory map with tempfile")
-        }
-    }
 
     #[test]
     fn test_calculate_fixed_challenges() {

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -503,22 +503,16 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                         );
                         assert_eq!(tree_data_len, config.size.unwrap());
 
-                        // FIXME: Add store method to take iter for persisting elements directly?
-                        // FIXME: Or have neptune return this as [u8]?
-                        let mut flat_tree_data = Vec::with_capacity(
-                            tree_data_len * std::mem::size_of::<<Tree::Hasher as Hasher>::Domain>(),
-                        );
-                        for el in &tree_data {
-                            let cur = fr_into_bytes(&el);
-                            flat_tree_data.extend(&cur);
-                        }
-                        drop(tree_data);
+                        let flat_tree_data: Vec<_> = tree_data
+                            .into_par_iter()
+                            .flat_map(|el| fr_into_bytes(&el))
+                            .collect();
 
                         // Persist the data to the store based on the current config.
                         DiskStore::<<Tree::Hasher as Hasher>::Domain>::new_from_slice_with_config(
                             tree_data_len,
                             Tree::Arity::to_usize(),
-                            &flat_tree_data,
+                            &flat_tree_data[..],
                             config.clone(),
                         )?;
                     }
@@ -752,7 +746,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         info!("building tree_r_last");
         let (configs, replica_config) = split_config_and_replica(
             tree_r_last_config.clone(),
-            replica_path.clone(),
+            replica_path,
             nodes_count,
             tree_count,
         )?;
@@ -794,18 +788,6 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             }
 
             assert_eq!(tree_count, trees.len());
-
-            // Write out replica data.
-            {
-                use std::fs::OpenOptions;
-                use std::io::prelude::*;
-
-                let mut f = OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .open(replica_path)?;
-                f.write_all(&data.as_ref())?;
-            }
 
             create_lc_tree::<
                 LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>,
@@ -891,9 +873,14 @@ mod tests {
     use super::*;
 
     use ff::Field;
+    use memmap::MmapMut;
+    use memmap::MmapOptions;
     use paired::bls12_381::Fr;
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
+    use std::fs::OpenOptions;
+    use std::io::Write;
+    use std::path::Path;
     use storage_proofs_core::{
         drgraph::{new_seed, BASE_DEGREE},
         fr32::fr_into_bytes,
@@ -907,6 +894,22 @@ mod tests {
     use crate::PoRep;
 
     const DEFAULT_STACKED_LAYERS: usize = 11;
+
+    pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
+        let mut f = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(replica_path)
+            .expect("Failed to create replica");
+        f.write_all(data).expect("Failed to write data to replica");
+
+        unsafe {
+            MmapOptions::new()
+                .map_mut(&f)
+                .expect("Failed to back memory map with tempfile")
+        }
+    }
 
     #[test]
     fn test_calculate_fixed_challenges() {
@@ -995,10 +998,20 @@ mod tests {
             })
             .collect();
 
-        let challenges = LayerChallenges::new(DEFAULT_STACKED_LAYERS, 5);
+        // MT for original data is always named tree-d, and it will be
+        // referenced later in the process as such.
+        let cache_dir = tempfile::tempdir().unwrap();
+        let config = StoreConfig::new(
+            cache_dir.path(),
+            CacheKey::CommDTree.to_string(),
+            StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
+        );
 
-        // create a copy, so we can compare roundtrips
-        let mut data_copy = data.clone();
+        // Generate a replica path.
+        let replica_path = cache_dir.path().join("replica-path");
+        let mut mmapped_data = setup_replica(&data, &replica_path);
+
+        let challenges = LayerChallenges::new(DEFAULT_STACKED_LAYERS, 5);
 
         let sp = SetupParams {
             nodes,
@@ -1010,41 +1023,31 @@ mod tests {
 
         let pp = StackedDrg::<Tree, Blake2sHasher>::setup(&sp).expect("setup failed");
 
-        // MT for original data is always named tree-d, and it will be
-        // referenced later in the process as such.
-        let cache_dir = tempfile::tempdir().unwrap();
-        let config = StoreConfig::new(
-            cache_dir.path(),
-            CacheKey::CommDTree.to_string(),
-            StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
-        );
-
-        // Generate a replica path.
-        let temp_dir = tempdir::TempDir::new("test-extract-all").unwrap();
-        let temp_path = temp_dir.path();
-        let replica_path = temp_path.join("replica-path");
-
         StackedDrg::<Tree, Blake2sHasher>::replicate(
             &pp,
             &replica_id,
-            (&mut data_copy[..]).into(),
+            (mmapped_data.as_mut()).into(),
             None,
             config.clone(),
             replica_path.clone(),
         )
         .expect("replication failed");
 
-        assert_ne!(data, data_copy);
+        let mut copied = vec![0; data.len()];
+        copied.copy_from_slice(&mmapped_data);
+        assert_ne!(data, copied, "replication did not change data");
 
         let decoded_data = StackedDrg::<Tree, Blake2sHasher>::extract_all(
             &pp,
             &replica_id,
-            data_copy.as_mut_slice(),
+            mmapped_data.as_mut(),
             Some(config.clone()),
         )
         .expect("failed to extract data");
 
         assert_eq!(data, decoded_data);
+
+        cache_dir.close().expect("Failed to remove cache dir");
     }
 
     fn prove_verify_fixed(n: usize) {
@@ -1161,28 +1164,16 @@ mod tests {
         //     .start(log::LevelFilter::Trace)
         //     .ok();
 
-        let n = n * get_base_tree_count::<Tree>();
+        let nodes = n * get_base_tree_count::<Tree>();
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
         let degree = BASE_DEGREE;
         let expansion_degree = EXP_DEGREE;
         let replica_id: <Tree::Hasher as Hasher>::Domain =
             <Tree::Hasher as Hasher>::Domain::random(rng);
-        let data: Vec<u8> = (0..n)
+        let data: Vec<u8> = (0..nodes)
             .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
             .collect();
-
-        // create a copy, so we can compare roundtrips
-        let mut data_copy = data.clone();
-        let partitions = 2;
-
-        let sp = SetupParams {
-            nodes: n,
-            degree,
-            expansion_degree,
-            seed: new_seed(),
-            layer_challenges: challenges.clone(),
-        };
 
         // MT for original data is always named tree-d, and it will be
         // referenced later in the process as such.
@@ -1190,25 +1181,37 @@ mod tests {
         let config = StoreConfig::new(
             cache_dir.path(),
             CacheKey::CommDTree.to_string(),
-            StoreConfig::default_cached_above_base_layer(n, BINARY_ARITY),
+            StoreConfig::default_cached_above_base_layer(nodes, BINARY_ARITY),
         );
 
-        // Generate a replica_path.
-        let temp_dir = tempdir::TempDir::new("test-prove-verify").unwrap();
-        let temp_path = temp_dir.path();
-        let replica_path = temp_path.join("replica-path");
+        // Generate a replica path.
+        let replica_path = cache_dir.path().join("replica-path");
+        let mut mmapped_data = setup_replica(&data, &replica_path);
+
+        let partitions = 2;
+
+        let sp = SetupParams {
+            nodes,
+            degree,
+            expansion_degree,
+            seed: new_seed(),
+            layer_challenges: challenges.clone(),
+        };
 
         let pp = StackedDrg::<Tree, Blake2sHasher>::setup(&sp).expect("setup failed");
         let (tau, (p_aux, t_aux)) = StackedDrg::<Tree, Blake2sHasher>::replicate(
             &pp,
             &replica_id,
-            (&mut data_copy[..]).into(),
+            (mmapped_data.as_mut()).into(),
             None,
             config,
             replica_path.clone(),
         )
         .expect("replication failed");
-        assert_ne!(data, data_copy);
+
+        let mut copied = vec![0; data.len()];
+        copied.copy_from_slice(&mmapped_data);
+        assert_ne!(data, copied, "replication did not change data");
 
         let seed = rng.gen();
 
@@ -1249,6 +1252,8 @@ mod tests {
         TemporaryAux::<Tree, Blake2sHasher>::clear_temp(t_aux_orig).expect("t_aux delete failed");
 
         assert!(proofs_are_valid);
+
+        cache_dir.close().expect("Failed to remove cache dir");
     }
 
     table_tests! {


### PR DESCRIPTION
fix: clean-up unrelated clippy warnings