### PR TITLE
Fix CI metrics_capture

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "f8:db:3c:6d:f9:74:2c:9e:07:42:3f:3f:23:07:f7:6d"
+            - "96:12:32:00:d7:ef:4e:ff:ae:1e:04:e2:5f:ce:23:bd"
       - run:
           name: Add benchmark server's public key to known hosts
           command: |
@@ -159,6 +159,7 @@ jobs:
               echo "
             ${BENCHMARK_SERVER_RSA_FINGERPRINT}
               " >> ~/.ssh/known_hosts
+              ssh-keyscan -H 147.75.55.201 >> ~/.ssh/known_hosts
             fi
       - checkout
       - attach_workspace:

--- a/fil-proofs-tooling/scripts/aggregate-benchmarks.sh
+++ b/fil-proofs-tooling/scripts/aggregate-benchmarks.sh
@@ -5,13 +5,13 @@ set -e
 stacked_path=$1
 micro_path=$2
 hash_constraints_path=$3
-election_post_path=$4
+window_post_path=$4
 
 jq --sort-keys -s '{ benchmarks: { "stacked-benchmarks": { outputs: { "max-resident-set-size-kb": .[0] } } } } * .[1]' \
   <(jq '.["max-resident-set-size-kb"]' $stacked_path) \
-  <(jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "stacked-benchmarks": .[2], "micro-benchmarks": .[3], "election-post-benchmarks": .[4] } }' \
+  <(jq -s '.[0] * { benchmarks: { "hash-constraints": .[1], "stacked-benchmarks": .[2], "micro-benchmarks": .[3], "window-post-benchmarks": .[4] } }' \
     <(jq 'del (.benchmarks)' $micro_path) \
     <(jq '.benchmarks' $hash_constraints_path) \
     <(jq '.benchmarks' $stacked_path) \
     <(jq '.benchmarks' $micro_path) \
-    <(jq '.benchmarks' $election_post_path))
+    <(jq '.benchmarks' $window_post_path))

--- a/fil-proofs-tooling/scripts/run-remote.sh
+++ b/fil-proofs-tooling/scripts/run-remote.sh
@@ -17,15 +17,12 @@ find /tmp/metrics/ -maxdepth 1 -mindepth 1 -type d -printf "%f\n" \
     | xargs -I {} bash -c 'if (({} < \$(date +%s))) ; then rm -rf /tmp/metrics/{} ; fi' 2> /dev/null
 
 # Make sure rust is installed on the remote host.
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-source $HOME/.cargo/env
+curl https://sh.rustup.rs -sSf | sh -s -- -y > /dev/null 2>&1
+source $HOME/.cargo/env  /dev/null 2>&1
 
 git clone -b $1 --single-branch https://github.com/filecoin-project/rust-fil-proofs.git \$_metrics_dir || true
 
 cd \$_metrics_dir
-
-cargo update
-cargo fetch
 
 ./fil-proofs-tooling/scripts/retry.sh 42 10 60000 \
     ./fil-proofs-tooling/scripts/with-lock.sh 42 /tmp/metrics.lock \

--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -224,7 +224,7 @@ fn main() -> Result<()> {
             Arg::with_name("validate")
                 .long("validate")
                 .required(false)
-                .default_value("false")
+                .default_value("true")
                 .help("Validate proofs if specified")
                 .takes_value(false),
         );


### PR DESCRIPTION
feat: enable proof validate by default on merkleproof bench

While proofs_count is CLI configurable, if it's more than the number
of nodes in the tree, just sequentially challenge each node in the
tree instead of randomly selecting and over-proving.