### PR TITLE
Constrain bits to result when creating label.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           no_output_timeout: 30m
       - restore_cache:
           keys:
-            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: rustup component add rustfmt-preview
@@ -40,7 +40,7 @@ jobs:
           paths:
             - Cargo.lock
       - save_cache:
-          key: cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+          key: cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
           paths:
             - /root/.cargo
             - /root/.rustup
@@ -56,7 +56,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (stable)
@@ -85,7 +85,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (stable) in release profile
@@ -111,7 +111,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test ignored in release profile
@@ -134,7 +134,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Test (nightly)
@@ -153,7 +153,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - restore_parameter_cache
       - run:
           name: Benchmarks (nightly)
@@ -241,7 +241,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo fmt
           command: cargo fmt --all -- --check
@@ -258,7 +258,7 @@ jobs:
           at: "."
       - restore_cache:
           keys:
-            - cargo-v27d-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+            - cargo-v27f-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
       - run:
           name: Run cargo clippy
           command: cargo +$(cat rust-toolchain) clippy --all
@@ -319,7 +319,7 @@ commands:
   save_parameter_cache:
     steps:
       - save_cache:
-          key: proof-params-v27d-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+          key: proof-params-v27f-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
           paths:
             - "~/paramcache.awesome"
             - "~/filecoin-proof-parameters/"
@@ -328,7 +328,7 @@ commands:
       - configure_environment_variables
       - restore_cache:
          keys:
-            - proof-params-v27d-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
+            - proof-params-v27f-{{ checksum "filecoin-proofs/parameters.json" }}-{{ arch }}
   configure_environment_variables:
     steps:
       - run:

--- a/storage-proofs/porep/src/drg/circuit.rs
+++ b/storage-proofs/porep/src/drg/circuit.rs
@@ -13,7 +13,7 @@ use paired::bls12_381::{Bls12, Fr};
 use storage_proofs_core::{
     compound_proof::CircuitComponent, error::Result, gadgets::constraint, gadgets::encode,
     gadgets::por::PoRCircuit, gadgets::uint64, gadgets::variables::Root, hasher::Hasher,
-    merkle::BinaryMerkleTree, util::fixup_bits,
+    merkle::BinaryMerkleTree, util::reverse_bit_numbering,
 };
 
 /// DRG based Proof of Replication.
@@ -145,7 +145,7 @@ impl<'a, H: 'static + Hasher> Circuit<Bls12> for DrgPoRepCircuit<'a, H> {
 
         // get the replica_id in bits
         let replica_id_bits =
-            fixup_bits(replica_node_num.to_bits_le(cs.namespace(|| "replica_id_bits"))?);
+            reverse_bit_numbering(replica_node_num.to_bits_le(cs.namespace(|| "replica_id_bits"))?);
 
         let replica_root_var = Root::Var(replica_root.allocated(cs.namespace(|| "replica_root"))?);
         let data_root_var = Root::Var(data_root.allocated(cs.namespace(|| "data_root"))?);
@@ -212,7 +212,7 @@ impl<'a, H: 'static + Hasher> Circuit<Bls12> for DrgPoRepCircuit<'a, H> {
                                     .ok_or_else(|| SynthesisError::AssignmentMissing)
                             },
                         )?;
