### PR TITLE
Add opaque porep_id as public input and use when constructing replica_id

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/prodbench.rs
+++ b/fil-proofs-tooling/src/bin/benchy/prodbench.rs
@@ -179,6 +179,7 @@ pub fn run(
     let mut outputs = ProdbenchOutputs::default();
 
     let sector_size = SectorSize(inputs.sector_size_bytes());
+    let arbitrary_porep_id = [123; 32];
 
     assert!(inputs.num_sectors > 0, "Missing num_sectors");
 
@@ -186,6 +187,7 @@ pub fn run(
         sector_size,
         inputs.num_sectors as usize,
         only_add_piece,
+        arbitrary_porep_id,
     );
 
     if only_add_piece || only_replicate {
@@ -270,7 +272,6 @@ fn run_measure_circuits(i: &ProdbenchInputs) -> CircuitOutputs {
 }
 
 fn measure_porep_circuit(i: &ProdbenchInputs) -> usize {
-    use storage_proofs::drgraph::new_seed;
     use storage_proofs::porep::stacked::{
         LayerChallenges, SetupParams, StackedCompound, StackedDrg,
     };
@@ -282,11 +283,12 @@ fn measure_porep_circuit(i: &ProdbenchInputs) -> usize {
     let nodes = (i.sector_size_bytes() / 32) as usize;
     let layer_challenges = LayerChallenges::new(layers, challenge_count);
 
+    let arbitrary_porep_id = [222; 32];
     let sp = SetupParams {
         nodes,
         degree: drg_degree,
         expansion_degree,
-        seed: new_seed(),
+        porep_id: arbitrary_porep_id,
         layer_challenges,
     };
 
@@ -315,10 +317,12 @@ fn generate_params(i: &ProdbenchInputs) {
         "generating params: porep: (size: {:?}, partitions: {:?})",
         &sector_size, &partitions
     );
+    let dummy_porep_id = [0; 32];
 
     cache_porep_params(PoRepConfig {
         sector_size,
         partitions,
+        porep_id: dummy_porep_id,
     });
 }
 
@@ -326,9 +330,11 @@ fn cache_porep_params(porep_config: PoRepConfig) {
     use filecoin_proofs::parameters::public_params;
     use storage_proofs::porep::stacked::{StackedCompound, StackedDrg};
 
+    let dummy_porep_id = [0; 32];
     let public_params = public_params(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
+        dummy_porep_id,
     )
     .unwrap();
 

--- a/fil-proofs-tooling/src/bin/benchy/stacked.rs
+++ b/fil-proofs-tooling/src/bin/benchy/stacked.rs
@@ -120,11 +120,12 @@ where
         );
 
         let replica_id = H::Domain::random(rng);
+        let arbitrary_porep_id = [11; 32];
         let sp = stacked::SetupParams {
             nodes,
             degree: BASE_DEGREE,
             expansion_degree: EXP_DEGREE,
-            seed: new_seed(),
+            porep_id: arbitrary_porep_id,
             layer_challenges: layer_challenges.clone(),
         };
 
@@ -154,11 +155,14 @@ where
                         replica_path.clone(),
                     )?;
 
+                let arbitrary_porep_id = [88; 32];
+
                 let pb = stacked::PublicInputs::<H::Domain, <Sha256Hasher as Hasher>::Domain> {
                     replica_id,
                     seed,
                     tau: Some(tau),
                     k: Some(0),
+                    porep_id: arbitrary_porep_id,
                 };
 
                 // Convert TemporaryAux to TemporaryAuxCache, which instantiates all

--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -102,6 +102,8 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
 
     let piece_infos = vec![piece_info];
 
+    let arbitrary_porep_id = [99; 32];
+
     // Replicate the staged sector, write the replica file to `sealed_path`.
     let porep_config = PoRepConfig {
         sector_size: SectorSize(sector_size),
@@ -112,6 +114,7 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
                 .get(&(sector_size))
                 .unwrap(),
         ),
+        porep_id: arbitrary_porep_id,
     };
     let cache_dir = tempfile::tempdir().unwrap();
     let sector_id = SectorId::from(SECTOR_ID);

--- a/fil-proofs-tooling/src/bin/benchy/winning_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/winning_post.rs
@@ -53,7 +53,8 @@ pub fn run_fallback_post_bench<Tree: 'static + MerkleTreeTrait>(
             "This benchmark only works with WINNING_POST_SECTOR_COUNT == 1"
         ));
     }
