### PR TITLE
feat: modularize window post bench

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -98,6 +98,57 @@ fn main() -> Result<()> {
     let window_post_cmd = SubCommand::with_name("window-post")
         .about("Benchmark Window PoST")
         .arg(
+            Arg::with_name("preserve-cache")
+                .long("preserve-cache")
+                .required(false)
+                .help("Preserve the directory where cached files are persisted")
+                .takes_value(false),
+        )
+        /*
+        .arg(
+            Arg::with_name("skip-precommit-phase1")
+                .long("skip-precommit-phase1")
+                .required(false)
+                .help("Skip precommit phase 1")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("skip-precommit-phase2")
+                .long("skip-precommit-phase2")
+                .required(false)
+                .help("Skip precommit phase 2")
+                .takes_value(false),
+        )*/
+        .arg(
+            Arg::with_name("skip-precommit")
+                .long("skip-precommit")
+                .required(false)
+                .help("Skip precommit phase 1 & 2")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("skip-commit-phase1")
+                .long("skip-commit-phase1")
+                .required(false)
+                .help("Skip commit phase 1")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("skip-commit-phase2")
+                .long("skip-commit-phase2")
+                .required(false)
+                .help("Skip commit phase 2")
+                .takes_value(false),
+        )
+        .arg(
+            Arg::with_name("cache")
+                .long("cache")
+                .required(false)
+                .help("The directory where cached files are persisted")
+                .default_value("")
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("size")
                 .long("size")
                 .required(true)
@@ -209,10 +260,25 @@ fn main() -> Result<()> {
             })?;
         }
         ("window-post", Some(m)) => {
+            let preserve_cache = m.is_present("preserve-cache");
+            // For now these options are combined.
+            let skip_precommit_phase1 = m.is_present("skip-precommit");
+            let skip_precommit_phase2 = m.is_present("skip-precommit");
+            let skip_commit_phase1 = m.is_present("skip-commit-phase1");
+            let skip_commit_phase2 = m.is_present("skip-commit-phase2");
+            let cache_dir = value_t!(m, "cache", String)?;
             let sector_size_kibs = value_t!(m, "size", usize)
                 .expect("could not convert `size` CLI argument to `usize`");
             let sector_size = sector_size_kibs * 1024;
-            window_post::run(sector_size)?;
+            window_post::run(
+                sector_size,
+                cache_dir,
+                preserve_cache,
+                skip_precommit_phase1,
+                skip_precommit_phase2,
+                skip_commit_phase1,
+                skip_commit_phase2,
+            )?;
         }
         ("winning-post", Some(m)) => {
             let sector_size_kibs = value_t!(m, "size", usize)

--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -1,13 +1,20 @@
 use std::collections::BTreeMap;
+use std::fs::{create_dir, read, read_to_string, remove_dir_all, File, OpenOptions};
 use std::io::{stdout, Seek, SeekFrom, Write};
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
 
+use anyhow::{ensure, Context};
+use bincode::{deserialize, serialize};
+use fil_proofs_tooling::measure::FuncMeasurement;
 use fil_proofs_tooling::shared::{PROVER_ID, RANDOMNESS, TICKET_BYTES};
 use fil_proofs_tooling::{measure, Metadata};
 use filecoin_proofs::constants::{
     POREP_PARTITIONS, WINDOW_POST_CHALLENGE_COUNT, WINDOW_POST_SECTOR_COUNT,
 };
 use filecoin_proofs::types::{
-    PaddedBytesAmount, PoRepConfig, PoRepProofPartitions, PoStConfig, SectorSize,
+    PaddedBytesAmount, PieceInfo, PoRepConfig, PoRepProofPartitions, PoStConfig,
+    SealCommitPhase1Output, SealPreCommitOutput, SealPreCommitPhase1Output, SectorSize,
     UnpaddedBytesAmount,
 };
 use filecoin_proofs::{
@@ -17,20 +24,27 @@ use filecoin_proofs::{
     PrivateReplicaInfo, PublicReplicaInfo,
 };
 use log::info;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use storage_proofs::merkle::MerkleTreeTrait;
 use storage_proofs::sector::SectorId;
-use tempfile::NamedTempFile;
 
 const SECTOR_ID: u64 = 0;
 
-#[derive(Serialize)]
+const PIECE_FILE: &str = "piece-file";
+const PIECE_INFOS_FILE: &str = "piece-infos-file";
+const STAGED_FILE: &str = "staged-file";
+const SEALED_FILE: &str = "sealed-file";
+const PRECOMMIT_PHASE1_OUTPUT_FILE: &str = "precommit-phase1-output";
+const PRECOMMIT_PHASE2_OUTPUT_FILE: &str = "precommit-phase2-output";
+const COMMIT_PHASE1_OUTPUT_FILE: &str = "commit-phase1-output";
+
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct Inputs {
     sector_size: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct Outputs {
     seal_pre_commit_phase1_cpu_time_ms: u64,
@@ -51,7 +65,7 @@ struct Outputs {
     verify_window_post_wall_time_ms: u64,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 struct Report {
     inputs: Inputs,
@@ -66,46 +80,11 @@ impl Report {
     }
 }
 
-pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
-    sector_size: u64,
-) -> anyhow::Result<()> {
-    let sector_size_unpadded_bytes_ammount =
-        UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size));
-
-    // Create files for the staged and sealed sectors.
-    let mut staged_file =
-        NamedTempFile::new().expect("could not create temp file for staged sector");
-
-    let sealed_file = NamedTempFile::new().expect("could not create temp file for sealed sector");
-
-    // Generate the data from which we will create a replica, we will then prove the continued
-    // storage of that replica using the PoSt.
-    let piece_bytes: Vec<u8> = (0..usize::from(sector_size_unpadded_bytes_ammount))
-        .map(|_| rand::random::<u8>())
-        .collect();
-
-    let mut piece_file = NamedTempFile::new()?;
-    piece_file.write_all(&piece_bytes)?;
-    piece_file.as_file_mut().sync_all()?;
-    piece_file.as_file_mut().seek(SeekFrom::Start(0))?;
-
-    let piece_info =
-        generate_piece_commitment(piece_file.as_file_mut(), sector_size_unpadded_bytes_ammount)?;
-    piece_file.as_file_mut().seek(SeekFrom::Start(0))?;
-
-    add_piece(
-        &mut piece_file,
-        &mut staged_file,
-        sector_size_unpadded_bytes_ammount,
-        &[],
-    )?;
-
-    let piece_infos = vec![piece_info];
-
+fn get_porep_config(sector_size: u64) -> PoRepConfig {
     let arbitrary_porep_id = [99; 32];
 
     // Replicate the staged sector, write the replica file to `sealed_path`.
-    let porep_config = PoRepConfig {
+    PoRepConfig {
         sector_size: SectorSize(sector_size),
         partitions: PoRepProofPartitions(
             *POREP_PARTITIONS
@@ -115,80 +94,360 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
                 .unwrap(),
         ),
         porep_id: arbitrary_porep_id,
+    }
+}
+
+fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
+    sector_size: u64,
+    cache_dir: PathBuf,
+    skip_precommit_phase1: bool,
+    skip_precommit_phase2: bool,
+) -> anyhow::Result<((u64, u64), (u64, u64), (u64, u64))> {
+    let (seal_pre_commit_phase1_measurement_cpu_time, seal_pre_commit_phase1_measurement_wall_time): (u64, u64) = if skip_precommit_phase1 {
+            // generate no-op measurements
+        (0, 0)
+    } else {
+        // Create files for the staged and sealed sectors.
+        let staged_file_path = cache_dir.join(STAGED_FILE);
+        let mut staged_file = OpenOptions::new().read(true).write(true).create(true).open(&staged_file_path)?;
+        info!("*** Created staged file");
+
+        let sealed_file_path = cache_dir.join(SEALED_FILE);
+        let _sealed_file = OpenOptions::new().read(true).write(true).create(true).open(&sealed_file_path)?;
+        info!("*** Created sealed file");
+
+        let sector_size_unpadded_bytes_amount =
+            UnpaddedBytesAmount::from(PaddedBytesAmount(sector_size));
+
+        // Generate the data from which we will create a replica, we will then prove the continued
+        // storage of that replica using the PoSt.
+        let piece_bytes: Vec<u8> = (0..usize::from(sector_size_unpadded_bytes_amount))
+            .map(|_| rand::random::<u8>())
+            .collect();
+
+        let piece_file_path = cache_dir.join(PIECE_FILE);
+        let mut piece_file = OpenOptions::new().read(true).write(true).create(true).open(&piece_file_path)?;
+        info!("*** Created piece file");
+        piece_file.write_all(&piece_bytes)?;
+        piece_file.sync_all()?;
+        piece_file.seek(SeekFrom::Start(0))?;
+
+        let piece_info =
+            generate_piece_commitment(&mut piece_file, sector_size_unpadded_bytes_amount)?;
+        piece_file.seek(SeekFrom::Start(0))?;
+
+        add_piece(
+            &mut piece_file,
+            &mut staged_file,
+            sector_size_unpadded_bytes_amount,
+            &[],
+        )?;
+
+        let piece_infos = vec![piece_info];
+        let sector_id = SectorId::from(SECTOR_ID);
+        let porep_config = get_porep_config(sector_size);
+
+        let seal_pre_commit_phase1_measurement: FuncMeasurement<SealPreCommitPhase1Output<Tree>> = measure(|| {
+            seal_pre_commit_phase1::<_, _, _, Tree>(
+                porep_config,
+                cache_dir.clone(),
+                staged_file_path.clone(),
+                sealed_file_path.clone(),
+                PROVER_ID,
+                sector_id,
+                TICKET_BYTES,
+                &piece_infos,
+            )
+        })
+            .expect("failed in seal_pre_commit_phase1");
+        let precommit_phase1_output = seal_pre_commit_phase1_measurement.return_value;
+
+        // Persist piece_infos here
+        let piece_infos_path = cache_dir.join(PIECE_INFOS_FILE);
+        let mut f = File::create(&piece_infos_path)
+            .with_context(|| format!("could not create file piece_infos_path={:?}", piece_infos_path))?;
+        info!("*** Created piece infos file");
+        let piece_infos_json = serde_json::to_string(&piece_infos.to_vec())?;
+        f.write_all(piece_infos_json.as_bytes())
+            .with_context(|| format!("could not write to file piece_infos_path={:?}", piece_infos_path))?;
+        info!("Persisted piece_infos to {:?} of size{}", piece_infos_path, f.metadata()?.len());
+
+        // Persist precommit phase1_output here
+        let precommit_phase1_output_path = cache_dir.join(PRECOMMIT_PHASE1_OUTPUT_FILE);
+        let mut f = File::create(&precommit_phase1_output_path)
+            .with_context(|| format!("could not create file precommit_phase1_output_path={:?}", precommit_phase1_output_path))?;
+        info!("*** Created precommit phase1 output file");
+        let precommit_phase1_output_bytes = serialize(&precommit_phase1_output)?;
+        f.write_all(&precommit_phase1_output_bytes)
+            .with_context(|| format!("could not write to file precommit_phase1_output_path={:?}", precommit_phase1_output_path))?;
+        info!("Persisted pre-commit phase1 output to {:?}", precommit_phase1_output_path);
+
+        (seal_pre_commit_phase1_measurement.cpu_time.as_millis() as u64, seal_pre_commit_phase1_measurement.wall_time.as_millis() as u64)
     };
-    let cache_dir = tempfile::tempdir().unwrap();
-    let sector_id = SectorId::from(SECTOR_ID);
 
-    let seal_pre_commit_phase1_measurement = measure(|| {
-        seal_pre_commit_phase1::<_, _, _, Tree>(
-            porep_config,
-            cache_dir.path(),
-            staged_file.path(),
-            sealed_file.path(),
-            PROVER_ID,
-            sector_id,
-            TICKET_BYTES,
-            &piece_infos,
-        )
-    })
-    .expect("failed in seal_pre_commit_phase1");
-    let phase1_output = seal_pre_commit_phase1_measurement.return_value;
+    let (
+        (
+            validate_cache_for_precommit_phase2_measurement_cpu_time,
+            validate_cache_for_precommit_phase2_measurement_wall_time,
+        ),
+        (seal_pre_commit_phase2_measurement_cpu_time, seal_pre_commit_phase2_measurement_wall_time),
+    ) = if skip_precommit_phase2 {
+        // generate no-op measurements
+        ((0, 0), (0, 0))
+    } else {
+        // Restore precommit phase1_output here
+        let precommit_phase1_output = {
+            let precommit_phase1_output_path = cache_dir.join(PRECOMMIT_PHASE1_OUTPUT_FILE);
+            info!("*** Restoring precommit phase1 output file");
+            let precommit_phase1_output_bytes =
+                read(&precommit_phase1_output_path).with_context(|| {
+                    format!(
+                        "could not read file precommit_phase1_output_path={:?}",
+                        precommit_phase1_output_path
+                    )
+                })?;
 
-    let validate_cache_for_precommit_phase2_measurement = measure(|| {
-        validate_cache_for_precommit_phase2::<_, _, Tree>(
-            cache_dir.path(),
-            sealed_file.path(),
-            &phase1_output,
-        )
-    })
-    .expect("failed to validate cache for precommit phase2");
+            let res: SealPreCommitPhase1Output<Tree> = deserialize(&precommit_phase1_output_bytes)?;
 
-    let seal_pre_commit_phase2_measurement = measure(|| {
-        seal_pre_commit_phase2::<_, _, Tree>(
-            porep_config,
-            phase1_output,
-            cache_dir.path(),
-            sealed_file.path(),
+            res
+        };
+
+        let porep_config = get_porep_config(sector_size);
+
+        let sealed_file_path = cache_dir.join(SEALED_FILE);
+
+        let validate_cache_for_precommit_phase2_measurement: FuncMeasurement<()> = measure(|| {
+            validate_cache_for_precommit_phase2::<_, _, Tree>(
+                cache_dir.clone(),
+                sealed_file_path.clone(),
+                &precommit_phase1_output,
+            )
+        })
+        .expect("failed to validate cache for precommit phase2");
+
+        let seal_pre_commit_phase2_measurement: FuncMeasurement<SealPreCommitOutput> =
+            measure(|| {
+                seal_pre_commit_phase2::<_, _, Tree>(
+                    porep_config,
+                    precommit_phase1_output,
+                    cache_dir.clone(),
+                    sealed_file_path.clone(),
+                )
+            })
+            .expect("failed in seal_pre_commit_phase2");
+        let precommit_phase2_output = seal_pre_commit_phase2_measurement.return_value;
+
+        // Persist precommit phase2_output here
+        let precommit_phase2_output_path = cache_dir.join(PRECOMMIT_PHASE2_OUTPUT_FILE);
+        let mut f = File::create(&precommit_phase2_output_path).with_context(|| {
+            format!(
+                "could not create file precommit_phase2_output_path={:?}",
+                precommit_phase2_output_path
+            )
+        })?;
+        info!("*** Created precommit phase2 output file");
+        let precommit_phase2_output_bytes = serialize(&precommit_phase2_output)?;
+        f.write_all(&precommit_phase2_output_bytes)
+            .with_context(|| {
+                format!(
+                    "could not write to file precommit_phase2_output_path={:?}",
+                    precommit_phase2_output_path
+                )
+            })?;
+        info!(
+            "Persisted pre-commit phase2 output to {:?}",
+            precommit_phase2_output_path
+        );
+
+        (
+            (
+                validate_cache_for_precommit_phase2_measurement
+                    .cpu_time
+                    .as_millis() as u64,
+                validate_cache_for_precommit_phase2_measurement
+                    .wall_time
+                    .as_millis() as u64,
+            ),
+            (
+                seal_pre_commit_phase2_measurement.cpu_time.as_millis() as u64,
+                seal_pre_commit_phase2_measurement.wall_time.as_millis() as u64,
+            ),
         )
-    })
-    .expect("failed in seal_pre_commit_phase2");
-    let seal_pre_commit_output = seal_pre_commit_phase2_measurement.return_value;
+    };
+
+    Ok((
+        (
+            seal_pre_commit_phase1_measurement_cpu_time,
+            seal_pre_commit_phase1_measurement_wall_time,
+        ),
+        (
+            validate_cache_for_precommit_phase2_measurement_cpu_time,
+            validate_cache_for_precommit_phase2_measurement_wall_time,
+        ),
+        (
+            seal_pre_commit_phase2_measurement_cpu_time,
+            seal_pre_commit_phase2_measurement_wall_time,
+        ),
+    ))
+}
+
+pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
+    sector_size: u64,
+    cache_dir: PathBuf,
+    preserve_cache: bool,
+    skip_precommit_phase1: bool,
+    skip_precommit_phase2: bool,
+    skip_commit_phase1: bool,
+    skip_commit_phase2: bool,
+) -> anyhow::Result<()> {
+    let (
+        (seal_pre_commit_phase1_cpu_time_ms, seal_pre_commit_phase1_wall_time_ms),
+        (
+            validate_cache_for_precommit_phase2_cpu_time_ms,
+            validate_cache_for_precommit_phase2_wall_time_ms,
+        ),
+        (seal_pre_commit_phase2_cpu_time_ms, seal_pre_commit_phase2_wall_time_ms),
+    ) = if skip_precommit_phase1 && skip_precommit_phase2 {
+        // generate no-op measurements
+        Ok(((0, 0), (0, 0), (0, 0)))
+    } else {
+        run_pre_commit_phases::<Tree>(
+            sector_size,
+            cache_dir.clone(),
+            skip_precommit_phase1,
+            skip_precommit_phase2,
+        )
+    }?;
+
+    let piece_infos = {
+        let piece_infos_path = cache_dir.join(PIECE_INFOS_FILE);
+        info!("*** Restoring piece infos file");
+        let piece_infos_json = read_to_string(&piece_infos_path).with_context(|| {
+            format!(
+                "could not read file piece_infos_path={:?}",
+                piece_infos_path
+            )
+        })?;
+
+        let res: Vec<PieceInfo> = serde_json::from_str(&piece_infos_json)?;
+
+        res
+    };
+
+    let seal_pre_commit_output = {
+        let phase2_output_path = cache_dir.join(PRECOMMIT_PHASE2_OUTPUT_FILE);
+        info!("*** Restoring precommit phase2 output file");
+        let phase2_output_bytes = read(&phase2_output_path).with_context(|| {
+            format!(
+                "could not read file phase2_output_path={:?}",
+                phase2_output_path
+            )
+        })?;
+
+        let res: SealPreCommitOutput = deserialize(&phase2_output_bytes)?;
+
+        res
+    };
 
     let seed = [0u8; 32];
     let comm_r = seal_pre_commit_output.comm_r;
 
-    let validate_cache_for_commit_measurement =
-        measure(|| validate_cache_for_commit::<_, _, Tree>(cache_dir.path(), sealed_file.path()))
-            .expect("failed to validate cache for commit");
+    let sector_id = SectorId::from(SECTOR_ID);
+    let porep_config = get_porep_config(sector_size);
 
-    let seal_commit_phase1_measurement = measure(|| {
-        seal_commit_phase1::<_, Tree>(
-            porep_config,
-            cache_dir.path(),
-            sealed_file.path(),
-            PROVER_ID,
-            sector_id,
-            TICKET_BYTES,
-            seed,
-            seal_pre_commit_output,
-            &piece_infos,
+    let sealed_file_path = cache_dir.join(SEALED_FILE);
+
+    let (
+        validate_cache_for_commit_cpu_time_ms,
+        validate_cache_for_commit_wall_time_ms,
+        seal_commit_phase1_cpu_time_ms,
+        seal_commit_phase1_wall_time_ms,
+    ) = if skip_commit_phase1 {
+        // generate no-op measurements
+        (0, 0, 0, 0)
+    } else {
+        let validate_cache_for_commit_measurement = measure(|| {
+            validate_cache_for_commit::<_, _, Tree>(cache_dir.clone(), sealed_file_path.clone())
+        })
+        .expect("failed to validate cache for commit");
+
+        let seal_commit_phase1_measurement = measure(|| {
+            seal_commit_phase1::<_, Tree>(
+                porep_config,
+                cache_dir.clone(),
+                sealed_file_path.clone(),
+                PROVER_ID,
+                sector_id,
+                TICKET_BYTES,
+                seed,
+                seal_pre_commit_output,
+                &piece_infos,
+            )
+        })
+        .expect("failed in seal_commit_phase1");
+        let phase1_output = seal_commit_phase1_measurement.return_value;
+
+        // Persist commit phase1_output here
+        let phase1_output_path = cache_dir.join(COMMIT_PHASE1_OUTPUT_FILE);
+        let mut f = File::create(&phase1_output_path).with_context(|| {
+            format!(
+                "could not create file phase1_output_path={:?}",
+                phase1_output_path
+            )
+        })?;
+        info!("*** Created commit phase1 output file");
+        let phase1_output_bytes = serialize(&phase1_output)?;
+        f.write_all(&phase1_output_bytes).with_context(|| {
+            format!(
+                "could not write to file phase1_output_path={:?}",
+                phase1_output_path
+            )
+        })?;
+        info!("Persisted commit phase1 output to {:?}", phase1_output_path);
+
+        (
+            validate_cache_for_commit_measurement.cpu_time.as_millis() as u64,
+            validate_cache_for_commit_measurement.wall_time.as_millis() as u64,
+            seal_commit_phase1_measurement.cpu_time.as_millis() as u64,
+            seal_commit_phase1_measurement.wall_time.as_millis() as u64,
         )
-    })
-    .expect("failed in seal_commit_phase1");
-    let phase1_output = seal_commit_phase1_measurement.return_value;
+    };
 
-    let seal_commit_phase2_measurement =
-        measure(|| seal_commit_phase2::<Tree>(porep_config, phase1_output, PROVER_ID, sector_id))
-            .expect("failed in seal_commit_phase2");
+    let (seal_commit_phase2_cpu_time_ms, seal_commit_phase2_wall_time_ms) = if skip_commit_phase2 {
+        // generate no-op measurements
+        (0, 0)
+    } else {
+        let commit_phase1_output = {
+            let commit_phase1_output_path = cache_dir.join(COMMIT_PHASE1_OUTPUT_FILE);
+            info!("*** Restoring commit phase1 output file");
+            let commit_phase1_output_bytes =
+                read(&commit_phase1_output_path).with_context(|| {
+                    format!(
+                        "could not read file commit_phase1_output_path={:?}",
+                        commit_phase1_output_path
+                    )
+                })?;
+
+            let res: SealCommitPhase1Output<Tree> = deserialize(&commit_phase1_output_bytes)?;
+
+            res
+        };
+
+        let seal_commit_phase2_measurement = measure(|| {
+            seal_commit_phase2::<Tree>(porep_config, commit_phase1_output, PROVER_ID, sector_id)
+        })
+        .expect("failed in seal_commit_phase2");
+
+        (
+            seal_commit_phase2_measurement.cpu_time.as_millis() as u64,
+            seal_commit_phase2_measurement.wall_time.as_millis() as u64,
+        )
+    };
 
     let pub_replica = PublicReplicaInfo::new(comm_r).expect("failed to create public replica info");
 
-    let priv_replica = PrivateReplicaInfo::<Tree>::new(
-        sealed_file.path().to_path_buf(),
-        comm_r,
-        cache_dir.into_path(),
-    )
-    .expect("failed to create private replica info");
+    let priv_replica = PrivateReplicaInfo::<Tree>::new(sealed_file_path, comm_r, cache_dir.clone())
+        .expect("failed to create private replica info");
 
     // Store the replica's private and publicly facing info for proving and verifying respectively.
     let mut pub_replica_info: BTreeMap<SectorId, PublicReplicaInfo> = BTreeMap::new();
@@ -228,43 +487,28 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
     })
     .expect("failed to verify window post proof");
 
+    if preserve_cache {
+        info!("Preserving cache directory {:?}", cache_dir);
+    } else {
+        info!("Removing cache directory {:?}", cache_dir);
+        remove_dir_all(cache_dir)?;
+    }
+
     let report = Report {
         inputs: Inputs { sector_size },
         outputs: Outputs {
-            seal_pre_commit_phase1_cpu_time_ms: seal_pre_commit_phase1_measurement
-                .cpu_time
-                .as_millis() as u64,
-            seal_pre_commit_phase1_wall_time_ms: seal_pre_commit_phase1_measurement
-                .wall_time
-                .as_millis() as u64,
-            validate_cache_for_precommit_phase2_cpu_time_ms:
-                validate_cache_for_precommit_phase2_measurement
-                    .cpu_time
-                    .as_millis() as u64,
-            validate_cache_for_precommit_phase2_wall_time_ms:
-                validate_cache_for_precommit_phase2_measurement
-                    .wall_time
-                    .as_millis() as u64,
-            seal_pre_commit_phase2_cpu_time_ms: seal_pre_commit_phase2_measurement
-                .cpu_time
-                .as_millis() as u64,
-            seal_pre_commit_phase2_wall_time_ms: seal_pre_commit_phase2_measurement
-                .wall_time
-                .as_millis() as u64,
-            validate_cache_for_commit_cpu_time_ms: validate_cache_for_commit_measurement
-                .cpu_time
-                .as_millis() as u64,
-            validate_cache_for_commit_wall_time_ms: validate_cache_for_commit_measurement
-                .wall_time
-                .as_millis() as u64,
-            seal_commit_phase1_cpu_time_ms: seal_commit_phase1_measurement.cpu_time.as_millis()
-                as u64,
-            seal_commit_phase1_wall_time_ms: seal_commit_phase1_measurement.wall_time.as_millis()
-                as u64,
-            seal_commit_phase2_cpu_time_ms: seal_commit_phase2_measurement.cpu_time.as_millis()
-                as u64,
-            seal_commit_phase2_wall_time_ms: seal_commit_phase2_measurement.wall_time.as_millis()
-                as u64,
+            seal_pre_commit_phase1_cpu_time_ms,
+            seal_pre_commit_phase1_wall_time_ms,
+            validate_cache_for_precommit_phase2_cpu_time_ms,
+            validate_cache_for_precommit_phase2_wall_time_ms,
+            seal_pre_commit_phase2_cpu_time_ms,
+            seal_pre_commit_phase2_wall_time_ms,
+            validate_cache_for_commit_cpu_time_ms,
+            validate_cache_for_commit_wall_time_ms,
+            seal_commit_phase1_cpu_time_ms,
+            seal_commit_phase1_wall_time_ms,
+            seal_commit_phase2_cpu_time_ms,
+            seal_commit_phase2_wall_time_ms,
             gen_window_post_cpu_time_ms: gen_window_post_measurement.cpu_time.as_millis() as u64,
             gen_window_post_wall_time_ms: gen_window_post_measurement.wall_time.as_millis() as u64,
             verify_window_post_cpu_time_ms: verify_window_post_measurement.cpu_time.as_millis()
@@ -280,12 +524,54 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
     Ok(())
 }
 
-pub fn run(sector_size: usize) -> anyhow::Result<()> {
-    info!("Benchy Window PoSt: sector-size={}", sector_size,);
+pub fn run(
+    sector_size: usize,
+    cache: String,
+    preserve_cache: bool,
+    skip_precommit_phase1: bool,
+    skip_precommit_phase2: bool,
+    skip_commit_phase1: bool,
+    skip_commit_phase2: bool,
+) -> anyhow::Result<()> {
+    info!("Benchy Window PoSt: sector-size={}, preserve_cache={}, skip_precommit_phase1={}, skip_precommit_phase2={}, skip_commit_phase1={}, skip_commit_phase2={}", sector_size, preserve_cache, skip_precommit_phase1, skip_precommit_phase2, skip_commit_phase1, skip_commit_phase2);
+
+    let cache_dir_specified = !cache.is_empty();
+    if skip_precommit_phase1 || skip_precommit_phase2 || skip_commit_phase1 || skip_commit_phase2 {
+        ensure!(
+            !preserve_cache,
+            "Preserve cache cannot be used if skipping any stages"
+        );
+        ensure!(
+            cache_dir_specified,
+            "Cache dir is required if skipping any stages"
+        );
+    }
+
+    let (cache_dir, preserve_cache) = if cache_dir_specified {
+        // If a cache dir was specified, automatically preserve it.
+        (PathBuf::from(cache), true)
+    } else {
+        let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
+        (
+            std::env::temp_dir().join(format!("window-post-bench-{}", timestamp)),
+            preserve_cache,
+        )
+    };
+
+    if !Path::new(&cache_dir).exists() {
+        create_dir(&cache_dir)?;
+    }
+    info!("Using cache directory {:?}", cache_dir);
 
     with_shape!(
         sector_size as u64,
         run_window_post_bench,
-        sector_size as u64
+        sector_size as u64,
+        cache_dir,
+        preserve_cache,
+        skip_precommit_phase1,
+        skip_precommit_phase2,
+        skip_commit_phase1,
+        skip_commit_phase2,
     )
 }

--- a/filecoin-proofs/src/types/mod.rs
+++ b/filecoin-proofs/src/types/mod.rs
@@ -35,6 +35,7 @@ pub type LCTree = storage_proofs::merkle::OctLCMerkleTree<DefaultTreeHasher>;
 pub use storage_proofs::porep::stacked::Labels;
 pub type DataTree = storage_proofs::merkle::BinaryMerkleTree<DefaultPieceHasher>;
 
+pub use storage_proofs::merkle::MerkleProof;
 pub use storage_proofs::merkle::MerkleTreeTrait;
 
 /// Arity for oct trees, used for comm_r_last.
@@ -43,7 +44,7 @@ pub const OCT_ARITY: usize = 8;
 /// Arity for binary trees, used for comm_d.
 pub const BINARY_ARITY: usize = 2;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SealPreCommitOutput {
     pub comm_r: Commitment,
     pub comm_d: Commitment,
@@ -53,6 +54,10 @@ pub type VanillaSealProof<Tree> = storage_proofs::porep::stacked::Proof<Tree, De
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SealCommitPhase1Output<Tree: MerkleTreeTrait> {
+    #[serde(bound(
+        serialize = "VanillaSealProof<Tree>: Serialize",
+        deserialize = "VanillaSealProof<Tree>: Deserialize<'de>"
+    ))]
     pub vanilla_proofs: Vec<Vec<VanillaSealProof<Tree>>>,
     pub comm_r: Commitment,
     pub comm_d: Commitment,
@@ -70,6 +75,10 @@ pub use merkletree::store::StoreConfig;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SealPreCommitPhase1Output<Tree: MerkleTreeTrait> {
+    #[serde(bound(
+        serialize = "Labels<Tree>: Serialize",
+        deserialize = "Labels<Tree>: Deserialize<'de>"
+    ))]
     pub labels: Labels<Tree>,
     pub config: StoreConfig,
     pub comm_d: Commitment,

--- a/filecoin-proofs/src/types/piece_info.rs
+++ b/filecoin-proofs/src/types/piece_info.rs
@@ -1,10 +1,11 @@
 use std::fmt;
 
 use anyhow::{ensure, Result};
+use serde::{Deserialize, Serialize};
 
 use crate::types::{Commitment, UnpaddedBytesAmount};
 
-#[derive(Clone, Default, PartialEq, Eq)]
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PieceInfo {
     pub commitment: Commitment,
     pub size: UnpaddedBytesAmount,


### PR DESCRIPTION
This work allows a cached directory to be preserved across runs so
that precommit_phase1, precommit_phase2, commit_phase1, and
commit_phase2 can be run in any combination for specific phase testing
(or isolating window post generation).  For now, precommit phase1/2
are controlled by a single option.