### PR TITLE
Safe write

### DIFF
--- a/filecoin-proofs/src/bin/fakeipfsadd.rs
+++ b/filecoin-proofs/src/bin/fakeipfsadd.rs
@@ -8,7 +8,7 @@ pub fn main() {
         .about(
             "
 This program is used to simulate the `ipfs add` command while testing. It
-accepts a path to a file and writes 32 characters of its hex-encoded BLAKE2b 
+accepts a path to a file and writes 32 characters of its hex-encoded BLAKE2b
 checksum to stdout. Note: The real `ipfs add` command computes and emits a CID.
 ",
         )

--- a/filecoin-proofs/src/bin/paramfetch.rs
+++ b/filecoin-proofs/src/bin/paramfetch.rs
@@ -1,6 +1,5 @@
 use std::collections::HashSet;
 use std::fs::{create_dir_all, rename, File};
-use std::io::copy;
 use std::io::prelude::*;
 use std::io::{BufReader, Stdout};
 use std::path::{Path, PathBuf};
@@ -342,10 +341,10 @@ fn download_file(url: Url, target: impl AsRef<Path>, is_verbose: bool) -> Result
             progress_bar: pb,
         };
 
-        let _ = copy(&mut source, &mut file)?;
+        let _ = std::io::copy(&mut source, &mut file)?;
     } else {
         let mut source = req.send()?;
-        let _ = copy(&mut source, &mut file)?;
+        let _ = std::io::copy(&mut source, &mut file)?;
     }
 
     Ok(())

