### PR TITLE
refactor(storage-proofs): fix clippy warnings

### DIFF
--- a/fil-proofs-tooling/src/bin/micro.rs
+++ b/fil-proofs-tooling/src/bin/micro.rs
@@ -311,9 +311,10 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn test_time_to_us() {
-        assert_eq!(time_to_us("123.12 us"), 123.12);
-        assert_eq!(time_to_us("1.0 s"), 1_000_000.);
+        assert_eq!(time_to_us("123.12 us"), 123.12); // No math done on 'us' so strict float cmp is ok.
+        assert_eq!(time_to_us("1.0 s"), 1_000_000.); // Multiplication, so strict float cmp is ok.
     }
 
     #[test]

--- a/fil-proofs-tooling/src/bin/micro.rs
+++ b/fil-proofs-tooling/src/bin/micro.rs
@@ -371,8 +371,8 @@ median [138.33 us 143.23 us] med. abs. dev. [1.7507 ms 8.4109 ms]";
                     unit: Some("us".to_string())
                 }),
                 r_2: Some(Interval {
-                    start: 0.8124914,
-                    end: 0.8320154,
+                    start: 0.812_491_4,
+                    end: 0.832_015_4,
                     unit: None
                 }),
                 std_dev: Some(Interval {
@@ -449,8 +449,8 @@ median [138.33 us 143.23 us] med. abs. dev. [1.7507 ms 8.4109 ms]";
                     unit: Some("us".to_string())
                 }),
                 r_2: Some(Interval {
-                    start: 0.8124914,
-                    end: 0.8320154,
+                    start: 0.812_491_4,
+                    end: 0.832_015_4,
                     unit: None
                 }),
                 std_dev: Some(Interval {

--- a/filecoin-proofs/benches/preprocessing.rs
+++ b/filecoin-proofs/benches/preprocessing.rs
@@ -55,7 +55,7 @@ fn preprocessing_benchmark(c: &mut Criterion) {
                 });
                 stop_profile();
             },
-            vec![128, 256, 512, 256_000, 512_000, 1024_000, 2048_000],
+            vec![128, 256, 512, 256_000, 512_000, 1_024_000, 2_048_000],
         )
         .sample_size(10)
         .throughput(|s| Throughput::Bytes(*s as u64))

