### PR TITLE
fix: better paramcache UX

### DIFF
--- a/filecoin-proofs/src/bin/paramcache.rs
+++ b/filecoin-proofs/src/bin/paramcache.rs
@@ -245,7 +245,7 @@ pub fn main() {
             .collect::<Vec<_>>();
 
         let selected_sector_sizes = MultiSelect::with_theme(&ColorfulTheme::default())
-            .with_prompt("Select the sizes that should be generated if not already cached")
+            .with_prompt("Select the sizes that should be generated if not already cached [use space key to select]")
             .items(&sector_sizes[..])
             .interact()
             .unwrap();


### PR DESCRIPTION
Make clear that you should use the space key to select items.

I just started it myself and was confused that I got an error that no parameters were selected.