-    let (sector_id, replica_output) = create_replica::<Tree>(sector_size);
+    let arbitrary_porep_id = [66; 32];
+    let (sector_id, replica_output) = create_replica::<Tree>(sector_size, arbitrary_porep_id);
 
     // Store the replica's private and publicly facing info for proving and verifying respectively.
     let pub_replica_info = vec![(sector_id, replica_output.public_replica_info)];

--- a/fil-proofs-tooling/src/bin/gpu-cpu-test/main.rs
+++ b/fil-proofs-tooling/src/bin/gpu-cpu-test/main.rs
@@ -129,9 +129,10 @@ fn threads_mode(parallel: u8, gpu_stealing: bool) {
     let mut senders = Vec::new();
     // All thread handles that get terminated
     let mut threads: Vec<Option<thread::JoinHandle<_>>> = Vec::new();
+    let arbitrary_porep_id = [234; 32];
 
     // Create fixtures only once for both threads
-    let (sector_id, replica_output) = create_replica::<MerkleTree>(SECTOR_SIZE);
+    let (sector_id, replica_output) = create_replica::<MerkleTree>(SECTOR_SIZE, arbitrary_porep_id);
     let priv_replica_info = (sector_id, replica_output.private_replica_info);
 
     // Put each proof into it's own scope (the other one is due to the if statement)

--- a/fil-proofs-tooling/src/shared.rs
+++ b/fil-proofs-tooling/src/shared.rs
@@ -64,8 +64,10 @@ pub fn create_piece(piece_bytes: UnpaddedBytesAmount) -> NamedTempFile {
 /// Create a replica for a single sector
 pub fn create_replica<Tree: 'static + MerkleTreeTrait>(
     sector_size: u64,
+    porep_id: [u8; 32],
 ) -> (SectorId, PreCommitReplicaOutput<Tree>) {
-    let (_porep_config, result) = create_replicas::<Tree>(SectorSize(sector_size), 1, false);
+    let (_porep_config, result) =
+        create_replicas::<Tree>(SectorSize(sector_size), 1, false, porep_id);
     // Extract the sector ID and replica output out of the result
     result
         .unwrap()
@@ -79,6 +81,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
     sector_size: SectorSize,
     qty_sectors: usize,
     only_add: bool,
+    porep_id: [u8; 32],
 ) -> (
     PoRepConfig,
     Option<(
@@ -99,6 +102,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
                 .get(&u64::from(sector_size))
                 .expect("unknown sector size"),
         ),
+        porep_id,
     };
 
     let mut out: Vec<(SectorId, PreCommitReplicaOutput<Tree>)> = Default::default();

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -44,6 +44,7 @@ merkletree = "0.20.0"
 bincode = "1.1.2"
 anyhow = "1.0.23"
 rand_xorshift = "0.2.0"
+sha2 = { version = "0.8.3", package = "sha2ni" }
 typenum = "1.11.2"
 bitintr = "0.3.0"
 gperftools = { version = "0.2", optional = true }

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -131,8 +131,13 @@ where
     let comm_d =
         as_safe_commitment::<<DefaultPieceHasher as Hasher>::Domain, _>(&comm_d, "comm_d")?;
 
-    let replica_id =
-        generate_replica_id::<Tree::Hasher, _>(&prover_id, sector_id.into(), &ticket, comm_d);
+    let replica_id = generate_replica_id::<Tree::Hasher, _>(
+        &prover_id,
+        sector_id.into(),
+        &ticket,
+        comm_d,
+        &porep_config.porep_id,
+    );
 
     let mut data = Vec::new();
     sealed_sector.read_to_end(&mut data)?;
@@ -152,6 +157,7 @@ where
     let pp = public_params(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.porep_id,
     )?;
 
     let offset_padded: PaddedBytesAmount = UnpaddedBytesAmount::from(offset).into();
@@ -559,6 +565,7 @@ mod tests {
         let out = bytes_into_fr(&not_convertible_to_fr_bytes);
         assert!(out.is_err(), "tripwire");
 
+        let arbitrary_porep_id = [87; 32];
         {
             let result = verify_seal::<DefaultOctLCTree>(
                 PoRepConfig {
@@ -570,6 +577,7 @@ mod tests {
                             .get(&SECTOR_SIZE_2_KIB)
                             .unwrap(),
                     ),
+                    porep_id: arbitrary_porep_id,
                 },
                 not_convertible_to_fr_bytes,
                 convertible_to_fr_bytes,
@@ -604,6 +612,7 @@ mod tests {
                             .get(&SECTOR_SIZE_2_KIB)
                             .unwrap(),
                     ),
+                    porep_id: arbitrary_porep_id,
                 },
                 convertible_to_fr_bytes,
                 not_convertible_to_fr_bytes,

--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -36,6 +36,7 @@ fn cache_porep_params<Tree: 'static + MerkleTreeTrait>(porep_config: PoRepConfig
     let public_params = public_params(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.porep_id,
     )
     .unwrap();
 
@@ -216,6 +217,7 @@ fn generate_params_porep(sector_size: u64) {
                     .get(&sector_size)
                     .expect("missing sector size"),
             ),
+            porep_id: [0; 32],
         }
     );
 }