--- a/filecoin-proofs/src/fr32.rs
+++ b/filecoin-proofs/src/fr32.rs
@@ -948,7 +948,7 @@ mod tests {
             .chunks(FR32_PADDING_MAP.data_bits)
             .into_iter()
         {
-            padded_data.extend(data_unit.into_iter());
+            padded_data.extend(data_unit);
 
             // To avoid reconverting the iterator, we deduce if we need the padding
             // by the length of `padded_data`: a full data unit would not leave the

--- a/filecoin-proofs/src/fr32_reader.rs
+++ b/filecoin-proofs/src/fr32_reader.rs
@@ -499,7 +499,7 @@ mod tests {
         let raw_data: BitVec<LittleEndian, u8> = BitVec::from(raw_data);
 
         for data_unit in raw_data.into_iter().chunks(DATA_BITS as usize).into_iter() {
-            padded_data.extend(data_unit.into_iter());
+            padded_data.extend(data_unit);
 
             // To avoid reconverting the iterator, we deduce if we need the padding
             // by the length of `padded_data`: a full data unit would not leave the

--- a/filecoin-proofs/src/fr32_reader.rs
+++ b/filecoin-proofs/src/fr32_reader.rs
@@ -328,9 +328,9 @@ mod tests {
         buffer.copy_from_slice(&val[..]);
         buffer.reset_available(64);
 
-        for i in 0..8 {
+        for (i, &byte) in val.iter().enumerate().take(8) {
             let read = buffer.read_u8();
-            assert_eq!(read, val[i], "failed to read byte {}", i);
+            assert_eq!(read, byte, "failed to read byte {}", i);
         }
     }
 
@@ -542,13 +542,13 @@ mod tests {
         let mut reader = Fr32Reader::new(io::Cursor::new(&source));
         reader.read_to_end(&mut buf).unwrap();
 
-        for i in 0..31 {
-            assert_eq!(buf[i], i as u8 + 1);
+        for (i, &byte) in buf.iter().enumerate().take(31) {
+            assert_eq!(byte, i as u8 + 1);
         }
         assert_eq!(buf[31], 63); // Six least significant bits of 0xff
         assert_eq!(buf[32], (1 << 2) | 0b11); // 7
-        for i in 33..63 {
-            assert_eq!(buf[i], (i as u8 - 31) << 2);
+        for (i, &byte) in buf.iter().enumerate().skip(33).take(30) {
+            assert_eq!(byte, (i as u8 - 31) << 2);
         }
         assert_eq!(buf[63], (0x0f << 2)); // 4-bits of ones, half of 0xff, shifted by two, followed by two bits of 0-padding.
         assert_eq!(buf[64], 0x0f | 9 << 4); // The last half of 0xff, 'followed' by 9.

--- a/filecoin-proofs/src/fr32_reader.rs
+++ b/filecoin-proofs/src/fr32_reader.rs
@@ -515,7 +515,7 @@ mod tests {
     }
 
     fn validate_fr32(bytes: &[u8]) {
-        let chunks = (bytes.len() as f64 / 32 as f64).ceil() as usize;
+        let chunks = (bytes.len() as f64 / 32_f64).ceil() as usize;
         for (i, chunk) in bytes.chunks(32).enumerate() {
             let _ = storage_proofs::fr32::bytes_into_fr(chunk).expect(&format!(
                 "chunk {}/{} cannot be converted to valid Fr: {:?}",

--- a/filecoin-proofs/src/fr32_reader.rs
+++ b/filecoin-proofs/src/fr32_reader.rs
@@ -517,12 +517,14 @@ mod tests {
     fn validate_fr32(bytes: &[u8]) {
         let chunks = (bytes.len() as f64 / 32_f64).ceil() as usize;
         for (i, chunk) in bytes.chunks(32).enumerate() {
-            let _ = storage_proofs::fr32::bytes_into_fr(chunk).expect(&format!(
-                "chunk {}/{} cannot be converted to valid Fr: {:?}",
-                i + 1,
-                chunks,
-                chunk
-            ));
+            let _ = storage_proofs::fr32::bytes_into_fr(chunk).unwrap_or_else(|_| {
+                panic!(
+                    "chunk {}/{} cannot be converted to valid Fr: {:?}",
+                    i + 1,
+                    chunks,
+                    chunk
+                )
+            });
         }
     }
 

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -491,19 +491,17 @@ mod tests {
         );
 
         assert!(
-            verify_pieces(&comm_d, &[e.clone(), c.clone(), d.clone()], sector_size)
-                .expect("failed to verify"),
+            verify_pieces(&comm_d, &[e.clone(), c, d], sector_size).expect("failed to verify"),
             "[e, c, d]"
         );
 
         assert!(
-            verify_pieces(&comm_d, &[e.clone(), f.clone()], sector_size).expect("failed to verify"),
+            verify_pieces(&comm_d, &[e, f.clone()], sector_size).expect("failed to verify"),
             "[e, f]"
         );
 
         assert!(
-            verify_pieces(&comm_d, &[a.clone(), b.clone(), f.clone()], sector_size)
-                .expect("failed to verify"),
+            verify_pieces(&comm_d, &[a, b, f], sector_size).expect("failed to verify"),
             "[a, b, f]"
         );
 
@@ -556,7 +554,7 @@ mod tests {
             pad.clone(),
             pad.clone(),
             pad.clone(),
-            pad.clone(),
+            pad,
         ];
 
         let hash = |a, b| {

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -483,7 +483,7 @@ mod tests {
         assert!(
             verify_pieces(
                 &comm_d,
-                &vec![a.clone(), b.clone(), c.clone(), d.clone()],
+                &[a.clone(), b.clone(), c.clone(), d.clone()],
                 sector_size
             )
             .expect("failed to verify"),
@@ -491,25 +491,24 @@ mod tests {
         );
 
         assert!(
-            verify_pieces(&comm_d, &vec![e.clone(), c.clone(), d.clone()], sector_size)
+            verify_pieces(&comm_d, &[e.clone(), c.clone(), d.clone()], sector_size)
                 .expect("failed to verify"),
             "[e, c, d]"
         );
 
         assert!(
-            verify_pieces(&comm_d, &vec![e.clone(), f.clone()], sector_size)
-                .expect("failed to verify"),
+            verify_pieces(&comm_d, &[e.clone(), f.clone()], sector_size).expect("failed to verify"),
             "[e, f]"
         );
 
         assert!(
-            verify_pieces(&comm_d, &vec![a.clone(), b.clone(), f.clone()], sector_size)
+            verify_pieces(&comm_d, &[a.clone(), b.clone(), f.clone()], sector_size)
                 .expect("failed to verify"),
             "[a, b, f]"
         );
 
         assert!(
-            verify_pieces(&comm_d, &vec![g], sector_size).expect("failed to verify"),
+            verify_pieces(&comm_d, &[g], sector_size).expect("failed to verify"),
             "[g]"
         );
     }

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -515,6 +515,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::identity_op)]
     fn test_verify_padded_pieces() {
         // [
         //   {(A0 00) (BB BB)} -> A(1) P(1) P(1) P(1) B(4)

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -331,8 +331,7 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
 ) -> Result<(SectorId, NamedTempFile, Commitment, tempfile::TempDir)> {
     init_logger();
 
-    let number_of_bytes_in_piece =
-        UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size.clone()));
+    let number_of_bytes_in_piece = UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size));
 
     let piece_bytes: Vec<u8> = (0..number_of_bytes_in_piece.0)
         .map(|_| rand::random::<u8>())
@@ -359,7 +358,7 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
     let sealed_sector_file = NamedTempFile::new()?;
     let mut unseal_file = NamedTempFile::new()?;
     let config = PoRepConfig {
-        sector_size: SectorSize(sector_size.clone()),
+        sector_size: SectorSize(sector_size),
         partitions: PoRepProofPartitions(
             *POREP_PARTITIONS.read().unwrap().get(&sector_size).unwrap(),
         ),
@@ -396,8 +395,8 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
         sealed_sector_file.path(),
     )?;
 
-    let comm_d = pre_commit_output.comm_d.clone();
-    let comm_r = pre_commit_output.comm_r.clone();
+    let comm_d = pre_commit_output.comm_d;
+    let comm_r = pre_commit_output.comm_r;
 
     validate_cache_for_commit::<_, _, Tree>(cache_dir.path(), sealed_sector_file.path())?;
 

--- a/filecoin-proofs/tests/paramfetch/prompts_to_fetch.rs
+++ b/filecoin-proofs/tests/paramfetch/prompts_to_fetch.rs
@@ -41,7 +41,7 @@ fn nothing_to_fetch_if_cache_fully_hydrated() -> Result<(), FailureError> {
         "aaa.vk".to_string(),
         ParameterData {
             cid: "".to_string(),
-            digest: aaa_checksum.clone(),
+            digest: aaa_checksum,
             sector_size: 1234,
         },
     );

--- a/filecoin-proofs/tests/paramfetch/support/session.rs
+++ b/filecoin-proofs/tests/paramfetch/support/session.rs
@@ -4,7 +4,6 @@ use std::path::{Path, PathBuf};
 
 use failure::SyncFailure;
 use rexpect::session::PtyBashSession;
-use tempfile;
 use tempfile::TempDir;
 
 use crate::support::{cargo_bin, spawn_bash_with_retries};

--- a/filecoin-proofs/tests/paramfetch/support/session.rs
+++ b/filecoin-proofs/tests/paramfetch/support/session.rs
@@ -77,7 +77,7 @@ impl ParamFetchSessionBuilder {
                 s.push_str(&wl.join(","));
                 s
             })
-            .unwrap_or("".to_string());
+            .unwrap_or_else(|| "".to_string());
 
         let json_argument = if self.manifest.is_some() {
             format!("--json={:?}", self.manifest.unwrap())

--- a/filecoin-proofs/tests/paramfetch/support/session.rs
+++ b/filecoin-proofs/tests/paramfetch/support/session.rs
@@ -51,7 +51,7 @@ impl ParamFetchSessionBuilder {
         filename: P,
         r: &mut R,
     ) -> ParamFetchSessionBuilder {
-        let mut pbuf = self.cache_dir.path().clone().to_path_buf();
+        let mut pbuf = self.cache_dir.path().to_path_buf();
         pbuf.push(filename.as_ref());
 
         let mut file = File::create(&pbuf).expect("failed to create file in temp dir");

--- a/filecoin-proofs/tests/parampublish/read_metadata_files.rs
+++ b/filecoin-proofs/tests/parampublish/read_metadata_files.rs
@@ -21,11 +21,11 @@ fn fails_if_missing_metadata_file() -> Result<(), FailureError> {
 
 #[test]
 fn fails_if_malformed_metadata_file() -> Result<(), FailureError> {
-    let mut malformed: &[u8] = &vec![42];
+    let mut malformed: &[u8] = &[42];
 
     let (mut session, _) = ParamPublishSessionBuilder::new()
         .with_session_timeout_ms(1000)
-        .with_files(&vec!["v11-aaa.vk", "v11-aaa.params"])
+        .with_files(&["v11-aaa.vk", "v11-aaa.params"])
         .with_file_and_bytes("v11-aaa.meta", &mut malformed)
         .with_prompt_disabled()
         .build();

--- a/filecoin-proofs/tests/parampublish/support/session.rs
+++ b/filecoin-proofs/tests/parampublish/support/session.rs
@@ -122,7 +122,7 @@ impl ParamPublishSessionBuilder {
         let cache_dir_path = format!("{:?}", self.cache_dir.path());
 
         let cache_contents: Vec<PathBuf> = std::fs::read_dir(&self.cache_dir)
-            .expect(&format!("failed to read cache dir {:?}", self.cache_dir))
+            .unwrap_or_else(|_| panic!("failed to read cache dir {:?}", self.cache_dir))
             .map(|x| x.expect("failed to get dir entry"))
             .map(|x| x.path())
             .collect();

--- a/filecoin-proofs/tests/parampublish/support/session.rs
+++ b/filecoin-proofs/tests/parampublish/support/session.rs
@@ -5,7 +5,6 @@ use std::path::{Path, PathBuf};
 use failure::SyncFailure;
 use rand::Rng;
 use rexpect::session::PtyBashSession;
-use tempfile;
 use tempfile::TempDir;
 
 use storage_proofs::parameter_cache::{CacheEntryMetadata, PARAMETER_CACHE_ENV_VAR};

--- a/filecoin-proofs/tests/parampublish/support/session.rs
+++ b/filecoin-proofs/tests/parampublish/support/session.rs
@@ -60,7 +60,8 @@ impl ParamPublishSessionBuilder {
         let mut file = File::create(&pbuf).expect("failed to create file in temp dir");
 
         let random_bytes = rand::thread_rng().gen::<[u8; 32]>();
-        file.write(&random_bytes).expect("failed to write bytes");
+        file.write_all(&random_bytes)
+            .expect("failed to write bytes");
 
         self.cached_file_pbufs.push(pbuf);
         self

--- a/filecoin-proofs/tests/parampublish/support/session.rs
+++ b/filecoin-proofs/tests/parampublish/support/session.rs
@@ -24,7 +24,7 @@ impl ParamPublishSessionBuilder {
     pub fn new() -> ParamPublishSessionBuilder {
         let temp_dir = tempfile::tempdir().expect("could not create temp dir");
 
-        let mut pbuf = temp_dir.path().clone().to_path_buf();
+        let mut pbuf = temp_dir.path().to_path_buf();
         pbuf.push("parameters.json");
 
         File::create(&pbuf).expect("failed to create file in temp dir");
@@ -56,7 +56,7 @@ impl ParamPublishSessionBuilder {
     /// Create a file containing 32 random bytes with the given name in the
     /// cache directory.
     pub fn with_file<P: AsRef<Path>>(mut self, filename: P) -> ParamPublishSessionBuilder {
-        let mut pbuf = self.cache_dir.path().clone().to_path_buf();
+        let mut pbuf = self.cache_dir.path().to_path_buf();
         pbuf.push(filename.as_ref());
 
         let mut file = File::create(&pbuf).expect("failed to create file in temp dir");
@@ -74,7 +74,7 @@ impl ParamPublishSessionBuilder {
         filename: P,
         r: &mut R,
     ) -> ParamPublishSessionBuilder {
-        let mut pbuf = self.cache_dir.path().clone().to_path_buf();
+        let mut pbuf = self.cache_dir.path().to_path_buf();
         pbuf.push(filename.as_ref());
 
         let mut file = File::create(&pbuf).expect("failed to create file in temp dir");

--- a/filecoin-proofs/tests/parampublish/support/session.rs
+++ b/filecoin-proofs/tests/parampublish/support/session.rs
@@ -123,7 +123,6 @@ impl ParamPublishSessionBuilder {
 
         let cache_contents: Vec<PathBuf> = std::fs::read_dir(&self.cache_dir)
             .expect(&format!("failed to read cache dir {:?}", self.cache_dir))
-            .into_iter()
             .map(|x| x.expect("failed to get dir entry"))
             .map(|x| x.path())
             .collect();

--- a/filecoin-proofs/tests/parampublish/support/session.rs
+++ b/filecoin-proofs/tests/parampublish/support/session.rs
@@ -48,9 +48,7 @@ impl ParamPublishSessionBuilder {
 
     /// Create empty files with the given names in the cache directory.
     pub fn with_files<P: AsRef<Path>>(self, filenames: &[P]) -> ParamPublishSessionBuilder {
-        filenames
-            .into_iter()
-            .fold(self, |acc, item| acc.with_file(item))
+        filenames.iter().fold(self, |acc, item| acc.with_file(item))
     }
 
     /// Create a file containing 32 random bytes with the given name in the

--- a/filecoin-proofs/tests/parampublish/write_json_manifest.rs
+++ b/filecoin-proofs/tests/parampublish/write_json_manifest.rs
@@ -79,7 +79,7 @@ fn filename_to_checksum<P: AsRef<Path>>(
                 .file_name()
                 .and_then(|os_str| os_str.to_str())
                 .map(|s| s.to_string())
-                .unwrap_or("".to_string()),
+                .unwrap_or_else(|| "".to_string()),
             ipfs_bin
                 .compute_checksum(item)
                 .expect("failed to compute checksum"),

--- a/storage-proofs/core/benches/blake2s.rs
+++ b/storage-proofs/core/benches/blake2s.rs
@@ -51,13 +51,9 @@ fn blake2s_benchmark(c: &mut Criterion) {
 
 fn blake2s_circuit_benchmark(c: &mut Criterion) {
     let mut rng1 = thread_rng();
-    let groth_params = generate_random_parameters::<Bls12, _, _>(
-        Blake2sExample {
-            data: &vec![None; 256],
-        },
-        &mut rng1,
-    )
-    .unwrap();
+    let groth_params =
+        generate_random_parameters::<Bls12, _, _>(Blake2sExample { data: &[None; 256] }, &mut rng1)
+            .unwrap();
 
     let params = vec![32];
 

--- a/storage-proofs/core/benches/blake2s.rs
+++ b/storage-proofs/core/benches/blake2s.rs
@@ -14,7 +14,7 @@ impl<'a> Circuit<Bls12> for Blake2sExample<'a> {
     fn synthesize<CS: ConstraintSystem<Bls12>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let data: Vec<Boolean> = self
             .data
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(i, b)| {
                 Ok(Boolean::from(boolean::AllocatedBit::alloc(

--- a/storage-proofs/core/benches/drgraph.rs
+++ b/storage-proofs/core/benches/drgraph.rs
@@ -2,6 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Parameter
 use storage_proofs_core::drgraph::*;
 use storage_proofs_core::hasher::pedersen::*;
 
+#[allow(clippy::unit_arg)]
 fn drgraph(c: &mut Criterion) {
     let params = vec![12, 24, 128, 1024];
 

--- a/storage-proofs/core/benches/merkle.rs
+++ b/storage-proofs/core/benches/merkle.rs
@@ -5,7 +5,7 @@ use storage_proofs_core::merkle::{create_base_merkle_tree, BinaryMerkleTree};
 
 fn merkle_benchmark(c: &mut Criterion) {
     #[cfg(feature = "big-sector-sizes-bench")]
-    let params = vec![128, 1024, 1048576];
+    let params = vec![128, 1024, 1_048_576];
     #[cfg(not(feature = "big-sector-sizes-bench"))]
     let params = vec![128, 1024];
 

--- a/storage-proofs/core/benches/pedersen.rs
+++ b/storage-proofs/core/benches/pedersen.rs
@@ -15,7 +15,7 @@ impl<'a> Circuit<Bls12> for PedersenExample<'a> {
     fn synthesize<CS: ConstraintSystem<Bls12>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let data: Vec<Boolean> = self
             .data
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(i, b)| {
                 Ok(Boolean::from(boolean::AllocatedBit::alloc(
@@ -45,7 +45,7 @@ impl<'a> Circuit<Bls12> for PedersenMdExample<'a> {
     fn synthesize<CS: ConstraintSystem<Bls12>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let data: Vec<Boolean> = self
             .data
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(i, b)| {
                 Ok(Boolean::from(boolean::AllocatedBit::alloc(

--- a/storage-proofs/core/benches/pedersen.rs
+++ b/storage-proofs/core/benches/pedersen.rs
@@ -212,5 +212,6 @@ criterion_group!(
     pedersen_benchmark,
     pedersen_md_benchmark,
     pedersen_circuit_benchmark,
+    pedersen_md_circuit_benchmark,
 );
 criterion_main!(benches);

--- a/storage-proofs/core/benches/pedersen.rs
+++ b/storage-proofs/core/benches/pedersen.rs
@@ -106,9 +106,7 @@ fn pedersen_md_benchmark(c: &mut Criterion) {
 fn pedersen_circuit_benchmark(c: &mut Criterion) {
     let mut rng1 = thread_rng();
     let groth_params = generate_random_parameters::<Bls12, _, _>(
-        PedersenExample {
-            data: &vec![None; 256],
-        },
+        PedersenExample { data: &[None; 256] },
         &mut rng1,
     )
     .unwrap();
@@ -160,9 +158,7 @@ fn pedersen_circuit_benchmark(c: &mut Criterion) {
 fn pedersen_md_circuit_benchmark(c: &mut Criterion) {
     let mut rng1 = thread_rng();
     let groth_params = generate_random_parameters::<Bls12, _, _>(
-        PedersenMdExample {
-            data: &vec![None; 256],
-        },
+        PedersenMdExample { data: &[None; 256] },
         &mut rng1,
     )
     .unwrap();

--- a/storage-proofs/core/benches/sha256.rs
+++ b/storage-proofs/core/benches/sha256.rs
@@ -17,7 +17,7 @@ impl<'a> Circuit<Bls12> for Sha256Example<'a> {
     fn synthesize<CS: ConstraintSystem<Bls12>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let data: Vec<Boolean> = self
             .data
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(i, b)| {
                 Ok(Boolean::from(boolean::AllocatedBit::alloc(

--- a/storage-proofs/core/benches/xor.rs
+++ b/storage-proofs/core/benches/xor.rs
@@ -68,8 +68,8 @@ fn xor_circuit_benchmark(c: &mut Criterion) {
     let mut rng1 = thread_rng();
     let groth_params = generate_random_parameters::<Bls12, _, _>(
         XorExample {
-            key: &vec![None; 8 * 32],
-            data: &vec![None; 256],
+            key: &[None; 8 * 32],
+            data: &[None; 256],
         },
         &mut rng1,
     )

--- a/storage-proofs/core/benches/xor.rs
+++ b/storage-proofs/core/benches/xor.rs
@@ -17,7 +17,7 @@ impl<'a> Circuit<Bls12> for XorExample<'a> {
     fn synthesize<CS: ConstraintSystem<Bls12>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let key: Vec<Boolean> = self
             .key
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(i, b)| {
                 Ok(Boolean::from(boolean::AllocatedBit::alloc(
@@ -28,7 +28,7 @@ impl<'a> Circuit<Bls12> for XorExample<'a> {
             .collect::<Result<Vec<_>, SynthesisError>>()?;
         let data: Vec<Boolean> = self
             .data
-            .into_iter()
+            .iter()
             .enumerate()
             .map(|(i, b)| {
                 Ok(Boolean::from(boolean::AllocatedBit::alloc(

--- a/storage-proofs/core/src/crypto/feistel.rs
+++ b/storage-proofs/core/src/crypto/feistel.rs
@@ -183,10 +183,8 @@ mod tests {
             if expect_success {
                 assert!(equal, "failed to permute (n = {})", n);
                 assert!(in_range, "output number is too big (n = {})", n);
-            } else {
-                if !equal || !in_range {
-                    failed = true;
-                }
+            } else if !equal || !in_range {
+                failed = true;
             }
         }
         if !expect_success {

--- a/storage-proofs/core/src/crypto/pedersen.rs
+++ b/storage-proofs/core/src/crypto/pedersen.rs
@@ -405,8 +405,8 @@ mod tests {
             let hashed = pedersen_md_no_padding(&flat);
 
             let mut hasher = Hasher::new(&x[0]).unwrap();
-            for k in 1..5 {
-                hasher.update(&x[k]).unwrap();
+            for val in x.iter().skip(1).take(4) {
+                hasher.update(&val).unwrap();
             }
 
             let hasher_final = hasher.finalize().unwrap();

--- a/storage-proofs/core/src/drgraph.rs
+++ b/storage-proofs/core/src/drgraph.rs
@@ -264,7 +264,7 @@ mod tests {
         let degree = BASE_DEGREE;
         let porep_id = [123; 32];
 
-        for size in vec![4, 16, 256, 2048] {
+        for &size in &[4, 16, 256, 2048] {
             let g = BucketGraph::<H>::new(size, degree, 0, porep_id).unwrap();
 
             assert_eq!(g.size(), size, "wrong nodes count");

--- a/storage-proofs/core/src/fr32.rs
+++ b/storage-proofs/core/src/fr32.rs
@@ -109,8 +109,8 @@ mod tests {
     use super::*;
 
     fn bytes_fr_test(bytes: Fr32Ary, expect_success: bool) {
-        let mut b = &bytes[..];
-        let fr_result = bytes_into_fr(&mut b);
+        let b = &bytes[..];
+        let fr_result = bytes_into_fr(&b);
         if expect_success {
             let f = fr_result.expect("Failed to convert bytes to `Fr`");
             let b2 = fr_into_bytes(&f);
@@ -164,8 +164,7 @@ mod tests {
     }
 
     fn bytes_into_frs_into_bytes_test(bytes: &Fr32) {
-        let mut bytes = bytes.clone();
-        let frs = bytes_into_frs(&mut bytes).expect("Failed to convert bytes into a `Vec<Fr>`");
+        let frs = bytes_into_frs(bytes).expect("Failed to convert bytes into a `Vec<Fr>`");
         assert!(frs.len() == 3);
         let bytes_back = frs_into_bytes(&frs);
         assert!(bytes.to_vec() == bytes_back);

--- a/storage-proofs/core/src/gadgets/constraint.rs
+++ b/storage-proofs/core/src/gadgets/constraint.rs
@@ -136,7 +136,7 @@ mod tests {
 
             let res = add(cs.namespace(|| "a+b"), &a, &b).expect("add failed");
 
-            let mut tmp = a.get_value().unwrap().clone();
+            let mut tmp = a.get_value().unwrap();
             tmp.add_assign(&b.get_value().unwrap());
 
             assert_eq!(res.get_value().unwrap(), tmp);
@@ -156,7 +156,7 @@ mod tests {
 
             let res = sub(cs.namespace(|| "a-b"), &a, &b).expect("subtraction failed");
 
-            let mut tmp = a.get_value().unwrap().clone();
+            let mut tmp = a.get_value().unwrap();
             tmp.sub_assign(&b.get_value().unwrap());
 
             assert_eq!(res.get_value().unwrap(), tmp);

--- a/storage-proofs/core/src/gadgets/uint64.rs
+++ b/storage-proofs/core/src/gadgets/uint64.rs
@@ -184,8 +184,8 @@ mod test {
             let b = UInt64::from_bits_be(&v);
 
             for (i, bit) in b.bits.iter().enumerate() {
-                match bit {
-                    &Boolean::Constant(bit) => {
+                match *bit {
+                    Boolean::Constant(bit) => {
                         assert!(bit == ((b.value.unwrap() >> i) & 1 == 1));
                     }
                     _ => unreachable!(),
@@ -216,8 +216,8 @@ mod test {
             let b = UInt64::from_bits(&v);
 
             for (i, bit) in b.bits.iter().enumerate() {
-                match bit {
-                    &Boolean::Constant(bit) => {
+                match *bit {
+                    Boolean::Constant(bit) => {
                         assert!(bit == ((b.value.unwrap() >> i) & 1 == 1));
                     }
                     _ => unreachable!(),

--- a/storage-proofs/core/src/hasher/poseidon.rs
+++ b/storage-proofs/core/src/hasher/poseidon.rs
@@ -425,7 +425,7 @@ mod tests {
             PoseidonDomain(Fr::one().into_repr()),
         ];
 
-        let t = MerkleTree::<PoseidonHasher, typenum::U2>::new(values.iter().map(|x| *x)).unwrap();
+        let t = MerkleTree::<PoseidonHasher, typenum::U2>::new(values.iter().copied()).unwrap();
 
         let p = t.gen_proof(0).unwrap(); // create a proof for the first value =k Fr::one()
 
@@ -453,7 +453,7 @@ mod tests {
             PoseidonDomain(Fr::one().into_repr()),
         ];
 
-        let t = MerkleTree::<PoseidonHasher, typenum::U2>::new(leaves.iter().map(|x| *x)).unwrap();
+        let t = MerkleTree::<PoseidonHasher, typenum::U2>::new(leaves.iter().copied()).unwrap();
 
         assert_eq!(t.leafs(), 4);
 

--- a/storage-proofs/core/src/merkle/proof.rs
+++ b/storage-proofs/core/src/merkle/proof.rs
@@ -718,7 +718,6 @@ mod tests {
     use super::super::*;
 
     use generic_array::typenum;
-    use rand;
 
     use crate::hasher::{Blake2sHasher, Domain, PedersenHasher, PoseidonHasher, Sha256Hasher};
     use crate::merkle::{generate_tree, MerkleProofTrait};

--- a/storage-proofs/core/src/util.rs
+++ b/storage-proofs/core/src/util.rs
@@ -258,7 +258,7 @@ mod tests {
             let val_vec = fr_into_bytes(&val_fr);
 
             let val_num =
-                num::AllocatedNum::alloc(cs.namespace(|| "val_num"), || Ok(val_fr.into())).unwrap();
+                num::AllocatedNum::alloc(cs.namespace(|| "val_num"), || Ok(val_fr)).unwrap();
             let val_num_bits = val_num.to_bits_le(cs.namespace(|| "val_bits")).unwrap();
 
             let bits =

--- a/storage-proofs/porep/benches/encode.rs
+++ b/storage-proofs/porep/benches/encode.rs
@@ -51,7 +51,6 @@ fn kdf_benchmark(c: &mut Criterion) {
         let (data, exp_data) = raw_data.split_at_mut(data.len());
 
         let graph = &graph;
-        let replica_id = replica_id.clone();
 
         b.iter(|| {
             black_box(create_label_exp(
@@ -69,7 +68,6 @@ fn kdf_benchmark(c: &mut Criterion) {
     group.bench_function("non-exp", |b| {
         let mut data = data.clone();
         let graph = &graph;
-        let replica_id = replica_id.clone();
 
         b.iter(|| black_box(create_label(graph, None, &replica_id, &mut data, 1, 2)))
     });

--- a/storage-proofs/porep/benches/parents.rs
+++ b/storage-proofs/porep/benches/parents.rs
@@ -37,7 +37,6 @@ fn stop_profile() {
 fn stop_profile() {}
 
 fn pregenerate_graph<H: Hasher>(size: usize) -> StackedBucketGraph<H> {
-    let seed = [1u8; 28];
     StackedBucketGraph::<H>::new_stacked(size, BASE_DEGREE, EXP_DEGREE, [32; 32]).unwrap()
 }
 

--- a/storage-proofs/porep/benches/parents.rs
+++ b/storage-proofs/porep/benches/parents.rs
@@ -46,6 +46,7 @@ fn parents_loop<H: Hasher, G: Graph<H>>(graph: &G, parents: &mut [u32]) {
         .collect()
 }
 
+#[allow(clippy::unit_arg)]
 fn parents_loop_benchmark(cc: &mut Criterion) {
     let sizes = vec![10, 50, 1000];
 

--- a/storage-proofs/porep/src/drg/circuit.rs
+++ b/storage-proofs/porep/src/drg/circuit.rs
@@ -389,7 +389,7 @@ mod tests {
         let pub_inputs = drg::PublicInputs {
             replica_id: Some(replica_id.into()),
             challenges: vec![challenge],
-            tau: Some(tau.into()),
+            tau: Some(tau),
         };
 
         let priv_inputs = drg::PrivateInputs::<PedersenHasher> {

--- a/storage-proofs/porep/src/drg/circuit.rs
+++ b/storage-proofs/porep/src/drg/circuit.rs
@@ -382,7 +382,7 @@ mod tests {
             (mmapped_data.as_mut()).into(),
             None,
             config,
-            replica_path.clone(),
+            replica_path,
         )
         .expect("failed to replicate");
 

--- a/storage-proofs/porep/src/drg/compound.rs
+++ b/storage-proofs/porep/src/drg/compound.rs
@@ -369,7 +369,7 @@ mod tests {
             (mmapped_data.as_mut()).into(),
             data_tree,
             config,
-            replica_path.clone(),
+            replica_path,
         )
         .expect("failed to replicate");
 

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -666,7 +666,7 @@ mod tests {
             (mmapped_data.as_mut()).into(),
             None,
             config.clone(),
-            replica_path.clone(),
+            replica_path,
         )
         .expect("replication failed");
 
@@ -678,7 +678,7 @@ mod tests {
             &pp,
             &replica_id,
             mmapped_data.as_mut(),
-            Some(config.clone()),
+            Some(config),
         )
         .unwrap_or_else(|e| {
             panic!("Failed to extract data from `DrgPoRep`: {}", e);
@@ -745,7 +745,7 @@ mod tests {
             (mmapped_data.as_mut()).into(),
             None,
             config.clone(),
-            replica_path.clone(),
+            replica_path,
         )
         .expect("replication failed");
 
@@ -848,7 +848,7 @@ mod tests {
             let pub_inputs = PublicInputs::<<Tree::Hasher as Hasher>::Domain> {
                 replica_id: Some(replica_id),
                 challenges: vec![challenge, challenge],
-                tau: Some(tau.clone()),
+                tau: Some(tau),
             };
 
             let priv_inputs = PrivateInputs::<Tree::Hasher> {

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -621,7 +621,6 @@ mod tests {
         test_helper::setup_replica,
         util::{data_at_node, default_rows_to_discard},
     };
-    use tempfile;
 
     use crate::stacked::BINARY_ARITY;
 

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -848,7 +848,7 @@ mod tests {
             let pub_inputs = PublicInputs::<<Tree::Hasher as Hasher>::Domain> {
                 replica_id: Some(replica_id),
                 challenges: vec![challenge, challenge],
-                tau: Some(tau.clone().into()),
+                tau: Some(tau.clone()),
             };
 
             let priv_inputs = PrivateInputs::<Tree::Hasher> {
@@ -876,7 +876,7 @@ mod tests {
                 let proof = Proof::new(
                     real_proof.replica_nodes.clone(),
                     fake_parents,
-                    real_proof.nodes.clone().into(),
+                    real_proof.nodes.clone(),
                 );
 
                 let is_valid =
@@ -915,7 +915,7 @@ mod tests {
                 let proof2 = Proof::new(
                     real_proof.replica_nodes,
                     fake_proof_parents,
-                    real_proof.nodes.into(),
+                    real_proof.nodes,
                 );
 
                 assert!(
@@ -937,7 +937,7 @@ mod tests {
                     PublicInputs::<<Tree::Hasher as Hasher>::Domain> {
                         replica_id: Some(replica_id),
                         challenges: vec![if challenge == 1 { 2 } else { 1 }],
-                        tau: Some(tau.into()),
+                        tau: Some(tau),
                     };
                 let verified = DrgPoRep::<Tree::Hasher, _>::verify(
                     &pp,

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -926,7 +926,7 @@ mod tests {
                     "verified in error -- with wrong parent proofs"
                 );
 
-                return ();
+                return;
             }
 
             let proof = real_proof;

--- a/storage-proofs/porep/src/stacked/circuit/create_label.rs
+++ b/storage-proofs/porep/src/stacked/circuit/create_label.rs
@@ -157,7 +157,7 @@ mod tests {
         let out = create_label_circuit(
             cs.namespace(|| "create_label"),
             &id_bits,
-            parents_bits.clone(),
+            parents_bits,
             layer_alloc,
             node_alloc,
         )

--- a/storage-proofs/porep/src/stacked/circuit/hash.rs
+++ b/storage-proofs/porep/src/stacked/circuit/hash.rs
@@ -105,7 +105,7 @@ mod tests {
             assert!(cs.is_satisfied(), "constraints not satisfied");
             assert_eq!(cs.num_constraints(), 598);
 
-            let expected: Fr = vanilla_hash_single_column(&vals).into();
+            let expected: Fr = vanilla_hash_single_column(&vals);
 
             assert_eq!(
                 expected,

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -484,16 +484,10 @@ mod tests {
             // Verify that MetricCS returns the same metrics as TestConstraintSystem.
             let mut cs = MetricCS::<Bls12>::new();
 
-            StackedCompound::<Tree, Sha256Hasher>::circuit(
-                &pub_inputs,
-                <StackedCircuit<Tree, Sha256Hasher> as CircuitComponent>::ComponentPrivateInputs::default(),
-                &proofs[0],
-                &pp,
-                None,
-            )
-            .expect("circuit failed")
-            .synthesize(&mut cs.namespace(|| "stacked drgporep"))
-            .expect("failed to synthesize circuit");
+            StackedCompound::<Tree, Sha256Hasher>::circuit(&pub_inputs, (), &proofs[0], &pp, None)
+                .expect("circuit failed")
+                .synthesize(&mut cs.namespace(|| "stacked drgporep"))
+                .expect("failed to synthesize circuit");
 
             assert_eq!(cs.num_inputs(), expected_inputs, "wrong number of inputs");
             assert_eq!(
@@ -504,16 +498,10 @@ mod tests {
         }
         let mut cs = TestConstraintSystem::<Bls12>::new();
 
-        StackedCompound::<Tree, Sha256Hasher>::circuit(
-            &pub_inputs,
-            <StackedCircuit<Tree, Sha256Hasher> as CircuitComponent>::ComponentPrivateInputs::default(),
-            &proofs[0],
-            &pp,
-            None,
-        )
-        .expect("circuit failed")
-        .synthesize(&mut cs.namespace(|| "stacked drgporep"))
-        .expect("failed to synthesize circuit");
+        StackedCompound::<Tree, Sha256Hasher>::circuit(&pub_inputs, (), &proofs[0], &pp, None)
+            .expect("circuit failed")
+            .synthesize(&mut cs.namespace(|| "stacked drgporep"))
+            .expect("failed to synthesize circuit");
 
         assert!(cs.is_satisfied(), "constraints not satisfied");
         assert_eq!(cs.num_inputs(), expected_inputs, "wrong number of inputs");

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -449,7 +449,7 @@ mod tests {
             PublicInputs::<<Tree::Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Domain> {
                 replica_id: replica_id.into(),
                 seed,
-                tau: Some(tau.into()),
+                tau: Some(tau),
                 k: None,
             };
 
@@ -461,10 +461,7 @@ mod tests {
         let t_aux = TemporaryAuxCache::<Tree, Sha256Hasher>::new(&t_aux, replica_path.clone())
             .expect("failed to restore contents of t_aux");
 
-        let priv_inputs = PrivateInputs::<Tree, Sha256Hasher> {
-            p_aux: p_aux.into(),
-            t_aux: t_aux.into(),
-        };
+        let priv_inputs = PrivateInputs::<Tree, Sha256Hasher> { p_aux, t_aux };
 
         let proofs = StackedDrg::<Tree, Sha256Hasher>::prove_all_partitions(
             &pp,

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -426,7 +426,7 @@ mod tests {
             degree,
             expansion_degree,
             porep_id: arbitrary_porep_id,
-            layer_challenges: layer_challenges.clone(),
+            layer_challenges,
         };
 
         let pp = StackedDrg::<Tree, Sha256Hasher>::setup(&sp).expect("setup failed");
@@ -458,7 +458,7 @@ mod tests {
 
         // Convert TemporaryAux to TemporaryAuxCache, which instantiates all
         // elements based on the configs stored in TemporaryAux.
-        let t_aux = TemporaryAuxCache::<Tree, Sha256Hasher>::new(&t_aux, replica_path.clone())
+        let t_aux = TemporaryAuxCache::<Tree, Sha256Hasher>::new(&t_aux, replica_path)
             .expect("failed to restore contents of t_aux");
 
         let priv_inputs = PrivateInputs::<Tree, Sha256Hasher> { p_aux, t_aux };
@@ -594,7 +594,7 @@ mod tests {
                 degree,
                 expansion_degree,
                 porep_id: arbitrary_porep_id,
-                layer_challenges: layer_challenges.clone(),
+                layer_challenges,
             },
             partitions: Some(partition_count),
             priority: false,
@@ -642,7 +642,7 @@ mod tests {
 
         // Convert TemporaryAux to TemporaryAuxCache, which instantiates all
         // elements based on the configs stored in TemporaryAux.
-        let t_aux = TemporaryAuxCache::<Tree, _>::new(&t_aux, replica_path.clone())
+        let t_aux = TemporaryAuxCache::<Tree, _>::new(&t_aux, replica_path)
             .expect("failed to restore contents of t_aux");
 
         let private_inputs = PrivateInputs::<Tree, Sha256Hasher> { p_aux, t_aux };

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -1286,14 +1286,14 @@ mod tests {
         let replica_path = cache_dir.path().join("replica-path");
         let mut mmapped_data = setup_replica(&data, &replica_path);
 
-        let challenges = LayerChallenges::new(DEFAULT_STACKED_LAYERS, 5);
+        let layer_challenges = LayerChallenges::new(DEFAULT_STACKED_LAYERS, 5);
 
         let sp = SetupParams {
             nodes,
             degree: BASE_DEGREE,
             expansion_degree: EXP_DEGREE,
             porep_id: [32; 32],
-            layer_challenges: challenges.clone(),
+            layer_challenges,
         };
 
         let pp = StackedDrg::<Tree, Blake2sHasher>::setup(&sp).expect("setup failed");
@@ -1304,7 +1304,7 @@ mod tests {
             (mmapped_data.as_mut()).into(),
             None,
             config.clone(),
-            replica_path.clone(),
+            replica_path,
         )
         .expect("replication failed");
 
@@ -1316,7 +1316,7 @@ mod tests {
             &pp,
             &replica_id,
             mmapped_data.as_mut(),
-            Some(config.clone()),
+            Some(config),
         )
         .expect("failed to extract data");
 
@@ -1428,8 +1428,7 @@ mod tests {
             challenges.clone(),
         );
         test_prove_verify::<DiskTree<PoseidonHasher, typenum::U8, typenum::U8, typenum::U2>>(
-            n,
-            challenges.clone(),
+            n, challenges,
         );
     }
 
@@ -1471,7 +1470,7 @@ mod tests {
             degree,
             expansion_degree,
             porep_id: arbitrary_porep_id,
-            layer_challenges: challenges.clone(),
+            layer_challenges: challenges,
         };
 
         let pp = StackedDrg::<Tree, Blake2sHasher>::setup(&sp).expect("setup failed");
@@ -1550,7 +1549,7 @@ mod tests {
             degree,
             expansion_degree,
             porep_id: [32; 32],
-            layer_challenges: layer_challenges.clone(),
+            layer_challenges,
         };
 
         // When this fails, the call to setup should panic, but seems to actually hang (i.e. neither return nor panic) for some reason.

--- a/storage-proofs/post/src/election/circuit.rs
+++ b/storage-proofs/post/src/election/circuit.rs
@@ -297,7 +297,7 @@ mod tests {
             comm_r: Some(comm_r.into()),
             comm_c: Some(comm_c.into()),
             comm_r_last: Some(comm_r_last.into()),
-            partial_ticket: Some(candidate.partial_ticket.into()),
+            partial_ticket: Some(candidate.partial_ticket),
             randomness: Some(randomness.into()),
             prover_id: Some(prover_id.into()),
             sector_id: Some(candidate.sector_id.into()),


### PR DESCRIPTION
Fix all clippy warnings produced with the following invocation:
```
cargo clippy --all-targets --all-features -- -D warnings
```

None of the fixes are particularly noteworthy except for:

- Usage of combinators instead of array index, arguably makes the test code harder to read: https://github.com/filecoin-project/rust-fil-proofs/pull/1147/commits/3592d8c78f70040c765ddaeb923e811dbe2c24c8
- Add test to criterion_group (see discussion below): https://github.com/filecoin-project/rust-fil-proofs/pull/1147/commits/889f4ad72e9d69f313ccf04b8fb2635e85a05fcf
- Allow `unit_arg` lint for usage of `black_box`: https://github.com/filecoin-project/rust-fil-proofs/pull/1147/commits/5d67be339a34ae21eb9a4d4cc5b2d475762d8465


Closes: #1123 