### PR TITLE
Implement fauxrep2.

### DIFF
--- a/storage-proofs/porep/Cargo.toml
+++ b/storage-proofs/porep/Cargo.toml
@@ -31,6 +31,7 @@ once_cell = "1.3.1"
 neptune = { version = "1.0.1", features = ["gpu"] }
 num_cpus = "1.10.1"
 hex = "0.4.2"
+bincode = "1.1.2"
 byteorder = "1.3.4"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR implements `fauxrep2`, which takes the path to an existing `p_aux` file and a cache directory path. It creates and writes a new `p_aux` and returns the corresponding `comm_r`. No replica or tree files are written, so it is the caller's responsibility to provide them (and they must match the `comm_r_last` in the provided `p_aux`).

Caveat: totally untested. If @cryptonemo can plumb through the API, maybe @travisperson can test before we merge. I won't have time to look at this more for a little while, but this might be enough for us to gain confidence and push this through soon.
