### PR TITLE
feat(storage-proofs): partial caching for SDR

### DIFF
--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -31,7 +31,7 @@ storage-proofs = { path = "../storage-proofs"}
 filecoin-proofs = { path = "../filecoin-proofs"}
 tempfile = "3.0.8"
 cpu-time = "1.0.0"
-git2 = "0.10.1"
+git2 = "0.13"
 heim = "0.0.9"
 futures-preview = "0.3.0-alpha.17"
 raw-cpuid = "7.0.3"

--- a/storage-proofs/core/src/parameter_cache.rs
+++ b/storage-proofs/core/src/parameter_cache.rs
@@ -134,7 +134,7 @@ fn ensure_ancestor_dirs_exist(cache_entry_path: PathBuf) -> Result<PathBuf> {
     Ok(cache_entry_path)
 }
 
-pub trait ParameterSetMetadata: Clone {
+pub trait ParameterSetMetadata {
     fn identifier(&self) -> String;
     fn sector_size(&self) -> u64;
 }

--- a/storage-proofs/core/src/settings.rs
+++ b/storage-proofs/core/src/settings.rs
@@ -22,6 +22,7 @@ pub struct Settings {
     pub use_gpu_tree_builder: bool,
     pub max_gpu_tree_batch_size: u32,
     pub rows_to_discard: u32,
+    pub sdr_parents_cache_size: u32,
 }
 
 impl Default for Settings {
@@ -35,6 +36,7 @@ impl Default for Settings {
             use_gpu_tree_builder: false,
             max_gpu_tree_batch_size: 700_000,
             rows_to_discard: 2,
+            sdr_parents_cache_size: 2048,
         }
     }
 }