--- a/filecoin-proofs/src/bin/phase2.rs
+++ b/filecoin-proofs/src/bin/phase2.rs
@@ -178,12 +178,14 @@ fn blank_porep_poseidon_circuit<Tree: MerkleTreeTrait>(
     let porep_config = PoRepConfig {
         sector_size: SectorSize(sector_size),
         partitions: PoRepProofPartitions(n_partitions),
+        porep_id: [0; 32],
     };
 
     let setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(
             PaddedBytesAmount::from(porep_config),
             usize::from(PoRepProofPartitions::from(porep_config)),
+            porep_config.porep_id,
         )
         .unwrap(),
         partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -81,6 +81,7 @@ pub fn get_stacked_params<Tree: 'static + MerkleTreeTrait>(
     let public_params = public_params::<Tree>(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.porep_id,
     )?;
 
     let parameters_generator = || {
@@ -151,6 +152,7 @@ pub fn get_stacked_verifying_key<Tree: 'static + MerkleTreeTrait>(
     let public_params = public_params(
         PaddedBytesAmount::from(porep_config),
         usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.porep_id,
     )?;
 
     let vk_generator = || {

--- a/filecoin-proofs/src/parameters.rs
+++ b/filecoin-proofs/src/parameters.rs
@@ -6,11 +6,6 @@ use storage_proofs::proof::ProofScheme;
 use crate::constants::*;
 use crate::types::{MerkleTreeTrait, PaddedBytesAmount, PoStConfig};
 
-const DRG_SEED: [u8; 28] = [
-    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
-    26, 27,
-]; // Arbitrary, need a theory for how to vary this over time.
-
 type WinningPostSetupParams = fallback::SetupParams;
 pub type WinningPostPublicParams = fallback::PublicParams;
 
@@ -20,8 +15,13 @@ pub type WindowPostPublicParams = fallback::PublicParams;
 pub fn public_params<Tree: 'static + MerkleTreeTrait>(
     sector_bytes: PaddedBytesAmount,
     partitions: usize,
+    porep_id: [u8; 32],
 ) -> Result<stacked::PublicParams<Tree>> {
-    StackedDrg::<Tree, DefaultPieceHasher>::setup(&setup_params(sector_bytes, partitions)?)
+    StackedDrg::<Tree, DefaultPieceHasher>::setup(&setup_params(
+        sector_bytes,
+        partitions,
+        porep_id,
+    )?)
 }
 
 pub fn winning_post_public_params<Tree: 'static + MerkleTreeTrait>(
@@ -71,6 +71,7 @@ pub fn window_post_setup_params(post_config: &PoStConfig) -> WindowPostSetupPara
 pub fn setup_params(
     sector_bytes: PaddedBytesAmount,
     partitions: usize,
+    porep_id: [u8; 32],
 ) -> Result<stacked::SetupParams> {
     let layer_challenges = select_challenges(
         partitions,
@@ -101,7 +102,7 @@ pub fn setup_params(
         nodes,
         degree,
         expansion_degree,
-        seed: DRG_SEED,
+        porep_id,
         layer_challenges,
     })
 }

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -356,7 +356,7 @@ mod tests {
     use paired::bls12_381::Fr;
     use rand::{Rng, RngCore, SeedableRng};
     use rand_xorshift::XorShiftRng;
-    use storage_proofs::drgraph::{new_seed, Graph};
+    use storage_proofs::drgraph::Graph;
     use storage_proofs::merkle::create_base_merkle_tree;
     use storage_proofs::porep::stacked::StackedBucketGraph;
 
@@ -698,11 +698,12 @@ mod tests {
         sector_size: SectorSize,
     ) -> Result<([u8; 32], Vec<PieceInfo>)> {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
+        let porep_id = [32; 32];
         let graph = StackedBucketGraph::<DefaultPieceHasher>::new_stacked(
             u64::from(sector_size) as usize / NODE_SIZE,
             DRG_DEGREE,
             EXP_DEGREE,
-            new_seed(),
+            porep_id,
         )?;
 
         let mut staged_sector = Vec::with_capacity(u64::from(sector_size) as usize);

--- a/filecoin-proofs/src/types/porep_config.rs
+++ b/filecoin-proofs/src/types/porep_config.rs
@@ -11,6 +11,7 @@ use crate::types::*;
 pub struct PoRepConfig {
     pub sector_size: SectorSize,
     pub partitions: PoRepProofPartitions,
+    pub porep_id: [u8; 32],
 }
 
 impl From<PoRepConfig> for PaddedBytesAmount {
@@ -47,6 +48,7 @@ impl PoRepConfig {
         let params = crate::parameters::public_params::<Tree>(
             self.sector_size.into(),
             self.partitions.into(),
+            self.porep_id,
         )?;
 
         Ok(

--- a/filecoin-proofs/src/types/sector_class.rs
+++ b/filecoin-proofs/src/types/sector_class.rs
@@ -4,6 +4,7 @@ use crate::types::*;
 pub struct SectorClass {
     pub sector_size: SectorSize,
     pub partitions: PoRepProofPartitions,
+    pub porep_id: [u8; 32],
 }
 
 impl From<SectorClass> for PoRepConfig {
@@ -11,10 +12,12 @@ impl From<SectorClass> for PoRepConfig {
         let SectorClass {
             sector_size,
             partitions,
+            porep_id,
         } = x;
         PoRepConfig {
             sector_size,
             partitions,
+            porep_id,
         }
     }
 }

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -349,7 +349,7 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
     )?;
 
     let piece_infos = vec![piece_info];
-
+    let arbitrary_porep_id = [28; 32];
     let sealed_sector_file = NamedTempFile::new()?;
     let mut unseal_file = NamedTempFile::new()?;
     let config = PoRepConfig {
@@ -357,6 +357,7 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
         partitions: PoRepProofPartitions(
             *POREP_PARTITIONS.read().unwrap().get(&sector_size).unwrap(),
         ),
+        porep_id: arbitrary_porep_id,
     };
 
     let cache_dir = tempfile::tempdir().unwrap();

--- a/storage-proofs/core/benches/drgraph.rs
+++ b/storage-proofs/core/benches/drgraph.rs
@@ -11,7 +11,7 @@ fn drgraph(c: &mut Criterion) {
             "bucket/m=6",
             |b, n| {
                 let graph =
-                    BucketGraph::<PedersenHasher>::new(*n, BASE_DEGREE, 0, new_seed()).unwrap();
+                    BucketGraph::<PedersenHasher>::new(*n, BASE_DEGREE, 0, [32; 32]).unwrap();
 
                 b.iter(|| {
                     let mut parents = vec![0; 6];

--- a/storage-proofs/core/src/crypto/mod.rs
+++ b/storage-proofs/core/src/crypto/mod.rs
@@ -1,5 +1,22 @@
+use sha2::{Digest, Sha256};
 pub mod aes;
 pub mod feistel;
 pub mod pedersen;
 pub mod sloth;
 pub mod xor;
+
+pub struct DomainSeparationTag(&'static str);
+
+pub const DRSAMPLE_DST: DomainSeparationTag = DomainSeparationTag("Filecoin_DRSample");
+pub const FEISTEL_DST: DomainSeparationTag = DomainSeparationTag("Filecoin_Feistel");
+
+pub fn derive_porep_domain_seed(
+    domain_separation_tag: DomainSeparationTag,
+    porep_id: [u8; 32],
+) -> [u8; 32] {
+    Sha256::new()
+        .chain(domain_separation_tag.0)
+        .chain(porep_id)
+        .result()
+        .into()
+}

--- a/storage-proofs/core/src/por.rs
+++ b/storage-proofs/core/src/por.rs
@@ -156,7 +156,7 @@ mod tests {
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
-    use crate::drgraph::{new_seed, BucketGraph, Graph, BASE_DEGREE};
+    use crate::drgraph::{BucketGraph, Graph, BASE_DEGREE};
     use crate::fr32::fr_into_bytes;
     use crate::hasher::{Blake2sHasher, PedersenHasher, PoseidonHasher, Sha256Hasher};
     use crate::merkle::{create_base_merkle_tree, DiskStore, MerkleProofTrait, MerkleTreeWrapper};
@@ -174,8 +174,8 @@ mod tests {
         let data: Vec<u8> = (0..leaves)
             .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
             .collect();
-
-        let graph = BucketGraph::<Tree::Hasher>::new(leaves, BASE_DEGREE, 0, new_seed()).unwrap();
+        let porep_id = [3; 32];
+        let graph = BucketGraph::<Tree::Hasher>::new(leaves, BASE_DEGREE, 0, porep_id).unwrap();
         let tree = create_base_merkle_tree::<Tree>(None, graph.size(), data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {
@@ -265,7 +265,9 @@ mod tests {
             .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
             .collect();
 
-        let graph = BucketGraph::<Tree::Hasher>::new(leaves, BASE_DEGREE, 0, new_seed()).unwrap();
+        let porep_id = [99; 32];
+
+        let graph = BucketGraph::<Tree::Hasher>::new(leaves, BASE_DEGREE, 0, porep_id).unwrap();
         let tree = create_base_merkle_tree::<Tree>(None, graph.size(), data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {
@@ -350,7 +352,8 @@ mod tests {
             .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
             .collect();
 
-        let graph = BucketGraph::<Tree::Hasher>::new(leaves, BASE_DEGREE, 0, new_seed()).unwrap();
+        let porep_id = [32; 32];
+        let graph = BucketGraph::<Tree::Hasher>::new(leaves, BASE_DEGREE, 0, porep_id).unwrap();
         let tree = create_base_merkle_tree::<Tree>(None, graph.size(), data.as_slice()).unwrap();
 
         let pub_inputs = PublicInputs {

--- a/storage-proofs/porep/benches/encode.rs
+++ b/storage-proofs/porep/benches/encode.rs
@@ -23,7 +23,7 @@ fn pregenerate_data<H: Hasher>(degree: usize) -> Pregenerated<H> {
         .collect();
     let replica_id: H::Domain = H::Domain::random(&mut rng);
 
-    let graph = StackedBucketGraph::<H>::new_stacked(size, 6, 8, new_seed()).unwrap();
+    let graph = StackedBucketGraph::<H>::new_stacked(size, 6, 8, [32; 32]).unwrap();
 
     Pregenerated {
         data,

--- a/storage-proofs/porep/benches/parents.rs
+++ b/storage-proofs/porep/benches/parents.rs
@@ -38,7 +38,7 @@ fn stop_profile() {}
 
 fn pregenerate_graph<H: Hasher>(size: usize) -> StackedBucketGraph<H> {
     let seed = [1u8; 28];
-    StackedBucketGraph::<H>::new_stacked(size, BASE_DEGREE, EXP_DEGREE, seed).unwrap()
+    StackedBucketGraph::<H>::new_stacked(size, BASE_DEGREE, EXP_DEGREE, [32; 32]).unwrap()
 }
 
 fn parents_loop<H: Hasher, G: Graph<H>>(graph: &G, parents: &mut [u32]) {

--- a/storage-proofs/porep/src/drg/circuit.rs
+++ b/storage-proofs/porep/src/drg/circuit.rs
@@ -314,7 +314,7 @@ mod tests {
     use storage_proofs_core::{
         cache_key::CacheKey,
         compound_proof,
-        drgraph::{graph_height, new_seed, BucketGraph, BASE_DEGREE},
+        drgraph::{graph_height, BucketGraph, BASE_DEGREE},
         fr32::{bytes_into_fr, fr_into_bytes},
         gadgets::TestConstraintSystem,
         hasher::PedersenHasher,
@@ -368,7 +368,7 @@ mod tests {
                 nodes,
                 degree,
                 expansion_degree: 0,
-                seed: new_seed(),
+                porep_id: [32; 32],
             },
             private: false,
             challenges_count: 1,

--- a/storage-proofs/porep/src/drg/compound.rs
+++ b/storage-proofs/porep/src/drg/compound.rs
@@ -289,7 +289,7 @@ mod tests {
     use storage_proofs_core::{
         cache_key::CacheKey,
         compound_proof,
-        drgraph::{new_seed, BucketGraph, BASE_DEGREE},
+        drgraph::{BucketGraph, BASE_DEGREE},
         fr32::fr_into_bytes,
         gadgets::{MetricCS, TestConstraintSystem},
         hasher::{Hasher, PedersenHasher, PoseidonHasher},
@@ -342,16 +342,13 @@ mod tests {
         let replica_path = cache_dir.path().join("replica-path");
         let mut mmapped_data = setup_replica(&data, &replica_path);
 
-        // Only generate seed once. It would be bad if we used different seeds in the same test.
-        let seed = new_seed();
-
         let setup_params = compound_proof::SetupParams {
             vanilla_params: drg::SetupParams {
                 drg: drg::DrgParams {
                     nodes,
                     degree,
                     expansion_degree: 0,
-                    seed,
+                    porep_id: [32; 32],
                 },
                 private: false,
                 challenges_count: 2,
@@ -396,7 +393,7 @@ mod tests {
                     nodes,
                     degree,
                     expansion_degree: 0,
-                    seed,
+                    porep_id: [32; 32],
                 },
                 private: false,
                 challenges_count: 2,

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -80,8 +80,7 @@ pub struct DrgParams {
 
     pub expansion_degree: usize,
 
-    // Random seed
-    pub seed: [u8; 28],
+    pub porep_id: [u8; 32],
 }
 
 #[derive(Debug, Clone)]
@@ -250,7 +249,7 @@ where
             sp.drg.nodes,
             sp.drg.degree,
             sp.drg.expansion_degree,
-            sp.drg.seed,
+            sp.drg.porep_id,
         )?;
 
         Ok(PublicParams::new(graph, sp.private, sp.challenges_count))
@@ -652,7 +651,7 @@ mod tests {
                 nodes,
                 degree: BASE_DEGREE,
                 expansion_degree: 0,
-                seed: new_seed(),
+                porep_id: [32; 32],
             },
             private: false,
             challenges_count: 1,
@@ -731,7 +730,7 @@ mod tests {
                 nodes: data.len() / 32,
                 degree: BASE_DEGREE,
                 expansion_degree: 0,
-                seed: new_seed(),
+                porep_id: [32; 32],
             },
             private: false,
             challenges_count: 1,
@@ -797,7 +796,6 @@ mod tests {
             let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
             let degree = BASE_DEGREE;
             let expansion_degree = 0;
-            let seed = new_seed();
 
             let replica_id: <Tree::Hasher as Hasher>::Domain =
                 <Tree::Hasher as Hasher>::Domain::random(rng);
@@ -825,7 +823,7 @@ mod tests {
                     nodes,
                     degree,
                     expansion_degree,
-                    seed,
+                    porep_id: [32; 32],
                 },
                 private: false,
                 challenges_count: 2,

--- a/storage-proofs/porep/src/stacked/circuit/create_label.rs
+++ b/storage-proofs/porep/src/stacked/circuit/create_label.rs
@@ -74,7 +74,7 @@ mod tests {
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use storage_proofs_core::{
-        drgraph::{new_seed, Graph, BASE_DEGREE},
+        drgraph::{Graph, BASE_DEGREE},
         fr32::{bytes_into_fr, fr_into_bytes},
         gadgets::TestConstraintSystem,
         hasher::Sha256Hasher,
@@ -92,12 +92,13 @@ mod tests {
         let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
 
         let size = 64;
+        let porep_id = [32; 32];
 
         let graph = StackedBucketGraph::<Sha256Hasher>::new_stacked(
             size,
             BASE_DEGREE,
             EXP_DEGREE,
-            new_seed(),
+            porep_id,
         )
         .unwrap();
 

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -349,7 +349,7 @@ mod tests {
     use storage_proofs_core::{
         cache_key::CacheKey,
         compound_proof,
-        drgraph::{new_seed, BASE_DEGREE},
+        drgraph::BASE_DEGREE,
         fr32::fr_into_bytes,
         gadgets::{MetricCS, TestConstraintSystem},
         hasher::{Hasher, PedersenHasher, PoseidonHasher, Sha256Hasher},
@@ -423,7 +423,7 @@ mod tests {
             nodes,
             degree,
             expansion_degree,
-            seed: new_seed(),
+            porep_id: [32; 32],
             layer_challenges: layer_challenges.clone(),
         };
 
@@ -443,10 +443,11 @@ mod tests {
         assert_ne!(data, copied, "replication did not change data");
 
         let seed = rng.gen();
-
+        let arbitrary_porep_id = [44; 32];
         let pub_inputs =
             PublicInputs::<<Tree::Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Domain> {
                 replica_id: replica_id.into(),
+                porep_id: arbitrary_porep_id,
                 seed,
                 tau: Some(tau.into()),
                 k: None,
@@ -594,7 +595,7 @@ mod tests {
                 nodes,
                 degree,
                 expansion_degree,
-                seed: new_seed(),
+                porep_id: [32; 32],
                 layer_challenges: layer_challenges.clone(),
             },
             partitions: Some(partition_count),
@@ -632,10 +633,11 @@ mod tests {
         assert_ne!(data, copied, "replication did not change data");
 
         let seed = rng.gen();
-
+        let arbitrary_porep_id = [55; 32];
         let public_inputs =
             PublicInputs::<<Tree::Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Domain> {
                 replica_id: replica_id.into(),
+                porep_id: arbitrary_porep_id,
                 seed,
                 tau: Some(tau),
                 k: None,

--- a/storage-proofs/porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/graph.rs
@@ -1,3 +1,4 @@
+use std::convert::TryInto;
 use std::marker::PhantomData;
 
 #[cfg(target_arch = "x86")]
@@ -11,7 +12,11 @@ use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 use sha2raw::Sha256;
 use storage_proofs_core::{
-    crypto::feistel::{self, FeistelPrecomputed},
+    crypto::{
+        derive_porep_domain_seed,
+        feistel::{self, FeistelPrecomputed},
+        FEISTEL_DST,
+    },
     drgraph::BASE_DEGREE,
     drgraph::{BucketGraph, Graph},
     error::Result,
@@ -114,6 +119,7 @@ where
 {
     expansion_degree: usize,
     base_graph: G,
+    feistel_keys: [feistel::Index; 4],
     feistel_precomputed: FeistelPrecomputed,
     id: String,
     cache: Option<&'static ParentCache>,
@@ -167,7 +173,7 @@ where
         nodes: usize,
         base_degree: usize,
         expansion_degree: usize,
-        seed: [u8; 28],
+        porep_id: [u8; 32],
     ) -> Result<Self> {
         assert_eq!(base_degree, BASE_DEGREE);
         assert_eq!(expansion_degree, EXP_DEGREE);
@@ -177,9 +183,16 @@ where
 
         let base_graph = match base_graph {
             Some(graph) => graph,
-            None => G::new(nodes, base_degree, 0, seed)?,
+            None => G::new(nodes, base_degree, 0, porep_id)?,
         };
         let bg_id = base_graph.identifier();
+
+        let mut feistel_keys = [0u64; 4];
+        let raw_seed = derive_porep_domain_seed(FEISTEL_DST, porep_id);
+        feistel_keys[0] = u64::from_le_bytes(raw_seed[0..8].try_into().unwrap());
+        feistel_keys[1] = u64::from_le_bytes(raw_seed[8..16].try_into().unwrap());
+        feistel_keys[2] = u64::from_le_bytes(raw_seed[16..24].try_into().unwrap());
+        feistel_keys[3] = u64::from_le_bytes(raw_seed[24..32].try_into().unwrap());
 
         let mut res = StackedGraph {
             base_graph,
@@ -189,6 +202,7 @@ where
             ),
             expansion_degree,
             cache: None,
+            feistel_keys,
             feistel_precomputed: feistel::precompute((expansion_degree * nodes) as feistel::Index),
             _h: PhantomData,
         };
@@ -369,9 +383,9 @@ where
         nodes: usize,
         base_degree: usize,
         expansion_degree: usize,
-        seed: [u8; 28],
+        porep_id: [u8; 32],
     ) -> Result<Self> {
-        Self::new_stacked(nodes, base_degree, expansion_degree, seed)
+        Self::new_stacked(nodes, base_degree, expansion_degree, porep_id)
     }
 
     fn create_key(
@@ -443,9 +457,9 @@ where
         nodes: usize,
         base_degree: usize,
         expansion_degree: usize,
-        seed: [u8; 28],
+        porep_id: [u8; 32],
     ) -> Result<Self> {
-        Self::new(None, nodes, base_degree, expansion_degree, seed)
+        Self::new(None, nodes, base_degree, expansion_degree, porep_id)
     }
 
     pub fn base_graph(&self) -> &G {

--- a/storage-proofs/porep/src/stacked/vanilla/params.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/params.rs
@@ -36,9 +36,7 @@ pub struct SetupParams {
 
     pub expansion_degree: usize,
 
-    // Random seed
-    pub seed: [u8; 28],
-
+    pub porep_id: [u8; 32],
     pub layer_challenges: LayerChallenges,
 }
 
@@ -109,6 +107,7 @@ where
 pub struct PublicInputs<T: Domain, S: Domain> {
     pub replica_id: T,
     pub seed: [u8; 32],
+    pub porep_id: [u8; 32],
     pub tau: Option<Tau<T, S>>,
     /// Partition index
     pub k: Option<usize>,
@@ -725,6 +724,7 @@ pub fn generate_replica_id<H: Hasher, T: AsRef<[u8]>>(
     sector_id: u64,
     ticket: &[u8; 32],
     comm_d: T,
+    porep_seed: &[u8; 32],
 ) -> H::Domain {
     use sha2::{Digest, Sha256};
 
@@ -733,6 +733,7 @@ pub fn generate_replica_id<H: Hasher, T: AsRef<[u8]>>(
         .chain(&sector_id.to_be_bytes()[..])
         .chain(ticket)
         .chain(AsRef::<[u8]>::as_ref(&comm_d))
+        .chain(porep_seed)
         .result();
 
     bytes_into_fr_repr_safe(hash.as_ref()).into()

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -891,7 +891,7 @@ mod tests {
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
     use storage_proofs_core::{
-        drgraph::{new_seed, BASE_DEGREE},
+        drgraph::BASE_DEGREE,
         fr32::fr_into_bytes,
         hasher::{Blake2sHasher, PedersenHasher, PoseidonHasher, Sha256Hasher},
         merkle::MerkleTreeTrait,
@@ -1011,7 +1011,7 @@ mod tests {
             nodes,
             degree: BASE_DEGREE,
             expansion_degree: EXP_DEGREE,
-            seed: new_seed(),
+            porep_id: [32; 32],
             layer_challenges: challenges.clone(),
         };
 
@@ -1188,7 +1188,7 @@ mod tests {
             nodes,
             degree,
             expansion_degree,
-            seed: new_seed(),
+            porep_id: [32; 32],
             layer_challenges: challenges.clone(),
         };
 
@@ -1208,10 +1208,11 @@ mod tests {
         assert_ne!(data, copied, "replication did not change data");
 
         let seed = rng.gen();
-
+        let arbitrary_porep_id = [92; 32];
         let pub_inputs =
             PublicInputs::<<Tree::Hasher as Hasher>::Domain, <Blake2sHasher as Hasher>::Domain> {
                 replica_id,
+                porep_id: arbitrary_porep_id,
                 seed,
                 tau: Some(tau),
                 k: None,
@@ -1268,7 +1269,7 @@ mod tests {
             nodes,
             degree,
             expansion_degree,
-            seed: new_seed(),
+            porep_id: [32; 32],
             layer_challenges: layer_challenges.clone(),
         };
 

--- a/storage-proofs/porep/src/stacked/vanilla/proof_scheme.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof_scheme.rs
@@ -31,7 +31,7 @@ impl<'a, 'c, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> ProofScheme<'
             sp.nodes,
             sp.degree,
             sp.expansion_degree,
-            sp.seed,
+            sp.porep_id,
         )?;
 
         Ok(PublicParams::new(graph, sp.layer_challenges.clone()))
@@ -142,6 +142,7 @@ impl<'a, 'c, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> ProofScheme<'
         self::PublicInputs {
             replica_id: pub_in.replica_id,
             seed: pub_in.seed,
+            porep_id: pub_in.porep_id,
             tau: pub_in.tau,
             k,
         }


### PR DESCRIPTION
This PR adds a new 32-byte public input, `porep_id`, to SDR. This value is used to construct `replica_id`, the drg seed, and the Feistel keys. As a public input, it must be supplied (with identical value) by both prover and verifier. The intention at the protocol level is that proofs consumers should pass a value derived from the `RegisteredProof` — since it is guaranteed to distinguish all extant PoReps. However, from the perspective of the `rust-fil-proofs` the `porep_id` is treated as opaque and is required only to be used consistently. If consumers choose to duplicate `porep_id`s, they take responsibility for the possibility that `replica_id` or DRG graph might be reused between the set of concrete proofs the duplicated id is used to create. If the Filecoin spec is modified to require a distinct `porep_id` for every distinct concrete type, such usage will violate the protocol.

*UPDATE: now supports Feistel keys*
- `porep_id` is a PublicParam
- It is passed to `derive_porep_domain_seed`, which also takes domain separation tag.
- In this way, the DRG seed and Feistel keys are created when the graphs are instantiated.