### PR TITLE
optimize oct and quad insertion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           no_output_timeout: 30m
       - restore_cache:
           keys:
-            - cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: rustup component add rustfmt-preview
@@ -40,7 +40,7 @@ jobs:
           paths:
             - Cargo.lock
       - save_cache:
-          key: cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
             - /root/.cargo
             - /root/.rustup
@@ -56,7 +56,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (stable)
@@ -85,7 +85,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (stable) in release profile
@@ -111,7 +111,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test ignored in release profile
@@ -134,7 +134,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (nightly)
@@ -153,7 +153,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Benchmarks (nightly)
@@ -241,7 +241,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
@@ -258,7 +258,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v26d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo clippy
           command: cargo +$(cat rust-toolchain) clippy --all
@@ -319,7 +319,7 @@ commands:
   save_parameter_cache:
     steps:
       - save_cache:
-          key: proof-params-v26d-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+          key: proof-params-v27b-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
           paths:
             - "~/paramcache.awesome"
             - "~/filecoin-proof-parameters/"
@@ -328,7 +328,7 @@ commands:
       - configure_environment_variables
       - restore_cache:
          keys:
-            - proof-params-v26d-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+            - proof-params-v27b-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
   configure_environment_variables:
     steps:
       - run:

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.2"
 glob = "0.3"
 human-size = "0.4"
 prettytable-rs = "0.8"
-regex = "1.1.6"
+regex = "=1.3.7"
 commandspec = "0.12.2"
 chrono = { version = "0.4.7", features = ["serde"] }
 memmap = "0.7.0"

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -22,7 +22,7 @@ itertools = "0.9"
 serde_cbor = "0.10.2"
 serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
-regex = "1"
+regex = "=1.3.7"
 ff = { version = "0.2.1", package = "fff" }
 blake2b_simd = "0.5"
 bellperson = "0.8.0"

