### PR TITLE
Fix misleading comment and restore test.

### DIFF
--- a/storage-proofs/porep/src/stacked/vanilla/challenges.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/challenges.rs
@@ -59,7 +59,7 @@ impl LayerChallenges {
 
                 let big_challenge = BigUint::from_bytes_le(hash.as_ref());
 
-                // For now, we cannot try to prove the first or last node, so make sure the challenge
+                // We cannot try to prove the first node, so make sure the challenge
                 // can never be 0.
                 let big_mod_challenge = big_challenge % (leaves - 1);
                 let big_mod_challenge = big_mod_challenge
@@ -117,9 +117,9 @@ mod test {
 
         // If we generate 100 layers with 1,000 challenges in each, at most two layers can contain
         // any duplicates for this assertion to succeed.
-        // assert!(layers_with_duplicates < 3);
-        // TODO: verify why this now fails
-        println!("duplicates: {}", layers_with_duplicates);
+        //
+        // This test could randomly fail (anything's possible), but if it happens regularly something is wrong.
+        assert!(layers_with_duplicates < 3);
     }
 
     #[test]


### PR DESCRIPTION
A comment in the challenge-derivation code suggested that we cannot challenge either the first or the last node (of each layer). This was true of ZigZag but does not hold with SDR. The underlying code, however, only excludes the first node (index 0) of each layer.

This PR corrects the comment.

It also incidentally uncomments a test which had been commented with a note to investigate why it now fails. This test represents a simple sanity check to ensure our challenge-generation method is not systematically producing an unexpectedly high number of duplicates. If it does begin to fail regularly, that *is* cause for investigation.