### PR TITLE
refactor(storage-proofs): use debug_assert

### DIFF
--- a/storage-proofs/core/src/merkle/tree.rs
+++ b/storage-proofs/core/src/merkle/tree.rs
@@ -92,8 +92,7 @@ impl<
     fn gen_proof(&self, i: usize) -> Result<Self::Proof> {
         let proof = self.inner.gen_proof(i)?;
 
-        // For development and debugging.
-        //assert!(proof.validate::<H::Function>().unwrap());
+        debug_assert!(proof.validate::<H::Function>().expect("validate failed"));
 
         MerkleProof::try_from_proof(proof)
     }
@@ -105,8 +104,7 @@ impl<
 
         let proof = self.inner.gen_cached_proof(i, rows_to_discard)?;
 
-        // For development and debugging.
-        //assert!(proof.validate::<H::Function>().unwrap());
+        debug_assert!(proof.validate::<H::Function>().expect("validate failed"));
 
         MerkleProof::try_from_proof(proof)
     }

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -159,8 +159,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                             Some(t_aux.tree_r_last_config_rows_to_discard),
                         )?;
 
-                        // For development and debugging.
-                        assert!(comm_r_last_proof.validate(challenge));
+                        debug_assert!(comm_r_last_proof.validate(challenge));
 
                         // Labeling Proofs Layer 1..l
                         let mut labeling_proofs = Vec::with_capacity(layers);


### PR DESCRIPTION
We have a few places where the `assert!` macro is used with a comment
```
// For development and debugging.
```
We have a macro for development and debugging, its `debug_assert!`.

Use `debug_assert` and remove the now redundant comment.