### PR TITLE
fix: allow parameters map to be accessible externally

### DIFF
--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -28,9 +28,11 @@ pub const WINDOW_POST_CHALLENGE_COUNT: usize = 10;
 pub const DRG_DEGREE: usize = storage_proofs::drgraph::BASE_DEGREE;
 pub const EXP_DEGREE: usize = storage_proofs::porep::stacked::EXP_DEGREE;
 
+pub const PARAMETERS_DATA: &str = include_str!("../parameters.json");
+
 lazy_static! {
     pub static ref PARAMETERS: ParameterMap =
-        serde_json::from_str(include_str!("../parameters.json")).expect("Invalid parameters.json");
+        serde_json::from_str(PARAMETERS_DATA).expect("Invalid parameters.json");
     pub static ref POREP_MINIMUM_CHALLENGES: RwLock<HashMap<u64, u64>> = RwLock::new(
         [
             (SECTOR_SIZE_2_KIB, 2),
@@ -187,6 +189,19 @@ pub fn get_parameter_data(cache_id: &str) -> Option<&ParameterData> {
 fn parameter_id(cache_id: &str) -> String {
     format!(
         "v{}-{}.params",
+        storage_proofs::parameter_cache::VERSION,
+        cache_id
+    )
+}
+
+/// Get the correct verifying key data for a given cache id.
+pub fn get_verifying_key_data(cache_id: &str) -> Option<&ParameterData> {
+    PARAMETERS.get(&verifying_key_id(cache_id))
+}
+
+fn verifying_key_id(cache_id: &str) -> String {
+    format!(
+        "v{}-{}.vk",
         storage_proofs::parameter_cache::VERSION,
         cache_id
     )


### PR DESCRIPTION
The motivation for this is because of a broken test that attempts to use this from rust-filecoin-proofs-api, which always fails due to the parameter file not being available