--- a/storage-proofs/core/src/settings.rs
+++ b/storage-proofs/core/src/settings.rs
@@ -27,7 +27,7 @@ pub struct Settings {
 impl Default for Settings {
     fn default() -> Self {
         Settings {
-            maximize_caching: false,
+            maximize_caching: true,
             pedersen_hash_exp_window_size: 16,
             use_gpu_column_builder: false,
             max_gpu_column_batch_size: 400_000,

--- a/storage-proofs/porep/Cargo.toml
+++ b/storage-proofs/porep/Cargo.toml
@@ -27,7 +27,6 @@ log = "0.4.7"
 pretty_assertions = "0.6.1"
 generic-array = "0.13.2"
 anyhow = "1.0.23"
-once_cell = "1.3.1"
 neptune = { version = "1.0.1", features = ["gpu"] }
 num_cpus = "1.10.1"
 hex = "0.4.2"

--- a/storage-proofs/porep/Cargo.toml
+++ b/storage-proofs/porep/Cargo.toml
@@ -30,6 +30,8 @@ anyhow = "1.0.23"
 once_cell = "1.3.1"
 neptune = { version = "1.0.1", features = ["gpu"] }
 num_cpus = "1.10.1"
+hex = "0.4.2"
+byteorder = "1.3.4"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/storage-proofs/porep/benches/encode.rs
+++ b/storage-proofs/porep/benches/encode.rs
@@ -53,7 +53,17 @@ fn kdf_benchmark(c: &mut Criterion) {
         let graph = &graph;
         let replica_id = replica_id.clone();
 
-        b.iter(|| black_box(create_label_exp(graph, &replica_id, &*exp_data, data, 1, 2)))
+        b.iter(|| {
+            black_box(create_label_exp(
+                graph,
+                None,
+                &replica_id,
+                &*exp_data,
+                data,
+                1,
+                2,
+            ))
+        })
     });
 
     group.bench_function("non-exp", |b| {
@@ -61,7 +71,7 @@ fn kdf_benchmark(c: &mut Criterion) {
         let graph = &graph;
         let replica_id = replica_id.clone();
 
-        b.iter(|| black_box(create_label(graph, &replica_id, &mut data, 1, 2)))
+        b.iter(|| black_box(create_label(graph, None, &replica_id, &mut data, 1, 2)))
     });
 
     group.finish();

--- a/storage-proofs/porep/src/stacked/circuit/create_label.rs
+++ b/storage-proofs/porep/src/stacked/circuit/create_label.rs
@@ -167,7 +167,7 @@ mod tests {
         assert_eq!(cs.num_constraints(), 532_025);
 
         let (l1, l2) = data.split_at_mut(size * NODE_SIZE);
-        create_label_exp(&graph, &id_fr.into(), &*l2, l1, layer, node).unwrap();
+        create_label_exp(&graph, None, &id_fr.into(), &*l2, l1, layer, node).unwrap();
         let expected_raw = data_at_node(&l1, node).unwrap();
         let expected = bytes_into_fr(expected_raw).unwrap();
 

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -239,7 +239,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher>
 
             // exp parents
             let mut exp_parents = vec![0; graph.expansion_degree()];
-            graph.expanded_parents(challenge, &mut exp_parents);
+            graph.expanded_parents(challenge, &mut exp_parents)?;
 
             // Inclusion Proofs: expander parent node in comm_c
             for parent in exp_parents.into_iter() {

--- a/storage-proofs/porep/src/stacked/vanilla/cache.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/cache.rs
@@ -1,7 +1,8 @@
 use std::ops::Range;
 use std::path::PathBuf;
+use std::sync::RwLock;
 
-use anyhow::{bail, Context};
+use anyhow::{bail, ensure, Context};
 use byteorder::{BigEndian, ByteOrder};
 use log::info;
 use rayon::prelude::*;
@@ -24,70 +25,119 @@ const NODE_BYTES: usize = 4;
 // StackedGraph will hold two different (but related) `ParentCache`,
 #[derive(Debug)]
 pub struct ParentCache {
-    /// This is a large list of fixed (parent) sized arrays.
-    data: memmap::Mmap,
     /// Disk path for the cache.
     path: PathBuf,
+    /// The total number of cache entries.
+    num_cache_entries: u32,
+    cache: RwLock<CacheData>,
+}
+
+#[derive(Debug)]
+struct CacheData {
+    /// This is a large list of fixed (parent) sized arrays.
+    data: memmap::Mmap,
     /// The range of the stored data
     range: Range<u32>,
-    /// The total number of cache entries.
-    num_cache_entries: usize,
+    /// The underlyling file.
+    file: std::fs::File,
+}
+
+impl CacheData {
+    /// Change the cache to point to the newly passed in range.
+    fn shift(&mut self, new_range: Range<u32>) -> Result<()> {
+        if self.range == new_range {
+            return Ok(());
+        }
+
+        self.data = unsafe {
+            memmap::MmapOptions::new()
+                .offset(new_range.start as u64)
+                .len(new_range.end as usize - new_range.start as usize)
+                .map(&self.file)
+                .context("could not shift mmap}")?
+        };
+        self.range = new_range;
+
+        Ok(())
+    }
+
+    /// Read the parents for the given node from cache.
+    ///
+    /// Panics if node is not in the cache.
+    fn read(&self, node: u32) -> [u32; DEGREE] {
+        let start = node as usize * DEGREE;
+        let end = start + DEGREE;
+
+        let mut res = [0u32; DEGREE];
+        BigEndian::read_u32_into(&self.data[start..end], &mut res);
+        res
+    }
+
+    fn open(range: Range<u32>, path: &PathBuf) -> Result<Self> {
+        let min_cache_size = DEGREE * (range.end as usize - range.start as usize);
+
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .open(&path)
+            .with_context(|| format!("could not open path={}", path.display()))?;
+
+        let actual_len = file.metadata()?.len();
+        if actual_len < min_cache_size as u64 {
+            bail!(
+                "corrupted cache: {}, expected at least {}, got {} bytes",
+                path.display(),
+                min_cache_size,
+                actual_len
+            );
+        }
+
+        let data = unsafe {
+            memmap::MmapOptions::new()
+                .offset(range.start as u64)
+                .len(range.end as usize - range.start as usize)
+                .map(&file)
+                .with_context(|| format!("could not mmap path={}", path.display()))?
+        };
+
+        Ok(Self { data, file, range })
+    }
 }
 
 impl ParentCache {
-    pub fn new<H, G>(cache_entries: u32, graph: &StackedGraph<H, G>) -> Result<Self>
+    pub fn new<H, G>(
+        range: Range<u32>,
+        cache_entries: u32,
+        graph: &StackedGraph<H, G>,
+    ) -> Result<Self>
     where
         H: Hasher,
         G: Graph<H> + ParameterSetMetadata + Send + Sync,
     {
         let path = cache_path(cache_entries, graph);
         if path.exists() {
-            Self::open(cache_entries, path)
+            Self::open(range, cache_entries, path)
         } else {
-            Self::generate(cache_entries, graph, path)
+            Self::generate(range, cache_entries, graph, path)
         }
     }
 
     /// Opens an existing cache from disk.
-    pub fn open(cache_entries: u32, path: PathBuf) -> Result<Self> {
+    pub fn open(range: Range<u32>, cache_entries: u32, path: PathBuf) -> Result<Self> {
         info!("parent cache: opening {}", path.display());
-        let cache_size = DEGREE * cache_entries as usize;
 
-        let data = {
-            let file = std::fs::OpenOptions::new()
-                .read(true)
-                .open(&path)
-                .with_context(|| format!("could not open path={}", path.display()))?;
-
-            let actual_len = file.metadata()?.len();
-            if actual_len != cache_size as u64 {
-                bail!(
-                    "corrupted cache: {}, expected {}, got {} bytes",
-                    path.display(),
-                    cache_size,
-                    actual_len
-                );
-            }
-
-            unsafe {
-                memmap::MmapOptions::new()
-                    .map(&file)
-                    .with_context(|| format!("could not mmap path={}", path.display()))?
-            }
-        };
-
+        let cache = CacheData::open(range, &path)?;
         info!("parent cache: opened");
 
         Ok(ParentCache {
-            data,
+            cache: RwLock::new(cache),
             path,
-            range: 0..cache_entries, // TODO: partial cache
-            num_cache_entries: cache_entries as usize,
+            num_cache_entries: cache_entries,
         })
     }
 
     /// Generates a new cache and stores it on disk.
     pub fn generate<H, G>(
+        range: Range<u32>,
         cache_entries: u32,
         graph: &StackedGraph<H, G>,
         path: PathBuf,
@@ -100,21 +150,21 @@ impl ParentCache {
 
         let cache_size = DEGREE * cache_entries as usize;
 
-        let mut data = {
-            let file = std::fs::OpenOptions::new()
-                .read(true)
-                .write(true)
-                .create(true)
-                .open(&path)
-                .with_context(|| format!("could not open path={}", path.display()))?;
-            file.set_len((NODE_BYTES * cache_size) as u64)
-                .with_context(|| format!("failed to set length: {}", cache_size))?;
+        let file = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open(&path)
+            .with_context(|| format!("could not open path={}", path.display()))?;
+        file.set_len((NODE_BYTES * cache_size) as u64)
+            .with_context(|| format!("failed to set length: {}", cache_size))?;
 
-            unsafe {
-                memmap::MmapOptions::new()
-                    .map_mut(&file)
-                    .with_context(|| format!("could not mmap path={}", path.display()))?
-            }
+        let mut data = unsafe {
+            memmap::MmapOptions::new()
+                .offset(range.start as u64)
+                .len(range.end as usize - range.start as usize)
+                .map_mut(&file)
+                .with_context(|| format!("could not mmap path={}", path.display()))?
         };
 
         data.par_chunks_mut(DEGREE * NODE_BYTES)
@@ -137,27 +187,43 @@ impl ParentCache {
         info!("parent cache: written to disk");
 
         Ok(ParentCache {
-            data: data.make_read_only()?,
+            cache: RwLock::new(CacheData {
+                data: data.make_read_only()?,
+                range,
+                file,
+            }),
             path,
-            range: 0..cache_entries, // TODO: partial cache
-            num_cache_entries: cache_entries as usize,
+            num_cache_entries: cache_entries,
         })
     }
 
     /// Read a single cache element at position `node`.
     #[inline]
-    pub fn read(&self, node: u32) -> [u32; DEGREE] {
-        if self.range.contains(&node) {
-            // in memory cache
-            let start = node as usize * DEGREE;
-            let end = start + DEGREE;
-
-            let mut res = [0u32; DEGREE];
-            BigEndian::read_u32_into(&self.data[start..end], &mut res);
-            res
+    pub fn read(&self, node: u32) -> Result<[u32; DEGREE]> {
+        let cache = self.cache.read().unwrap();
+        if cache.range.contains(&node) {
+            Ok(cache.read(node))
         } else {
-            // not in memory, read from disk
-            todo!()
+            // not in memory, shift cache
+            drop(cache);
+            let cache = &mut *self.cache.write().unwrap();
+            ensure!(
+                node >= cache.range.end,
+                "cache must be read in ascending order"
+            );
+
+            // TODO: shift by more than 1 entry to reduce changing the mapping continously.
+            // Idea: move cache by the range size.
+            let end = node + 1;
+            let start = if end > self.num_cache_entries {
+                end - self.num_cache_entries as u32
+            } else {
+                0
+            };
+            let new_range = start..node + 1;
+            cache.shift(new_range)?;
+
+            Ok(cache.read(node))
         }
     }
 }

--- a/storage-proofs/porep/src/stacked/vanilla/cache.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/cache.rs
@@ -276,7 +276,7 @@ where
 mod tests {
     use super::*;
 
-    use crate::stacked::vanilla::graph::StackedBucketGraph;
+    use crate::stacked::vanilla::graph::{StackedBucketGraph, EXP_DEGREE};
     use storage_proofs_core::hasher::PoseidonHasher;
 
     #[test]

--- a/storage-proofs/porep/src/stacked/vanilla/cache.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/cache.rs
@@ -1,0 +1,177 @@
+use std::ops::Range;
+use std::path::PathBuf;
+
+use anyhow::{bail, Context};
+use byteorder::{BigEndian, ByteOrder};
+use log::info;
+use rayon::prelude::*;
+
+use storage_proofs_core::{
+    drgraph::Graph,
+    drgraph::BASE_DEGREE,
+    error::Result,
+    hasher::Hasher,
+    parameter_cache::{ParameterSetMetadata, VERSION},
+    settings,
+    util::NODE_SIZE,
+};
+
+use super::graph::{StackedGraph, DEGREE, EXP_DEGREE};
+
+/// u32 = 4 bytes
+const NODE_BYTES: usize = 4;
+
+// StackedGraph will hold two different (but related) `ParentCache`,
+#[derive(Debug)]
+pub struct ParentCache {
+    /// This is a large list of fixed (parent) sized arrays.
+    data: memmap::Mmap,
+    /// Disk path for the cache.
+    path: PathBuf,
+    /// The range of the stored data
+    range: Range<u32>,
+    /// The total number of cache entries.
+    num_cache_entries: usize,
+}
+
+impl ParentCache {
+    pub fn new<H, G>(cache_entries: u32, graph: &StackedGraph<H, G>) -> Result<Self>
+    where
+        H: Hasher,
+        G: Graph<H> + ParameterSetMetadata + Send + Sync,
+    {
+        let path = cache_path(cache_entries, graph);
+        if path.exists() {
+            Self::open(cache_entries, path)
+        } else {
+            Self::generate(cache_entries, graph, path)
+        }
+    }
+
+    /// Opens an existing cache from disk.
+    pub fn open(cache_entries: u32, path: PathBuf) -> Result<Self> {
+        info!("parent cache: opening {}", path.display());
+        let cache_size = DEGREE * cache_entries as usize;
+
+        let data = {
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .open(&path)
+                .with_context(|| format!("could not open path={}", path.display()))?;
+
+            let actual_len = file.metadata()?.len();
+            if actual_len != cache_size as u64 {
+                bail!(
+                    "corrupted cache: {}, expected {}, got {} bytes",
+                    path.display(),
+                    cache_size,
+                    actual_len
+                );
+            }
+
+            unsafe {
+                memmap::MmapOptions::new()
+                    .map(&file)
+                    .with_context(|| format!("could not mmap path={}", path.display()))?
+            }
+        };
+
+        info!("parent cache: opened");
+
+        Ok(ParentCache {
+            data,
+            path,
+            range: 0..cache_entries, // TODO: partial cache
+            num_cache_entries: cache_entries as usize,
+        })
+    }
+
+    /// Generates a new cache and stores it on disk.
+    pub fn generate<H, G>(
+        cache_entries: u32,
+        graph: &StackedGraph<H, G>,
+        path: PathBuf,
+    ) -> Result<Self>
+    where
+        H: Hasher,
+        G: Graph<H> + ParameterSetMetadata + Send + Sync,
+    {
+        info!("parent cache: generating {}", path.display());
+
+        let cache_size = DEGREE * cache_entries as usize;
+
+        let mut data = {
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open(&path)
+                .with_context(|| format!("could not open path={}", path.display()))?;
+            file.set_len((NODE_BYTES * cache_size) as u64)
+                .with_context(|| format!("failed to set length: {}", cache_size))?;
+
+            unsafe {
+                memmap::MmapOptions::new()
+                    .map_mut(&file)
+                    .with_context(|| format!("could not mmap path={}", path.display()))?
+            }
+        };
+
+        data.par_chunks_mut(DEGREE * NODE_BYTES)
+            .enumerate()
+            .try_for_each(|(node, entry)| -> Result<()> {
+                let mut parents = [0u32; BASE_DEGREE + EXP_DEGREE];
+                graph
+                    .base_graph()
+                    .parents(node, &mut parents[..BASE_DEGREE])?;
+                graph.generate_expanded_parents(node, &mut parents[BASE_DEGREE..]);
+
+                BigEndian::write_u32_into(&parents, entry);
+
+                Ok(())
+            })?;
+
+        info!("parent cache: generated");
+        data.flush().context("failed to flush parent cache")?;
+
+        info!("parent cache: written to disk");
+
+        Ok(ParentCache {
+            data: data.make_read_only()?,
+            path,
+            range: 0..cache_entries, // TODO: partial cache
+            num_cache_entries: cache_entries as usize,
+        })
+    }
+
+    /// Read a single cache element at position `node`.
+    #[inline]
+    pub fn read(&self, node: u32) -> [u32; DEGREE] {
+        if self.range.contains(&node) {
+            // in memory cache
+            let start = node as usize * DEGREE;
+            let end = start + DEGREE;
+
+            let mut res = [0u32; DEGREE];
+            BigEndian::read_u32_into(&self.data[start..end], &mut res);
+            res
+        } else {
+            // not in memory, read from disk
+            todo!()
+        }
+    }
+}
+
+fn cache_path<H, G>(cache_entries: u32, graph: &StackedGraph<H, G>) -> PathBuf
+where
+    H: Hasher,
+    G: Graph<H> + ParameterSetMetadata + Send + Sync,
+{
+    PathBuf::from(format!(
+        "v{}-sdr-parent-h{}-{}-e{}.cache",
+        VERSION,
+        H::name(),
+        hex::encode(graph.identifier()),
+        cache_entries,
+    ))
+}

--- a/storage-proofs/porep/src/stacked/vanilla/create_label.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/create_label.rs
@@ -34,7 +34,7 @@ pub fn create_label<H: Hasher>(
             _mm_prefetch(prev.as_ptr() as *const i8, _MM_HINT_T0);
         }
 
-        graph.copy_parents_data(node as u32, &*layer_labels, hasher)
+        graph.copy_parents_data(node as u32, &*layer_labels, hasher)?
     } else {
         hasher.finish()
     };
@@ -73,7 +73,7 @@ pub fn create_label_exp<H: Hasher>(
             _mm_prefetch(prev.as_ptr() as *const i8, _MM_HINT_T0);
         }
 
-        graph.copy_parents_data_exp(node as u32, &*layer_labels, exp_parents_data, hasher)
+        graph.copy_parents_data_exp(node as u32, &*layer_labels, exp_parents_data, hasher)?
     } else {
         hasher.finish()
     };

--- a/storage-proofs/porep/src/stacked/vanilla/create_label.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/create_label.rs
@@ -10,10 +10,11 @@ use storage_proofs_core::{
     util::{data_at_node_offset, NODE_SIZE},
 };
 
-use super::graph::StackedBucketGraph;
+use super::{cache::ParentCache, graph::StackedBucketGraph};
 
 pub fn create_label<H: Hasher>(
     graph: &StackedBucketGraph<H>,
+    cache: Option<&mut ParentCache>,
     replica_id: &H::Domain,
     layer_labels: &mut [u8],
     layer_index: usize,
@@ -34,7 +35,7 @@ pub fn create_label<H: Hasher>(
             _mm_prefetch(prev.as_ptr() as *const i8, _MM_HINT_T0);
         }
 
-        graph.copy_parents_data(node as u32, &*layer_labels, hasher)?
+        graph.copy_parents_data(node as u32, &*layer_labels, hasher, cache)?
     } else {
         hasher.finish()
     };
@@ -52,6 +53,7 @@ pub fn create_label<H: Hasher>(
 
 pub fn create_label_exp<H: Hasher>(
     graph: &StackedBucketGraph<H>,
+    cache: Option<&mut ParentCache>,
     replica_id: &H::Domain,
     exp_parents_data: &[u8],
     layer_labels: &mut [u8],
@@ -73,7 +75,7 @@ pub fn create_label_exp<H: Hasher>(
             _mm_prefetch(prev.as_ptr() as *const i8, _MM_HINT_T0);
         }
 
-        graph.copy_parents_data_exp(node as u32, &*layer_labels, exp_parents_data, hasher)?
+        graph.copy_parents_data_exp(node as u32, &*layer_labels, exp_parents_data, hasher, cache)?
     } else {
         hasher.finish()
     };

--- a/storage-proofs/porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/graph.rs
@@ -142,11 +142,15 @@ where
     }
 
     /// Returns a reference to the parent cache, initializing it lazily the first time this is called.
-    pub fn parent_cache(&mut self, cache_entries: u32) -> Result<()> {
+    fn parent_cache(&mut self, cache_entries: u32) -> Result<()> {
+        const NODE_GIB: u32 = (1024 * 1024 * 1024) / NODE_SIZE as u32;
+
+        // Number of nodes to be cached in memory
+        const DEFAULT_CACHE_SIZE: u32 = 2048;
+
         static INSTANCE_32_GIB: OnceCell<ParentCache> = OnceCell::new();
         static INSTANCE_64_GIB: OnceCell<ParentCache> = OnceCell::new();
 
-        const NODE_GIB: u32 = (1024 * 1024 * 1024) / NODE_SIZE as u32;
         ensure!(
             ((cache_entries == 32 * NODE_GIB) || (cache_entries == 64 * NODE_GIB)),
             "Cache is only available for 32GiB and 64GiB sectors"
@@ -155,12 +159,12 @@ where
 
         if cache_entries == 32 * NODE_GIB {
             self.cache = Some(INSTANCE_32_GIB.get_or_init(|| {
-                ParentCache::new(0..cache_entries, cache_entries, self)
+                ParentCache::new(DEFAULT_CACHE_SIZE, cache_entries, self)
                     .expect("failed to fill 32GiB cache")
             }));
         } else {
             self.cache = Some(INSTANCE_64_GIB.get_or_init(|| {
-                ParentCache::new(0..cache_entries, cache_entries, self)
+                ParentCache::new(DEFAULT_CACHE_SIZE, cache_entries, self)
                     .expect("failed to fill 64GiB cache")
             }));
         }

--- a/storage-proofs/porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/graph.rs
@@ -20,6 +20,7 @@ use storage_proofs_core::{
     error::Result,
     hasher::Hasher,
     parameter_cache::ParameterSetMetadata,
+    settings,
     util::NODE_SIZE,
 };
 
@@ -132,9 +133,9 @@ where
     /// Returns a reference to the parent cache.
     pub fn parent_cache(&self) -> Result<ParentCache> {
         // Number of nodes to be cached in memory
-        const DEFAULT_CACHE_SIZE: u32 = 2048;
+        let default_cache_size = settings::SETTINGS.lock().unwrap().sdr_parents_cache_size;
         let cache_entries = self.size() as u32;
-        let cache_size = cache_entries.min(DEFAULT_CACHE_SIZE);
+        let cache_size = cache_entries.min(default_cache_size);
 
         info!("using parent_cache[{} / {}]", cache_size, cache_entries);
 

--- a/storage-proofs/porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/graph.rs
@@ -134,10 +134,11 @@ where
         // Number of nodes to be cached in memory
         const DEFAULT_CACHE_SIZE: u32 = 2048;
         let cache_entries = self.size() as u32;
+        let cache_size = cache_entries.min(DEFAULT_CACHE_SIZE);
 
-        info!("using parent_cache[{}]", cache_entries);
+        info!("using parent_cache[{} / {}]", cache_size, cache_entries);
 
-        ParentCache::new(DEFAULT_CACHE_SIZE, cache_entries, self)
+        ParentCache::new(cache_size, cache_entries, self)
     }
 
     pub fn copy_parents_data_exp(

--- a/storage-proofs/porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/mod.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 mod macros;
 
+mod cache;
 mod challenges;
 mod column;
 mod column_proof;

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -301,19 +301,36 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         // NOTE: this means we currently keep 2x sector size around, to improve speed.
         let mut labels_buffer = vec![0u8; 2 * layer_size];
 
+        let use_cache = settings::SETTINGS.lock().unwrap().maximize_caching;
+        let mut cache = if use_cache {
+            Some(graph.parent_cache()?)
+        } else {
+            None
+        };
+
         for layer in 1..=layers {
             info!("generating layer: {}", layer);
-            graph.reset_parent_cache()?;
+            if let Some(ref mut cache) = cache {
+                cache.reset()?;
+            }
 
             if layer == 1 {
                 let layer_labels = &mut labels_buffer[..layer_size];
                 for node in 0..graph.size() {
-                    create_label(graph, replica_id, layer_labels, layer, node)?;
+                    create_label(graph, cache.as_mut(), replica_id, layer_labels, layer, node)?;
                 }
             } else {
                 let (layer_labels, exp_labels) = labels_buffer.split_at_mut(layer_size);
                 for node in 0..graph.size() {
-                    create_label_exp(graph, replica_id, exp_labels, layer_labels, layer, node)?;
+                    create_label_exp(
+                        graph,
+                        cache.as_mut(),
+                        replica_id,
+                        exp_labels,
+                        layer_labels,
+                        layer,
+                        node,
+                    )?;
                 }
             }
 

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -303,6 +303,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
 
         for layer in 1..=layers {
             info!("generating layer: {}", layer);
+            graph.reset_parent_cache()?;
 
             if layer == 1 {
                 let layer_labels = &mut labels_buffer[..layer_size];

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -100,7 +100,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
 
         let get_exp_parents_columns = |x: usize| -> Result<Vec<Column<Tree::Hasher>>> {
             let mut parents = vec![0; graph.expansion_degree()];
-            graph.expanded_parents(x, &mut parents);
+            graph.expanded_parents(x, &mut parents)?;
 
             parents.iter().map(|parent| t_aux.column(*parent)).collect()
         };


### PR DESCRIPTION
- reduces memory usage during `precommit_phase1` by 56GiB for 3i2GB sectors, when using max caching
- generate and store parents cache on disk
- mmap cache to use it 
- only mmap part of it, to minimize memory usage 
- cache is local, not global anymore
- cache can be used by all sector sizes
- enables cache usage by default, given its small overhead (112 KiB at the current configuration)
- increases required fast disk space by 56GiB for 32GiB sectors, this file is stored in `/var/tmp/filecoin-parents` for now

Based on the ideas in #1135 