--- a/storage-proofs/core/src/gadgets/por.rs
+++ b/storage-proofs/core/src/gadgets/por.rs
@@ -546,18 +546,18 @@ mod tests {
 
     #[test]
     fn test_por_circuit_pedersen_base_4() {
-        test_por_circuit::<TestTree<PedersenHasher, typenum::U4>>(3, 12_411);
+        test_por_circuit::<TestTree<PedersenHasher, typenum::U4>>(3, 12_399);
     }
 
     #[test]
     fn test_por_circuit_pedersen_sub_8_2() {
-        test_por_circuit::<TestTree2<PedersenHasher, typenum::U8, typenum::U2>>(3, 20_731);
+        test_por_circuit::<TestTree2<PedersenHasher, typenum::U8, typenum::U2>>(3, 20_663);
     }
 
     #[test]
     fn test_por_circuit_pedersen_top_8_4_2() {
         test_por_circuit::<TestTree3<PedersenHasher, typenum::U8, typenum::U4, typenum::U2>>(
-            3, 24_867,
+            3, 24_795,
         );
     }
 
@@ -566,67 +566,67 @@ mod tests {
         // We can handle top-heavy trees with a non-zero subtree arity.
         // These should never be produced, though.
         test_por_circuit::<TestTree3<PedersenHasher, typenum::U8, typenum::U2, typenum::U4>>(
-            3, 24_867,
+            3, 24_795,
         );
     }
 
     #[test]
     fn test_por_circuit_blake2s_base_4() {
-        test_por_circuit::<TestTree<Blake2sHasher, typenum::U4>>(3, 130_308);
+        test_por_circuit::<TestTree<Blake2sHasher, typenum::U4>>(3, 130_296);
     }
 
     #[test]
     fn test_por_circuit_sha256_base_4() {
-        test_por_circuit::<TestTree<Sha256Hasher, typenum::U4>>(3, 216_270);
+        test_por_circuit::<TestTree<Sha256Hasher, typenum::U4>>(3, 216_258);
     }
 
     #[test]
     fn test_por_circuit_poseidon_base_4() {
-        test_por_circuit::<TestTree<PoseidonHasher, typenum::U4>>(3, 1_185);
+        test_por_circuit::<TestTree<PoseidonHasher, typenum::U4>>(3, 1_173);
     }
 
     #[test]
     fn test_por_circuit_pedersen_base_8() {
-        test_por_circuit::<TestTree<PedersenHasher, typenum::U8>>(3, 19_357);
+        test_por_circuit::<TestTree<PedersenHasher, typenum::U8>>(3, 19_289);
     }
 
     #[test]
     fn test_por_circuit_blake2s_base_8() {
-        test_por_circuit::<TestTree<Blake2sHasher, typenum::U8>>(3, 174_571);
+        test_por_circuit::<TestTree<Blake2sHasher, typenum::U8>>(3, 174_503);
     }
 
     #[test]
     fn test_por_circuit_sha256_base_8() {
-        test_por_circuit::<TestTree<Sha256Hasher, typenum::U8>>(3, 251_055);
+        test_por_circuit::<TestTree<Sha256Hasher, typenum::U8>>(3, 250_987);
     }
 
     #[test]
     fn test_por_circuit_poseidon_base_8() {
-        test_por_circuit::<TestTree<PoseidonHasher, typenum::U8>>(3, 1_137);
+        test_por_circuit::<TestTree<PoseidonHasher, typenum::U8>>(3, 1_069);
     }
 
     #[test]
     fn test_por_circuit_poseidon_sub_8_2() {
-        test_por_circuit::<TestTree2<PoseidonHasher, typenum::U8, typenum::U2>>(3, 1_454);
+        test_por_circuit::<TestTree2<PoseidonHasher, typenum::U8, typenum::U2>>(3, 1_386);
     }
 
     #[test]
     fn test_por_circuit_poseidon_top_8_4_2() {
         test_por_circuit::<TestTree3<PoseidonHasher, typenum::U8, typenum::U4, typenum::U2>>(
-            3, 1_848,
+            3, 1_776,
         );
     }
 
     #[test]
     fn test_por_circuit_poseidon_top_8_8() {
         // This is the shape we want for 32GiB sectors.
-        test_por_circuit::<TestTree2<PoseidonHasher, typenum::U8, typenum::U8>>(3, 1_704);
+        test_por_circuit::<TestTree2<PoseidonHasher, typenum::U8, typenum::U8>>(3, 1_602);
     }
     #[test]
     fn test_por_circuit_poseidon_top_8_8_2() {
         // This is the shape we want for 64GiB secotrs.
         test_por_circuit::<TestTree3<PoseidonHasher, typenum::U8, typenum::U8, typenum::U2>>(
-            3, 2_021,
+            3, 1_919,
         );
     }
 
@@ -635,7 +635,7 @@ mod tests {
         // We can handle top-heavy trees with a non-zero subtree arity.
         // These should never be produced, though.
         test_por_circuit::<TestTree3<PoseidonHasher, typenum::U8, typenum::U2, typenum::U4>>(
-            3, 1_848,
+            3, 1_776,
         );
     }
 
@@ -893,12 +893,12 @@ mod tests {
 
     #[test]
     fn test_private_por_input_circuit_pedersen_quad() {
-        test_private_por_input_circuit::<TestTree<PedersenHasher, typenum::U4>>(12_410);
+        test_private_por_input_circuit::<TestTree<PedersenHasher, typenum::U4>>(12_398);
     }
 
     #[test]
     fn test_private_por_input_circuit_poseidon_quad() {
-        test_private_por_input_circuit::<TestTree<PoseidonHasher, typenum::U4>>(1_184);
+        test_private_por_input_circuit::<TestTree<PoseidonHasher, typenum::U4>>(1_172);
     }
 
     fn test_private_por_input_circuit<Tree: MerkleTreeTrait>(num_constraints: usize) {

--- a/storage-proofs/core/src/lib.rs
+++ b/storage-proofs/core/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all, clippy::perf, clippy::correctness)]
+#![allow(clippy::many_single_char_names)]
 #![allow(clippy::unreadable_literal)]
 #![allow(clippy::type_repetition_in_bounds)]
 

--- a/storage-proofs/core/src/parameter_cache.rs
+++ b/storage-proofs/core/src/parameter_cache.rs
@@ -16,7 +16,7 @@ use std::io::{self, SeekFrom};
 use std::path::{Path, PathBuf};
 
 /// Bump this when circuits change to invalidate the cache.
-pub const VERSION: usize = 26;
+pub const VERSION: usize = 27;
 
 pub const PARAMETER_CACHE_ENV_VAR: &str = "FIL_PROOFS_PARAMETER_CACHE";
 pub const PARAMETER_CACHE_DIR: &str = "/var/tmp/filecoin-proof-parameters/";

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -376,17 +376,17 @@ mod tests {
 
     #[test]
     fn stacked_input_circuit_poseidon_base_8() {
-        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U0, U0>>(22, 1_200_258);
+        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U0, U0>>(22, 1_199_714);
     }
 
     #[test]
     fn stacked_input_circuit_poseidon_sub_8_4() {
-        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U4, U0>>(22, 1_297_326);
+        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U4, U0>>(22, 1_296_718);
     }
 
     #[test]
     fn stacked_input_circuit_poseidon_top_8_4_2() {
-        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U4, U2>>(22, 1_347_780);
+        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U4, U2>>(22, 1_347_172);
     }
 
     fn stacked_input_circuit<Tree: MerkleTreeTrait + 'static>(

--- a/storage-proofs/post/src/election/circuit.rs
+++ b/storage-proofs/post/src/election/circuit.rs
@@ -197,12 +197,12 @@ mod tests {
 
     #[test]
     fn test_election_post_circuit_pedersen() {
-        test_election_post_circuit::<LCTree<PedersenHasher, U8, U0, U0>>(389_883);
+        test_election_post_circuit::<LCTree<PedersenHasher, U8, U0, U0>>(388_523);
     }
 
     #[test]
     fn test_election_post_circuit_poseidon() {
-        test_election_post_circuit::<LCTree<PoseidonHasher, U8, U0, U0>>(24_426);
+        test_election_post_circuit::<LCTree<PoseidonHasher, U8, U0, U0>>(23_066);
     }
 
     fn test_election_post_circuit<Tree: 'static + MerkleTreeTrait>(expected_constraints: usize) {

--- a/storage-proofs/post/src/fallback/circuit.rs
+++ b/storage-proofs/post/src/fallback/circuit.rs
@@ -191,37 +191,37 @@ mod tests {
 
     #[test]
     fn fallback_post_pedersen_single_partition_matching_base_8() {
-        fallback_post::<LCTree<PedersenHasher, U8, U0, U0>>(3, 3, 1, 19, 294_459);
+        fallback_post::<LCTree<PedersenHasher, U8, U0, U0>>(3, 3, 1, 19, 293_439);
     }
 
     #[test]
     fn fallback_post_poseidon_single_partition_matching_base_8() {
-        fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 3, 1, 19, 17_988);
+        fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 3, 1, 19, 16_968);
     }
 
     #[test]
     fn fallback_post_poseidon_single_partition_matching_sub_8_4() {
-        fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 3, 1, 19, 23_898);
+        fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 3, 1, 19, 22_818);
     }
 
     #[test]
     fn fallback_post_poseidon_single_partition_matching_top_8_4_2() {
-        fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 3, 1, 19, 28_653);
+        fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 3, 1, 19, 27_573);
     }
 
     #[test]
     fn fallback_post_poseidon_single_partition_smaller_base_8() {
-        fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(2, 3, 1, 19, 17_988);
+        fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(2, 3, 1, 19, 16_968);
     }
 
     #[test]
     fn fallback_post_poseidon_two_partitions_matching_base_8() {
-        fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2, 13, 11_992);
+        fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2, 13, 11_312);
     }
 
     #[test]
     fn fallback_post_poseidon_two_partitions_smaller_base_8() {
-        fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2, 19, 17_988);
+        fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2, 19, 16_968);
     }
 
     #[test]
