### PR TITLE
Audit: Update total challenge count and increase partitions.

### DIFF
--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -41,8 +41,8 @@ lazy_static! {
             (SECTOR_SIZE_16_MIB, 2),
             (SECTOR_SIZE_512_MIB, 2),
             (SECTOR_SIZE_1_GIB, 2),
-            (SECTOR_SIZE_32_GIB, 138),
-            (SECTOR_SIZE_64_GIB, 138),
+            (SECTOR_SIZE_32_GIB, 180),
+            (SECTOR_SIZE_64_GIB, 180),
         ]
         .iter()
         .copied()
@@ -58,8 +58,8 @@ lazy_static! {
             (SECTOR_SIZE_16_MIB, 1),
             (SECTOR_SIZE_512_MIB, 1),
             (SECTOR_SIZE_1_GIB, 1),
-            (SECTOR_SIZE_32_GIB, 8),
-            (SECTOR_SIZE_64_GIB, 8),
+            (SECTOR_SIZE_32_GIB, 10),
+            (SECTOR_SIZE_64_GIB, 10),
         ]
         .iter()
         .copied()


### PR DESCRIPTION
The internal audit found we should be using more total challenges. This PR raises the minimum challenges to 180 and the partitions to 10, for both 32GiB and 64GiB sectors. The partition count increases so circuit size will not.