### PR TITLE
Include layer index before node when creating label preimage.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           no_output_timeout: 30m
       - restore_cache:
           keys:
-            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: rustup component add rustfmt-preview
@@ -40,7 +40,7 @@ jobs:
           paths:
             - Cargo.lock
       - save_cache:
-          key: cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
             - /root/.cargo
             - /root/.rustup
@@ -56,7 +56,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (stable)
@@ -85,7 +85,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (stable) in release profile
@@ -111,7 +111,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test ignored in release profile
@@ -134,7 +134,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (nightly)
@@ -153,7 +153,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Benchmarks (nightly)
@@ -241,7 +241,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
@@ -258,7 +258,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27b-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo clippy
           command: cargo +$(cat rust-toolchain) clippy --all
@@ -319,7 +319,7 @@ commands:
   save_parameter_cache:
     steps:
       - save_cache:
-          key: proof-params-v27b-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+          key: proof-params-v27d-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
           paths:
             - "~/paramcache.awesome"
             - "~/filecoin-proof-parameters/"
@@ -328,7 +328,7 @@ commands:
       - configure_environment_variables
       - restore_cache:
          keys:
-            - proof-params-v27b-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+            - proof-params-v27d-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
   configure_environment_variables:
     steps:
       - run:

--- a/storage-proofs/.gitignore
+++ b/storage-proofs/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 **/*.rs.bk
 Cargo.lock
 .criterion

--- a/storage-proofs/core/src/gadgets/por.rs
+++ b/storage-proofs/core/src/gadgets/por.rs
@@ -901,6 +901,11 @@ mod tests {
         test_private_por_input_circuit::<TestTree<PoseidonHasher, typenum::U4>>(1_172);
     }
 
+    #[test]
+    fn test_private_por_input_circuit_poseidon_oct() {
+        test_private_por_input_circuit::<TestTree<PoseidonHasher, typenum::U8>>(1_068);
+    }
+
     fn test_private_por_input_circuit<Tree: MerkleTreeTrait>(num_constraints: usize) {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 

--- a/storage-proofs/porep/benches/encode.rs
+++ b/storage-proofs/porep/benches/encode.rs
@@ -54,7 +54,7 @@ fn kdf_benchmark(c: &mut Criterion) {
         let graph = &graph;
         let replica_id = replica_id.clone();
 
-        b.iter(|| black_box(create_label_exp(graph, &replica_id, &*exp_data, data, 1)))
+        b.iter(|| black_box(create_label_exp(graph, &replica_id, &*exp_data, data, 1, 2)))
     });
 
     group.bench_function("non-exp", |b| {
@@ -62,7 +62,7 @@ fn kdf_benchmark(c: &mut Criterion) {
         let graph = &graph;
         let replica_id = replica_id.clone();
 
-        b.iter(|| black_box(create_label(graph, &replica_id, &mut data, 1)))
+        b.iter(|| black_box(create_label(graph, &replica_id, &mut data, 1, 2)))
     });
 
     group.finish();

--- a/storage-proofs/porep/src/stacked/circuit/params.rs
+++ b/storage-proofs/porep/src/stacked/circuit/params.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use bellperson::gadgets::{boolean::Boolean, num};
+use bellperson::gadgets::{boolean::Boolean, num, uint32};
 use bellperson::{ConstraintSystem, SynthesisError};
 use generic_array::typenum::{U0, U2};
 use paired::bls12_381::{Bls12, Fr};
@@ -159,6 +159,8 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
         challenge_num.pack_into_input(cs.namespace(|| "challenge input"))?;
 
         for layer in 1..=layers {
+            let layer_num = uint32::UInt32::constant(layer as u32);
+
             let mut cs = cs.namespace(|| format!("labeling_{}", layer));
 
             // Collect the parents
@@ -207,6 +209,7 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
                 cs.namespace(|| "create_label"),
                 replica_id,
                 expanded_parents,
+                layer_num,
                 challenge_num.clone(),
             )?;
             column_labels.push(label);

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -475,7 +475,7 @@ mod tests {
 
         let proofs_are_valid =
             StackedDrg::<Tree, Sha256Hasher>::verify_all_partitions(&pp, &pub_inputs, &proofs)
-                .expect("failed to verify partition proofs");
+                .expect("failed while trying to verify partition proofs");
 
         assert!(proofs_are_valid);
 

--- a/storage-proofs/porep/src/stacked/vanilla/create_label.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/create_label.rs
@@ -16,12 +16,14 @@ pub fn create_label<H: Hasher>(
     graph: &StackedBucketGraph<H>,
     replica_id: &H::Domain,
     layer_labels: &mut [u8],
+    layer_index: usize,
     node: usize,
 ) -> Result<()> {
     let mut hasher = Sha256::new();
     let mut buffer = [0u8; 32];
 
-    buffer[..8].copy_from_slice(&(node as u64).to_be_bytes());
+    buffer[..4].copy_from_slice(&(layer_index as u32).to_be_bytes());
+    buffer[4..12].copy_from_slice(&(node as u64).to_be_bytes());
     hasher.input(&[AsRef::<[u8]>::as_ref(replica_id), &buffer[..]][..]);
 
     // hash parents for all non 0 nodes
@@ -53,12 +55,14 @@ pub fn create_label_exp<H: Hasher>(
     replica_id: &H::Domain,
     exp_parents_data: &[u8],
     layer_labels: &mut [u8],
+    layer_index: usize,
     node: usize,
 ) -> Result<()> {
     let mut hasher = Sha256::new();
     let mut buffer = [0u8; 32];
 
-    buffer[..8].copy_from_slice(&(node as u64).to_be_bytes());
+    buffer[0..4].copy_from_slice(&(layer_index as u32).to_be_bytes());
+    buffer[4..12].copy_from_slice(&(node as u64).to_be_bytes());
     hasher.input(&[AsRef::<[u8]>::as_ref(replica_id), &buffer[..]][..]);
 
     // hash parents for all non 0 nodes

--- a/storage-proofs/porep/src/stacked/vanilla/encoding_proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/encoding_proof.rs
@@ -11,14 +11,16 @@ use crate::encode::encode;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EncodingProof<H: Hasher> {
     pub(crate) parents: Vec<H::Domain>,
+    pub(crate) layer_index: u32,
     pub(crate) node: u64,
     #[serde(skip)]
     _h: PhantomData<H>,
 }
 
 impl<H: Hasher> EncodingProof<H> {
-    pub fn new(node: u64, parents: Vec<H::Domain>) -> Self {
+    pub fn new(layer_index: u32, node: u64, parents: Vec<H::Domain>) -> Self {
         EncodingProof {
+            layer_index,
             node,
             parents,
             _h: PhantomData,
@@ -32,8 +34,10 @@ impl<H: Hasher> EncodingProof<H> {
         // replica_id
         buffer[..32].copy_from_slice(AsRef::<[u8]>::as_ref(replica_id));
 
+        // layer index
+        buffer[32..36].copy_from_slice(&(self.layer_index as u32).to_be_bytes());
         // node id
-        buffer[32..40].copy_from_slice(&(self.node as u64).to_be_bytes());
+        buffer[36..44].copy_from_slice(&(self.node as u64).to_be_bytes());
 
         hasher.input(&buffer[..]);
 

--- a/storage-proofs/porep/src/stacked/vanilla/labeling_proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/labeling_proof.rs
@@ -8,15 +8,17 @@ use storage_proofs_core::{fr32::bytes_into_fr_repr_safe, hasher::Hasher};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LabelingProof<H: Hasher> {
     pub(crate) parents: Vec<H::Domain>,
+    pub(crate) layer_index: u32,
     pub(crate) node: u64,
     #[serde(skip)]
     _h: PhantomData<H>,
 }
 
 impl<H: Hasher> LabelingProof<H> {
-    pub fn new(node: u64, parents: Vec<H::Domain>) -> Self {
+    pub fn new(layer_index: u32, node: u64, parents: Vec<H::Domain>) -> Self {
         LabelingProof {
             node,
+            layer_index,
             parents,
             _h: PhantomData,
         }
@@ -29,8 +31,11 @@ impl<H: Hasher> LabelingProof<H> {
         // replica_id
         buffer[..32].copy_from_slice(AsRef::<[u8]>::as_ref(replica_id));
 
+        // layer index
+        buffer[32..36].copy_from_slice(&(self.layer_index as u32).to_be_bytes());
+
         // node id
-        buffer[32..40].copy_from_slice(&(self.node as u64).to_be_bytes());
+        buffer[36..44].copy_from_slice(&(self.node as u64).to_be_bytes());
 
         hasher.input(&buffer[..]);
 

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -203,6 +203,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                             }
 
                             let proof = LabelingProof::<Tree::Hasher>::new(
+                                layer as u32,
                                 challenge as u64,
                                 parents_data_full.clone(),
                             );
@@ -219,8 +220,11 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                             labeling_proofs.push(proof);
 
                             if layer == layers {
-                                encoding_proof =
-                                    Some(EncodingProof::new(challenge as u64, parents_data_full));
+                                encoding_proof = Some(EncodingProof::new(
+                                    layer as u32,
+                                    challenge as u64,
+                                    parents_data_full,
+                                ));
                             }
                         }
 
@@ -296,12 +300,12 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             if layer == 1 {
                 let layer_labels = &mut labels_buffer[..layer_size];
                 for node in 0..graph.size() {
-                    create_label(graph, replica_id, layer_labels, node)?;
+                    create_label(graph, replica_id, layer_labels, layer, node)?;
                 }
             } else {
                 let (layer_labels, exp_labels) = labels_buffer.split_at_mut(layer_size);
                 for node in 0..graph.size() {
-                    create_label_exp(graph, replica_id, exp_labels, layer_labels, node)?;
+                    create_label_exp(graph, replica_id, exp_labels, layer_labels, layer, node)?;
                 }
             }
 


### PR DESCRIPTION
This adds constraints, which slightly surprised me — since it does not increase the length of the preimage being hashed. ~I believe the reason for this is that the padding bits being replaced were in fact boolean constants. Some initial operations in the sha256 computation involving them may therefore have been optimized away at synthesis time.~

*UPDATE:* I don't think my explanation above makes sense. I think the actual source of the increase is the booleanity constraints introduced when allocating the bits.

*UPDATE 2*: Although my update is accurate, there should not have been an allocation. The latest should now correctly use constants everywhere.
