### PR TITLE
feat: rebuild tree_r_last trees from a replica file

### DIFF
--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -48,6 +48,7 @@ bytefmt = "0.1.7"
 rayon = "1.3.0"
 flexi_logger = "0.14.7"
 typenum = "1.11.2"
+generic-array = "0.13.2"
 
 [features]
 default = ["gpu", "measurements"]

--- a/fil-proofs-tooling/src/bin/update_tree_r_cache/main.rs
+++ b/fil-proofs-tooling/src/bin/update_tree_r_cache/main.rs
@@ -1,0 +1,136 @@
+use std::fs::{create_dir_all, OpenOptions};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{value_t, App, Arg, SubCommand};
+use generic_array::typenum::{U0, U8};
+use memmap::MmapOptions;
+use merkletree::store::StoreConfig;
+
+use filecoin_proofs::constants::*;
+use filecoin_proofs::types::*;
+use storage_proofs::cache_key::CacheKey;
+use storage_proofs::merkle::LCTree;
+use storage_proofs::merkle::{get_base_tree_count, split_config_and_replica};
+use storage_proofs::util::{default_rows_to_discard, NODE_SIZE};
+
+fn run_update(sector_size: usize, cache: PathBuf, replica_path: PathBuf) -> Result<()> {
+    let tree_count = match sector_size as u64 {
+        SECTOR_SIZE_2_KIB => get_base_tree_count::<SectorShape2KiB>(),
+        SECTOR_SIZE_4_KIB => get_base_tree_count::<SectorShape4KiB>(),
+        SECTOR_SIZE_16_KIB => get_base_tree_count::<SectorShape16KiB>(),
+        SECTOR_SIZE_32_KIB => get_base_tree_count::<SectorShape32KiB>(),
+        SECTOR_SIZE_512_MIB => get_base_tree_count::<SectorShape512MiB>(),
+        SECTOR_SIZE_32_GIB => get_base_tree_count::<SectorShape32GiB>(),
+        SECTOR_SIZE_64_GIB => get_base_tree_count::<SectorShape64GiB>(),
+        _ => panic!("Unsupported sector size"),
+    };
+    // Number of nodes per base tree
+    let nodes_count = sector_size / NODE_SIZE / tree_count;
+
+    // If the cache dir doesn't exist, create it
+    if !Path::new(&cache).exists() {
+        create_dir_all(&cache)?;
+    }
+
+    // Create a StoreConfig from the provided cache path
+    let tree_r_last_config = StoreConfig::new(
+        &cache,
+        CacheKey::CommRLastTree.to_string(),
+        default_rows_to_discard(nodes_count, OCT_ARITY),
+    );
+    println!(
+        "Using nodes_count {}, rows_to_discard {}",
+        nodes_count,
+        default_rows_to_discard(nodes_count, OCT_ARITY)
+    );
+
+    // Split the config based on the number of nodes required
+    let (configs, replica_config) = split_config_and_replica(
+        tree_r_last_config,
+        replica_path.clone(),
+        nodes_count,
+        tree_count,
+    )?;
+
+    let f_data = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(&replica_path)
+        .with_context(|| format!("could not open replica_path={:?}", replica_path))?;
+    let input_mmap = unsafe {
+        MmapOptions::new()
+            .map(&f_data)
+            .with_context(|| format!("could not mmap replica_path={:?}", replica_path))?
+    };
+
+    for i in 0..tree_count {
+        let config = &configs[i];
+        let offset = replica_config.offsets[i];
+
+        let slice = &input_mmap[offset..(offset + (sector_size / tree_count))];
+        let store_path = StoreConfig::data_path(&config.path, &config.id);
+        println!(
+            "Building tree_r_last {}/{}, {} nodes at replica offset {}-{} and storing in {:?}",
+            i + 1,
+            tree_count,
+            nodes_count,
+            offset,
+            (offset + (sector_size / tree_count)),
+            &store_path
+        );
+        LCTree::<DefaultTreeHasher, U8, U0, U0>::from_byte_slice_with_config(
+            slice,
+            config.clone(),
+        )?;
+    }
+
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    fil_logger::init();
+
+    let rebuild_cmd = SubCommand::with_name("rebuild")
+        .about("Rebuild tree_r_last trees from replica")
+        .arg(
+            Arg::with_name("size")
+                .required(true)
+                .long("size")
+                .default_value("32")
+                .help("The data size in GiB")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("replica")
+                .long("replica")
+                .help("The replica file")
+                .required(true)
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("cache")
+                .long("cache")
+                .help("The cache directory for the output trees")
+                .required(true)
+                .takes_value(true),
+        );
+
+    let matches = App::new("update_tree_r_cache")
+        .version("0.1")
+        .subcommand(rebuild_cmd)
+        .get_matches();
+
+    match matches.subcommand() {
+        ("rebuild", Some(m)) => {
+            let cache = value_t!(m, "cache", PathBuf)?;
+            let replica = value_t!(m, "replica", PathBuf)?;
+            let size = value_t!(m, "size", usize)
+                .expect("could not convert `size` CLI argument to `usize`");
+            run_update(size, cache, replica)?;
+        }
+        _ => panic!("Unrecognized subcommand"),
+    }
+
+    Ok(())
+}

--- a/storage-proofs/core/src/merkle/tree.rs
+++ b/storage-proofs/core/src/merkle/tree.rs
@@ -184,6 +184,11 @@ impl<
         Ok(tree.into())
     }
 
+    pub fn from_byte_slice_with_config(data: &[u8], config: StoreConfig) -> Result<Self> {
+        let tree = merkle::MerkleTree::from_byte_slice_with_config(data, config)?;
+        Ok(tree.into())
+    }
+
     pub fn from_tree_slice(data: &[u8], leafs: usize) -> Result<Self> {
         let tree = merkle::MerkleTree::from_tree_slice(data, leafs)?;
         Ok(tree.into())


### PR DESCRIPTION
This PR adds a tool for rebuilding tree_r_last trees from a replica file.  The intended usage is for replacing existing trees with an updated `rows_to_discard` setting, as trees with different values for that setting are incompatible.

OPTIONAL (one time sanity check, but can be skipped entirely): To verify that the tool works as expected, let's use the 'old' default of rows_to_discard as 3 for 32GiB sectors and simply rebuild them to make sure the data produced exactly matches what's already present:

```
time RUST_LOG=trace RUSTFLAGS="-C target-cpu=native" FIL_PROOFS_ROWS_TO_DISCARD=3 cargo run --release --bin update_tree_r_cache rebuild --size 34359738368 --cache /some/new/output/dir --replica /path/to/existing/sealed-file
```

OPTIONAL (continued): After this completes, use md5sum to match the tree_r_last files produced in `/some/new/output/dir` against the ones already present in the path containing the existing tree_r_last files.  If these match exactly, the real conversion step is run as follows:

Example usage:

```
time RUST_LOG=trace RUSTFLAGS="-C target-cpu=native" FIL_PROOFS_ROWS_TO_DISCARD=2 cargo run --release --bin update_tree_r_cache rebuild --size 34359738368 --cache /some/new/output/dir --replica /path/to/existing/sealed-file
```

Note that in this case, `FIL_PROOFS_ROWS_TO_DISCARD` is changed from 3 to 2.  Alternatively, you could unset that env var, as 2 is the new default value.

The output trees produced in this step should be bigger, as less data is discarded.  While it's recommended that you preserve the old tree_r_last files (just until we're sure everything starts up properly with the new code), the newly produced files should be placed where the 'old' ones were present.