### PR TITLE
refactor(storage-proofs): use copy instead of clone

### DIFF
--- a/storage-proofs/core/src/gadgets/test/mod.rs
+++ b/storage-proofs/core/src/gadgets/test/mod.rs
@@ -71,7 +71,7 @@ fn proc_lc<E: Engine>(terms: &LinearCombination<E>) -> BTreeMap<OrderedVariable,
     let mut to_remove = vec![];
     for (var, coeff) in map.iter() {
         if coeff.is_zero() {
-            to_remove.push(var.clone())
+            to_remove.push(*var)
         }
     }
 


### PR DESCRIPTION
Clippy emits error:

	error: using `clone` on a `Copy` type

This type implements `Copy`, we can copy it instead of cloning.

Closes: #1113 