-                        Ok(fixup_bits(num.to_bits_le(
+                        Ok(reverse_bit_numbering(num.to_bits_le(
                             cs.namespace(|| format!("parents_{}_bits", i)),
                         )?))
                     })

--- a/storage-proofs/porep/src/stacked/circuit/params.rs
+++ b/storage-proofs/porep/src/stacked/circuit/params.rs
@@ -10,7 +10,7 @@ use storage_proofs_core::{
     gadgets::{encode::encode, uint64, variables::Root},
     hasher::{Hasher, PoseidonArity},
     merkle::{DiskStore, MerkleProofTrait, MerkleTreeTrait, MerkleTreeWrapper},
-    util::fixup_bits,
+    util::reverse_bit_numbering,
 };
 
 use super::{
@@ -170,7 +170,7 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
             for parent_col in &drg_parents {
                 let parent_val_num = parent_col.get_value(layer);
                 let parent_val_bits =
-                    fixup_bits(parent_val_num.to_bits_le(
+                    reverse_bit_numbering(parent_val_num.to_bits_le(
                         cs.namespace(|| format!("drg_parent_{}_bits", parents.len())),
                     )?);
                 parents.push(parent_val_bits);
@@ -182,7 +182,7 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
                     // subtract 1 from the layer index, as the exp parents, are shifted by one, as they
                     // do not store a value for the first layer
                     let parent_val_num = parent_col.get_value(layer - 1);
-                    let parent_val_bits = fixup_bits(parent_val_num.to_bits_le(
+                    let parent_val_bits = reverse_bit_numbering(parent_val_num.to_bits_le(
                         cs.namespace(|| format!("exp_parent_{}_bits", parents.len())),
                     )?);
                     parents.push(parent_val_bits);

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -16,7 +16,7 @@ use storage_proofs_core::{
     parameter_cache::{CacheableParameters, ParameterSetMetadata},
     por,
     proof::ProofScheme,
-    util::fixup_bits,
+    util::reverse_bit_numbering,
 };
 
 use super::params::Proof;
@@ -97,7 +97,7 @@ impl<'a, Tree: MerkleTreeTrait, G: Hasher> Circuit<Bls12> for StackedCircuit<'a,
         replica_id_num.inputize(cs.namespace(|| "replica_id_input"))?;
 
         let replica_id_bits =
-            fixup_bits(replica_id_num.to_bits_le(cs.namespace(|| "replica_id_bits"))?);
+            reverse_bit_numbering(replica_id_num.to_bits_le(cs.namespace(|| "replica_id_bits"))?);
 
         // Allocate comm_d as Fr
         let comm_d_num = num::AllocatedNum::alloc(cs.namespace(|| "comm_d"), || {
@@ -366,27 +366,27 @@ mod tests {
 
     #[test]
     fn stacked_input_circuit_pedersen_base_2() {
-        stacked_input_circuit::<DiskTree<PedersenHasher, U2, U0, U0>>(22, 1_258_195);
+        stacked_input_circuit::<DiskTree<PedersenHasher, U2, U0, U0>>(22, 1_258_197);
     }
 
     #[test]
     fn stacked_input_circuit_poseidon_base_2() {
-        stacked_input_circuit::<DiskTree<PoseidonHasher, U2, U0, U0>>(22, 1_206_402);
+        stacked_input_circuit::<DiskTree<PoseidonHasher, U2, U0, U0>>(22, 1_206_404);
     }
 
     #[test]
     fn stacked_input_circuit_poseidon_base_8() {
-        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U0, U0>>(22, 1_199_714);
+        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U0, U0>>(22, 1_199_716);
     }
 
     #[test]
     fn stacked_input_circuit_poseidon_sub_8_4() {
-        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U4, U0>>(22, 1_296_718);
+        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U4, U0>>(22, 1_296_720);
     }
 
     #[test]
     fn stacked_input_circuit_poseidon_top_8_4_2() {
-        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U4, U2>>(22, 1_347_172);
+        stacked_input_circuit::<DiskTree<PoseidonHasher, U8, U4, U2>>(22, 1_347_174);
     }
 
     fn stacked_input_circuit<Tree: MerkleTreeTrait + 'static>(


### PR DESCRIPTION
When creating a label, the bits resulting from the SHA256 circuit were not being constrained to the returned result — although that result was correctly computed. This PR corrects that.

- Use `pack_bits` instead of `compute_multipacking`. This adds one constraint per call to `create_label`.
- Use a general utility function (`reverse_bit_numbering` was `fixup_bits`) rather than ad-hoc transformation of the sha256-result bit array.
- Rename `fixup_bits`, an inscrutable and domain-specific name, to the transparent and general-purpose `reverse_bit_numbering`. NOTE: I chose 'bit numbering' (https://en.wikipedia.org/wiki/Bit_numbering) rather than 'bit endianness' to avoid potential ambiguity when mentioning 'endianness', since this function preserves byte order (when the bit array is viewed as a flattened sequence of octets).
- Generalize the renamed function to not require 255-bit input but instead zero-pad to fulfill the functional requirement that octets should be full before reversal.