### PR TITLE
fix: finish propagating porep_id.

### DIFF
--- a/storage-proofs/core/src/drgraph.rs
+++ b/storage-proofs/core/src/drgraph.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use anyhow::ensure;
 use generic_array::typenum;
-use rand::{rngs::OsRng, Rng, SeedableRng};
+use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use sha2::{Digest, Sha256};
 
@@ -228,10 +228,6 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
             _h: PhantomData,
         })
     }
-}
-
-pub fn new_seed() -> [u8; 28] {
-    OsRng.gen()
 }
 
 #[cfg(test)]

--- a/storage-proofs/porep/benches/encode.rs
+++ b/storage-proofs/porep/benches/encode.rs
@@ -2,7 +2,6 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughpu
 use ff::Field;
 use paired::bls12_381::Fr;
 use rand::thread_rng;
-use storage_proofs_core::drgraph::new_seed;
 use storage_proofs_core::fr32::fr_into_bytes;
 use storage_proofs_core::hasher::sha256::Sha256Hasher;
 use storage_proofs_core::hasher::{Domain, Hasher};

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -613,7 +613,7 @@ mod tests {
     use rand_xorshift::XorShiftRng;
     use storage_proofs_core::{
         cache_key::CacheKey,
-        drgraph::{new_seed, BucketGraph, BASE_DEGREE},
+        drgraph::{BucketGraph, BASE_DEGREE},
         fr32::fr_into_bytes,
         hasher::{Blake2sHasher, PedersenHasher, Sha256Hasher},
         merkle::{BinaryMerkleTree, MerkleTreeTrait},

--- a/storage-proofs/porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/graph.rs
@@ -28,7 +28,6 @@ use storage_proofs_core::{
 
 /// The expansion degree used for Stacked Graphs.
 pub const EXP_DEGREE: usize = 8;
-const FEISTEL_KEYS: [feistel::Index; 4] = [1, 2, 3, 4];
 
 const DEGREE: usize = BASE_DEGREE + EXP_DEGREE;
 
@@ -437,7 +436,7 @@ where
         let transformed = feistel::permute(
             self.size() as feistel::Index * self.expansion_degree as feistel::Index,
             a,
-            &FEISTEL_KEYS,
+            &self.feistel_keys,
             self.feistel_precomputed,
         );
         transformed as u32 / self.expansion_degree as u32


### PR DESCRIPTION
This PR is a follow-up to #1144. It removes the old `FEISTEL_KEYS` constant and instead uses the keys created from the `porep_id`.