--- a/filecoin-proofs/src/commitment_reader.rs
+++ b/filecoin-proofs/src/commitment_reader.rs
@@ -88,6 +88,7 @@ mod tests {
     use crate::types::*;
 
     use storage_proofs::pieces::generate_piece_commitment_bytes_from_source;
+    use storage_proofs::safe_write;
 
     #[test]
     fn test_commitment_reader() {
@@ -103,7 +104,7 @@ mod tests {
 
         let fr32_reader = crate::fr32_reader::Fr32Reader::new(io::Cursor::new(&source));
         let mut commitment_reader = CommitmentReader::new(fr32_reader);
-        io::copy(&mut commitment_reader, &mut io::sink()).unwrap();
+        safe_write::safe_copy(&mut commitment_reader, &mut io::sink()).unwrap();
 
         let commitment2 = commitment_reader.finish().unwrap();
 

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -65,7 +65,7 @@ fn empty_comm_d(sector_size: SectorSize) -> Commitment {
         let size: UnpaddedBytesAmount = sector_size.into();
         let fr32_reader = Fr32Reader::new(EmptySource::new(size.into()));
         let mut commitment_reader = CommitmentReader::new(fr32_reader);
-        io::copy(&mut commitment_reader, &mut io::sink()).unwrap();
+        std::io::copy(&mut commitment_reader, &mut io::sink()).unwrap();
 
         let mut comm = [0u8; 32];
         comm.copy_from_slice(

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -8,6 +8,7 @@ use paired::bls12_381::Fr;
 use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use storage_proofs::hasher::Hasher;
+use storage_proofs::safe_write::SafeFileExt;
 use storage_proofs::sector::*;
 use tempfile::NamedTempFile;
 
@@ -339,7 +340,7 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
         .collect();
 
     let mut piece_file = NamedTempFile::new()?;
-    piece_file.write_all(&piece_bytes)?;
+    piece_file.safe_write_all(&piece_bytes)?;
     piece_file.as_file_mut().sync_all()?;
     piece_file.as_file_mut().seek(SeekFrom::Start(0))?;
 

--- a/filecoin-proofs/tests/paramfetch/prompts_to_fetch.rs
+++ b/filecoin-proofs/tests/paramfetch/prompts_to_fetch.rs
@@ -10,6 +10,7 @@ use crate::support::tmp_manifest;
 use blake2b_simd::State as Blake2b;
 use filecoin_proofs::param::{ParameterData, ParameterMap};
 use rand::Rng;
+use storage_proofs::safe_write::{self, SafeFileExt};
 
 /// Produce a random sequence of bytes and first 32 characters of hex encoded
 /// BLAKE2b checksum. This helper function must be kept up-to-date with the
@@ -21,7 +22,7 @@ fn rand_bytes_with_blake2b() -> Result<(Vec<u8>, String), FailureError> {
 
     let mut as_slice = &bytes[..];
 
-    std::io::copy(&mut as_slice, &mut hasher)?;
+    safe_write::safe_copy(&mut as_slice, &mut hasher)?;
 
     Ok((
         bytes.iter().cloned().collect(),
@@ -172,7 +173,7 @@ fn invalid_json_produces_error() -> Result<(), FailureError> {
     let manifest_pbuf = tmp_manifest(None)?;
 
     let mut file = File::create(&manifest_pbuf)?;
-    file.write_all(b"invalid json")?;
+    file.safe_write_all(b"invalid json")?;
 
     let mut session = ParamFetchSessionBuilder::new(Some(manifest_pbuf))
         .with_session_timeout_ms(1000)

--- a/filecoin-proofs/tests/paramfetch/support/session.rs
+++ b/filecoin-proofs/tests/paramfetch/support/session.rs
@@ -9,6 +9,7 @@ use tempfile::TempDir;
 
 use crate::support::{cargo_bin, spawn_bash_with_retries};
 use storage_proofs::parameter_cache::PARAMETER_CACHE_ENV_VAR;
+use storage_proofs::safe_write;
 
 pub struct ParamFetchSessionBuilder {
     cache_dir: TempDir,
@@ -57,7 +58,7 @@ impl ParamFetchSessionBuilder {
 
         let mut file = File::create(&pbuf).expect("failed to create file in temp dir");
 
-        std::io::copy(r, &mut file).expect("failed to copy bytes to file");
+        safe_write::safe_copy(r, &mut file).expect("failed to copy bytes to file");
 
         self
     }

--- a/filecoin-proofs/tests/parampublish/support/session.rs
+++ b/filecoin-proofs/tests/parampublish/support/session.rs
@@ -9,6 +9,7 @@ use tempfile;
 use tempfile::TempDir;
 
 use storage_proofs::parameter_cache::{CacheEntryMetadata, PARAMETER_CACHE_ENV_VAR};
+use storage_proofs::safe_write;
 
 use crate::support::{cargo_bin, spawn_bash_with_retries, FakeIpfsBin};
 
@@ -80,7 +81,7 @@ impl ParamPublishSessionBuilder {
 
         let mut file = File::create(&pbuf).expect("failed to create file in temp dir");
 
-        std::io::copy(r, &mut file).expect("failed to copy bytes to file");
+        safe_write::safe_copy(r, &mut file).expect("failed to copy bytes to file");
 
         self.cached_file_pbufs.push(pbuf);
         self

--- a/storage-proofs/core/benches/misc.rs
+++ b/storage-proofs/core/benches/misc.rs
@@ -1,7 +1,8 @@
-use std::io::{Read, Seek, Write};
+use std::io::{Read, Seek};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use rand::{thread_rng, Rng};
+use storage_proofs::safe_write::SafeFileExt;
 use tempfile::tempfile;
 
 fn read_bytes_benchmark(c: &mut Criterion) {
@@ -16,7 +17,7 @@ fn read_bytes_benchmark(c: &mut Criterion) {
                 let data: Vec<u8> = (0..*bytes).map(|_| rng.gen()).collect();
 
                 let mut f = tempfile().unwrap();
-                f.write_all(&data).unwrap();
+                f.safe_write_all(&data).unwrap();
                 f.sync_all().unwrap();
 
                 b.iter(|| {

--- a/storage-proofs/core/src/lib.rs
+++ b/storage-proofs/core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod partitions;
 pub mod pieces;
 pub mod por;
 pub mod proof;
+pub mod safe_write;
 pub mod sector;
 pub mod settings;
 pub mod util;

--- a/storage-proofs/core/src/merkle/builders.rs
+++ b/storage-proofs/core/src/merkle/builders.rs
@@ -1,4 +1,3 @@
-use std::io::Write;
 use std::path::PathBuf;
 
 use anyhow::{ensure, Result};
@@ -13,6 +12,7 @@ use rayon::prelude::*;
 
 use crate::error::*;
 use crate::hasher::{Domain, Hasher, PoseidonArity};
+use crate::safe_write::SafeFileExt;
 use crate::util::{data_at_node, default_rows_to_discard, NODE_SIZE};
 
 use super::*;
@@ -418,7 +418,7 @@ where
 
         // Write out the replica data.
         let mut f = std::fs::File::create(&replica_path).unwrap();
-        f.write_all(&data).unwrap();
+        f.safe_write_all(&data).unwrap();
 
         {
             // Beware: evil dynamic downcasting RUST MAGIC down below.

--- a/storage-proofs/core/src/safe_write.rs
+++ b/storage-proofs/core/src/safe_write.rs
@@ -1,0 +1,45 @@
+//! Module provides safe write functionality by first checking if
+//! there is enough space on the file system before writing.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+
+pub trait SafeFileExt {
+    fn safe_write_all(&mut self, buf: &[u8]) -> io::Result<()>;
+    fn safe_set_len(&self, size: u64) -> io::Result<()>;
+}
+
+impl SafeFileExt for File {
+    fn safe_write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        let size = buf.len();
+        self.safe_set_len(size as u64)?;
+        self.write_all(buf)
+    }
+
+    fn safe_set_len(&self, size: u64) -> io::Result<()> {
+        let metadata = self.metadata()?;
+        let orig = metadata.len();
+
+        if self.set_len(size).is_err() {
+            if self.set_len(orig).is_err() {
+                panic!("truncating to original length failed");
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn safe_copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64> {
+    let from_path = from.as_ref();
+    let mut from_file = OpenOptions::new().read(true).open(from_path)?;
+    let metadata = from_file.metadata()?;
+    let size = metadata.len();
+
+    let to_path = to.as_ref();
+    let mut to_file = OpenOptions::new().read(true).open(to_path)?;
+
+    to_file.safe_set_len(size)?;
+
+    io::copy(&mut from_file, &mut to_file)
+}

--- a/storage-proofs/core/src/test_helper.rs
+++ b/storage-proofs/core/src/test_helper.rs
@@ -1,8 +1,9 @@
 use memmap::MmapMut;
 use memmap::MmapOptions;
 use std::fs::OpenOptions;
-use std::io::Write;
 use std::path::Path;
+
+use crate::safe_write::SafeFileExt;
 
 pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
     let mut f = OpenOptions::new()
@@ -11,7 +12,8 @@ pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
         .create(true)
         .open(replica_path)
         .expect("Failed to create replica");
-    f.write_all(data).expect("Failed to write data to replica");
+    f.safe_write_all(data)
+        .expect("Failed to write data to replica");
 
     unsafe {
         MmapOptions::new()

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -1,5 +1,4 @@
 use std::fs::OpenOptions;
-use std::io::Write;
 use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::sync::{mpsc, Arc, RwLock};
@@ -24,6 +23,7 @@ use storage_proofs_core::{
         Operation::{CommD, EncodeWindowTimeAll, GenerateTreeC, GenerateTreeRLast},
     },
     merkle::*,
+    safe_write::SafeFileExt,
     settings,
     util::{default_rows_to_discard, NODE_SIZE},
 };
@@ -845,7 +845,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                                 .write(true)
                                 .open(&tree_r_last_path)
                                 .expect("failed to open file for tree_r_last");
-                            f.write_all(&flat_tree_data)
+                            f.safe_write_all(&flat_tree_data)
                                 .expect("failed to wrote tree_r_last data");
 
                             // Move on to the next config.


### PR DESCRIPTION
Makes an effort at adding safe write functionality. Draft because currently this does not cover _all_ writes in the repo.

Adds a trait
```
pub trait SafeFileExt {
    fn safe_write_all(&mut self, buf: &[u8]) -> io::Result<()>;
    fn safe_set_len(&self, size: u64) -> io::Result<()>;
}
```
And also a `io::copy` wrapper
```
pub fn safe_copy<P: AsRef<Path>, Q: AsRef<Path>>(from: P, to: Q) -> io::Result<u64>
```

Done as part of resolving: https://github.com/filecoin-project/rust-fil-proofs/issues/943