### PR TITLE
Make pieces::Stack methods private.

### DIFF
--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -142,31 +142,31 @@ struct Stack(Vec<PieceInfo>);
 
 impl Stack {
     /// Creates a new stack.
-    pub fn new() -> Self {
+    fn new() -> Self {
         Stack(Vec::new())
     }
 
     /// Pushes a single element onto the stack.
-    pub fn shift(&mut self, el: PieceInfo) {
+    fn shift(&mut self, el: PieceInfo) {
         self.0.push(el)
     }
 
     /// Look at the last element of the stack.
-    pub fn peek(&self) -> &PieceInfo {
+    fn peek(&self) -> &PieceInfo {
         &self.0[self.0.len() - 1]
     }
 
     /// Look at the second to last element of the stack.
-    pub fn peek2(&self) -> &PieceInfo {
+    fn peek2(&self) -> &PieceInfo {
         &self.0[self.0.len() - 2]
     }
 
     /// Pop the last element of the stack.
-    pub fn pop(&mut self) -> Result<PieceInfo> {
+    fn pop(&mut self) -> Result<PieceInfo> {
         self.0.pop().context("empty stack popped")
     }
 
-    pub fn reduce1(&mut self) -> Result<bool> {
+    fn reduce1(&mut self) -> Result<bool> {
         if self.len() < 2 {
             return Ok(false);
         }
@@ -182,17 +182,17 @@ impl Stack {
         Ok(false)
     }
 
-    pub fn reduce(&mut self) -> Result<()> {
+    fn reduce(&mut self) -> Result<()> {
         while self.reduce1()? {}
         Ok(())
     }
 
-    pub fn shift_reduce(&mut self, piece: PieceInfo) -> Result<()> {
+    fn shift_reduce(&mut self, piece: PieceInfo) -> Result<()> {
         self.shift(piece);
         self.reduce()
     }
 
-    pub fn len(&self) -> usize {
+    fn len(&self) -> usize {
         self.0.len()
     }
 }


### PR DESCRIPTION
The `pieces::Stack` struct is only used in the implementation of `compute_comm_d`, and accurate usage of its helper methods is required for correctness. For example, `peek()` and `peek2` must not be called when the stack is not large enough. This correctness is guaranteed by usage of `Stack` as a helper data structure within `compute_comm_d` as written, but there is no reason to expose these methods to callers who *might* misuse them. Put differently, correctness of the `Stack` data structure depends on these methods being private. This allows a reader to determine — by only inspecting  the `pieces` module — that these methods are never called incorrectly.
