### PR TITLE
build(storage-proofs): fix build for profile feature

### DIFF
--- a/storage-proofs/core/Cargo.toml
+++ b/storage-proofs/core/Cargo.toml
@@ -42,6 +42,7 @@ anyhow = "1.0.23"
 thiserror = "1.0.6"
 neptune = { version = "0.7.1", features = ["gpu"] }
 cpu-time = { version = "1.0", optional = true }
+gperftools = { version = "0.2", optional = true }
 
 [dev-dependencies]
 proptest = "0.7"
@@ -58,7 +59,7 @@ simd = []
 asm = ["sha2/sha2-asm"]
 big-sector-sizes-bench = []
 gpu = ["bellperson/gpu", "fil-sapling-crypto/gpu"]
-measurements = ["cpu-time"]
+measurements = ["cpu-time", "gperftools"]
 profile = ["measurements"]
 
 [[bench]]


### PR DESCRIPTION
Currently the build fails when run with

        cargo build --all-features

This is because of a missing optional dependencie on `gperftools`.

Add the dependency as an optional dev dependency for the `measurements` feature on `core` crate.

Found while working on: https://github.com/filecoin-project/rust-fil-proofs/issues/1123