### PR TITLE
fix: verify consistent use of porep_id when sealing

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/stacked.rs
+++ b/fil-proofs-tooling/src/bin/benchy/stacked.rs
@@ -156,14 +156,11 @@ where
                         replica_path.clone(),
                     )?;
 
-                let arbitrary_porep_id = [88; 32];
-
                 let pb = stacked::PublicInputs::<H::Domain, <Sha256Hasher as Hasher>::Domain> {
                     replica_id,
                     seed,
                     tau: Some(tau),
                     k: Some(0),
-                    porep_id: arbitrary_porep_id,
                 };
 
                 // Convert TemporaryAux to TemporaryAuxCache, which instantiates all

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -377,7 +377,6 @@ pub fn seal_commit_phase1<T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
 
     let public_inputs = stacked::PublicInputs {
         replica_id,
-        porep_id: porep_config.porep_id,
         tau: Some(stacked::Tau {
             comm_d: comm_d_safe,
             comm_r: comm_r_safe,
@@ -458,7 +457,6 @@ pub fn seal_commit_phase2<Tree: 'static + MerkleTreeTrait>(
 
     let public_inputs = stacked::PublicInputs {
         replica_id,
-        porep_id: porep_config.porep_id,
         tau: Some(stacked::Tau {
             comm_d: comm_d_safe,
             comm_r: comm_r_safe,
@@ -592,7 +590,6 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
     let public_inputs =
         stacked::PublicInputs::<<Tree::Hasher as Hasher>::Domain, DefaultPieceDomain> {
             replica_id,
-            porep_id: porep_config.porep_id,
             tau: Some(Tau { comm_r, comm_d }),
             seed,
             k: None,
@@ -715,7 +712,6 @@ pub fn verify_batch_seal<Tree: 'static + MerkleTreeTrait>(
             DefaultPieceDomain,
         > {
             replica_id,
-            porep_id: porep_config.porep_id,
             tau: Some(Tau { comm_r, comm_d }),
             seed: seeds[i],
             k: None,

--- a/storage-proofs/core/src/drgraph.rs
+++ b/storage-proofs/core/src/drgraph.rs
@@ -217,9 +217,7 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
             "The number of metagraph nodes must be precisely castable to `f64`"
         );
 
-        let mut drg_seed = [0; 28];
-        let raw_seed = derive_porep_domain_seed(DRSAMPLE_DST, porep_id);
-        drg_seed.copy_from_slice(&raw_seed[..28]);
+        let drg_seed = derive_drg_seed(porep_id);
 
         Ok(BucketGraph {
             nodes,
@@ -228,6 +226,13 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
             _h: PhantomData,
         })
     }
+}
+
+pub fn derive_drg_seed(porep_id: [u8; 32]) -> [u8; 28] {
+    let mut drg_seed = [0; 28];
+    let raw_seed = derive_porep_domain_seed(DRSAMPLE_DST, porep_id);
+    drg_seed.copy_from_slice(&raw_seed[..28]);
+    drg_seed
 }
 
 #[cfg(test)]

--- a/storage-proofs/core/src/proof.rs
+++ b/storage-proofs/core/src/proof.rs
@@ -34,6 +34,7 @@ pub trait ProofScheme<'a> {
     ) -> Result<Vec<Self::Proof>> {
         info!("groth_proof_count: {}", partition_count);
         info!("generating {} groth proofs.", partition_count);
+
         let start = Instant::now();
 
         let result = (0..partition_count)

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -420,11 +420,12 @@ mod tests {
         let replica_path = cache_dir.path().join("replica-path");
         let mut mmapped_data = setup_replica(&data, &replica_path);
 
+        let arbitrary_porep_id = [44; 32];
         let sp = SetupParams {
             nodes,
             degree,
             expansion_degree,
-            porep_id: [32; 32],
+            porep_id: arbitrary_porep_id,
             layer_challenges: layer_challenges.clone(),
         };
 
@@ -444,11 +445,9 @@ mod tests {
         assert_ne!(data, copied, "replication did not change data");
 
         let seed = rng.gen();
-        let arbitrary_porep_id = [44; 32];
         let pub_inputs =
             PublicInputs::<<Tree::Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Domain> {
                 replica_id: replica_id.into(),
-                porep_id: arbitrary_porep_id,
                 seed,
                 tau: Some(tau.into()),
                 k: None,
@@ -591,12 +590,13 @@ mod tests {
             .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
             .collect();
 
+        let arbitrary_porep_id = [55; 32];
         let setup_params = compound_proof::SetupParams {
             vanilla_params: SetupParams {
                 nodes,
                 degree,
                 expansion_degree,
-                porep_id: [32; 32],
+                porep_id: arbitrary_porep_id,
                 layer_challenges: layer_challenges.clone(),
             },
             partitions: Some(partition_count),
@@ -632,11 +632,9 @@ mod tests {
         assert_ne!(data, copied, "replication did not change data");
 
         let seed = rng.gen();
-        let arbitrary_porep_id = [55; 32];
         let public_inputs =
             PublicInputs::<<Tree::Hasher as Hasher>::Domain, <Sha256Hasher as Hasher>::Domain> {
                 replica_id: replica_id.into(),
-                porep_id: arbitrary_porep_id,
                 seed,
                 tau: Some(tau),
                 k: None,

--- a/storage-proofs/porep/src/stacked/vanilla/params.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/params.rs
@@ -108,7 +108,6 @@ where
 pub struct PublicInputs<T: Domain, S: Domain> {
     pub replica_id: T,
     pub seed: [u8; 32],
-    pub porep_id: [u8; 32],
     pub tau: Option<Tau<T, S>>,
     /// Partition index
     pub k: Option<usize>,

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -1447,11 +1447,12 @@ mod tests {
 
         let partitions = 2;
 
+        let arbitrary_porep_id = [92; 32];
         let sp = SetupParams {
             nodes,
             degree,
             expansion_degree,
-            porep_id: [32; 32],
+            porep_id: arbitrary_porep_id,
             layer_challenges: challenges.clone(),
         };
 
@@ -1471,11 +1472,9 @@ mod tests {
         assert_ne!(data, copied, "replication did not change data");
 
         let seed = rng.gen();
-        let arbitrary_porep_id = [92; 32];
         let pub_inputs =
             PublicInputs::<<Tree::Hasher as Hasher>::Domain, <Blake2sHasher as Hasher>::Domain> {
                 replica_id,
-                porep_id: arbitrary_porep_id,
                 seed,
                 tau: Some(tau),
                 k: None,

--- a/storage-proofs/porep/src/stacked/vanilla/proof_scheme.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof_scheme.rs
@@ -142,7 +142,6 @@ impl<'a, 'c, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> ProofScheme<'
         self::PublicInputs {
             replica_id: pub_in.replica_id,
             seed: pub_in.seed,
-            porep_id: pub_in.porep_id,
             tau: pub_in.tau,
             k,
         }


### PR DESCRIPTION
Use of `porep_id` in generating `replica_id`, when deriving drg seed, and when deriving feistel keys are independent. This PR adds a check to ensure they are consistent. Current `filecoin_proofs` API function will always pass the correct `porep_id` obtained from the `PoRepConfig` and therefore be 'consistent'. The checks inserted here ensure this is true.

**UPDATE**: In fact, `porep_id` still being a public input was a vestige of its evolution and no longer required. So consistency is produced even more simply by removing it altogether.