@@ -242,7 +242,7 @@ mod tests {
             .synthesize(&mut cs)
             .unwrap();
 
-        assert_eq!(cs.num_constraints(), 285_180);
+        assert_eq!(cs.num_constraints(), 268_180);
     }
 
     fn fallback_post<Tree: 'static + MerkleTreeTrait>(


### PR DESCRIPTION
## WARNING: this PR reduces constraints and is therefore a breaking circuit change. Only merge once last v26 release has been cut. cc: @cryptonemo 

This PR updates `insertion.rs` to use hand-optimized versions of insertion when the size of the output array is either 4 or 8. These are the sizes used for our merkle trees and for which optimization will help. By taking advantage of redundancy in the output for each position, we can avoid the full generality otherwise required. This allows us to avoid the quadratic cost of `size * (size - 1)` constraints.

In order to aid in legibility and for consistency with internal spec audit (the motivation for this change), I have introduced a macro, `witness!` which allows declarative assignment of constraints to allocated numbers based on the value of an allocated boolean value.

Previous behavior is preserved and verified in tests — so bit input for insertion is still little endian. Bit and position indices are 0-indexed, and witness names rely on these conventions systematically.

For reference, here are the constraint definitions used to compute the oct insertion result:
```
    witness!(p1_x00 <== if b0 { a } else { b });
    witness!(p1_xx0 <== if b1 { c } else { &p1_x00 });
    witness!(p1 <== if b2 { c } else { &p1_xx0 });

    witness!(p2_x10 <== if b0 { d } else { a });
    witness!(p2_xx0 <== if b1 { &p2_x10 } else { c });
    witness!(p2 <== if b2 { d } else { &p2_xx0 });

    witness!(p3_xx0 <== if &b0_and_b1 { a } else { d });
    witness!(p3 <== if b2 { e } else { &p3_xx0 });

    witness!(p4_xx1 <== if &b0_nor_b1 { a } else { f });
    witness!(p4 <== if b2 { &p4_xx1 } else { e });

    witness!(p5_x01 <== if b0 { a } else { f });
    witness!(p5_xx1 <== if b1 { g } else { &p5_x01 });
    witness!(p5 <== if b2 { &p5_xx1 } else { f });

    witness!(p6_x11 <== if b0 { h } else { a });
    witness!(p6_xx1 <== if b1 { &p6_x11 } else { g });
    witness!(p6 <== if b2 { &p6_xx1 } else { g });

    witness!(p7_xx1 <== if &b0_and_b1 { a } else { h });
    witness!(p7 <== if b2 { &p7_xx1 } else { h });

    Ok(vec![p0, p1, p2, p3, p4, p5, p6, p7])
```