### PR TITLE
use partial parent cache and other methods to reduce the mem usage for sdr

### DIFF
--- a/storage-proofs/core/src/settings.rs
+++ b/storage-proofs/core/src/settings.rs
@@ -15,6 +15,8 @@ const SETTINGS_PATH: &str = "./rust-fil-proofs.config.toml";
 #[serde(default)]
 pub struct Settings {
     pub maximize_caching: bool,
+    pub partial_parent_num: Option<usize>,
+    pub base_nodes_on_disk: usize,
     pub pedersen_hash_exp_window_size: u32,
     pub use_gpu_column_builder: bool,
     pub max_gpu_column_batch_size: u32,
@@ -26,6 +28,8 @@ impl Default for Settings {
     fn default() -> Self {
         Settings {
             maximize_caching: false,
+            partial_parent_num: None,
+            base_nodes_on_disk: 0,
             pedersen_hash_exp_window_size: 16,
             use_gpu_column_builder: false,
             max_gpu_column_batch_size: 400_000,

--- a/storage-proofs/porep/Cargo.toml
+++ b/storage-proofs/porep/Cargo.toml
@@ -30,10 +30,12 @@ anyhow = "1.0.23"
 once_cell = "1.3.1"
 neptune = { version = "0.7.1", features = ["gpu"] }
 num_cpus = "1.10.1"
+byteorder = "1.3"
+hex = "0.4.0"
+tempfile = "3"
 
 [dev-dependencies]
 tempdir = "0.3.7"
-tempfile = "3"
 rand_xorshift = "0.2.0"
 criterion = "0.3.2"
 
@@ -47,4 +49,3 @@ harness = false
 [[bench]]
 name = "parents"
 harness = false
-

--- a/storage-proofs/porep/src/stacked/vanilla/cache.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/cache.rs
@@ -1,0 +1,15 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+pub const SDR_CACHE_ENV_VAR: &str = "FIL_PROOFS_SDR_CACHE";
+pub const PARAMETER_CACHE_DIR: &str = "/var/tmp/filecoin-proof-sdr-cache/";
+
+pub fn dir_name() -> PathBuf {
+    env::var(SDR_CACHE_ENV_VAR)
+        .map(PathBuf::from)
+        .unwrap_or(PathBuf::from(PARAMETER_CACHE_DIR))
+}
+
+pub fn file_path<P: AsRef<Path>>(name: P) -> PathBuf {
+    dir_name().join(name)
+}

--- a/storage-proofs/porep/src/stacked/vanilla/create_label_mixed.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/create_label_mixed.rs
@@ -1,0 +1,147 @@
+#[cfg(target_arch = "x86")]
+use std::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::*;
+
+use sha2raw::Sha256;
+use storage_proofs_core::{
+    error::Result,
+    hasher::Hasher,
+    util::{data_at_node_offset, NODE_SIZE},
+};
+
+use super::graph::{PartialParentCache, StackedBucketGraph};
+
+pub fn create_label_mixed<H: Hasher>(
+    parents: &mut PartialParentCache,
+    graph: &StackedBucketGraph<H>,
+    replica_id: &H::Domain,
+    layer_labels: &mut [u8],
+    node: usize,
+) -> Result<()> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 32];
+
+    buffer[..8].copy_from_slice(&(node as u64).to_be_bytes());
+    hasher.input(&[AsRef::<[u8]>::as_ref(replica_id), &buffer[..]][..]);
+
+    // hash parents for all non 0 nodes
+    let hash = if node > 0 {
+        // prefetch previous node, which is always a parent
+        let prev = &layer_labels[(node - 1) * NODE_SIZE..node * NODE_SIZE];
+        unsafe {
+            _mm_prefetch(prev.as_ptr() as *const i8, _MM_HINT_T0);
+        }
+
+        graph.copy_parents_data_mixed(parents, node as u32, &*layer_labels, hasher)?
+    } else {
+        hasher.finish()
+    };
+
+    // store the newly generated key
+    let start = data_at_node_offset(node);
+    let end = start + NODE_SIZE;
+    layer_labels[start..end].copy_from_slice(&hash[..]);
+
+    // strip last two bits, to ensure result is in Fr.
+    layer_labels[end - 1] &= 0b0011_1111;
+
+    Ok(())
+}
+
+pub fn create_label_exp_mixed<H: Hasher>(
+    parents: &mut PartialParentCache,
+    graph: &StackedBucketGraph<H>,
+    replica_id: &H::Domain,
+    exp_parents_data: &[u8],
+    layer_labels: &mut [u8],
+    node: usize,
+) -> Result<()> {
+    let mut hasher = Sha256::new();
+    let mut buffer = [0u8; 32];
+
+    buffer[..8].copy_from_slice(&(node as u64).to_be_bytes());
+    hasher.input(&[AsRef::<[u8]>::as_ref(replica_id), &buffer[..]][..]);
+
+    // hash parents for all non 0 nodes
+    let hash = if node > 0 {
+        // prefetch previous node, which is always a parent
+        let prev = &layer_labels[(node - 1) * NODE_SIZE..node * NODE_SIZE];
+        unsafe {
+            _mm_prefetch(prev.as_ptr() as *const i8, _MM_HINT_T0);
+        }
+
+        graph.copy_parents_data_exp_mixed(
+            parents,
+            node as u32,
+            &*layer_labels,
+            exp_parents_data,
+            hasher,
+        )?
+    } else {
+        hasher.finish()
+    };
+
+    // store the newly generated key
+    let start = data_at_node_offset(node);
+    let end = start + NODE_SIZE;
+    layer_labels[start..end].copy_from_slice(&hash[..]);
+
+    // strip last two bits, to ensure result is in Fr.
+    layer_labels[end - 1] &= 0b0011_1111;
+
+    Ok(())
+}
+
+pub struct MixedLayer<'a> {
+    ondisk: &'a mut [u8],
+    ondisk_nodes: usize,
+    ondisk_bytes: usize,
+
+    inmem: &'a mut [u8],
+    inmem_nodes: usize,
+    inmem_bytes: usize,
+
+    nodes: usize,
+}
+
+impl<'a> MixedLayer<'a> {
+    pub fn push(&mut self, hash: &[u8]) {
+        let start = self.nodes * NODE_SIZE;
+        let end = start + NODE_SIZE;
+
+        if end <= self.inmem_bytes {
+            self.inmem[start..end].copy_from_slice(hash);
+            if end == self.ondisk_bytes {
+                self.ondisk
+                    .copy_from_slice(&self.inmem[..self.ondisk_bytes]);
+            }
+        } else {
+            self.inmem[start - self.inmem_bytes..end - self.inmem_bytes].copy_from_slice(hash);
+        }
+
+        self.nodes += 1;
+    }
+
+    // [ 0,  1,  2,  3 ][ 0,  1,  2,  3,  4,  5,  6,  7 ]
+    //                  [ 8,  9, 10, 11 ]
+    pub fn read(&self, node: usize) -> &[u8] {
+        let mut start = node * NODE_SIZE;
+        // we'll never read a node larger than the latest generated one
+        if self.nodes <= self.inmem_nodes {
+            return &self.inmem[start..start + NODE_SIZE];
+        }
+
+        let lowest = self.nodes - self.inmem_nodes;
+        // lower nodes can only be read from ondisk part
+        if node < lowest {
+            return &self.ondisk[start..start + NODE_SIZE];
+        }
+
+        if node >= self.inmem_nodes {
+            start = (node - self.inmem_nodes) * NODE_SIZE;
+        }
+
+        &self.inmem[start..start + NODE_SIZE]
+    }
+}

--- a/storage-proofs/porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/mod.rs
@@ -1,10 +1,12 @@
 #[macro_use]
 mod macros;
 
+mod cache;
 mod challenges;
 mod column;
 mod column_proof;
 mod create_label;
+mod create_label_mixed;
 mod encoding_proof;
 mod graph;
 pub(crate) mod hash;


### PR DESCRIPTION
tested on a machine
- AMD Ryzen 9 3900X 12-Core Processor
- 62.9GiB physical mem
- 10GiB swap on ssd
- 8T hdd (7200rpm) for staged file, sealed file & cache dir

with
- 13:32:51 ~ 20:11:44 for seal_pre_commit_phase1
- 20:11:44 ~ 23:04:04 for seal_pre_commit_phase2

TODOs:
- [x] patch bellman to serialize circuit synthesizing & calculating: [bellman pr #81](https://github.com/filecoin-project/bellman/pull/81)
- [ ] use mixed-base-layer to see if we can reduce some more mem for seal_pre_commit_phase1
- [ ] copying base layer to exp cost ~9min in the last 4 layers, with a high ratio of SWAPIN, which I think, can be optimized

[see log here](https://gist.github.com/dtynn/80cbdaaf893644a7830d93722a86fb0d)