### PR TITLE
Use (varied) constant-length vector to hash column roots.

### DIFF
--- a/storage-proofs/core/Cargo.toml
+++ b/storage-proofs/core/Cargo.toml
@@ -40,7 +40,7 @@ hex = "0.4.0"
 generic-array = "0.13.2"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
-neptune = { version = "1.0.1", features = ["gpu"] }
+neptune = { version = "2.0.0", features = ["gpu"] }
 cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"

--- a/storage-proofs/core/src/hasher/types.rs
+++ b/storage-proofs/core/src/hasher/types.rs
@@ -1,6 +1,6 @@
 use bellperson::gadgets::{boolean, num};
 use bellperson::{ConstraintSystem, SynthesisError};
-use generic_array::typenum::{U0, U11, U16, U2, U24, U36, U4, U8};
+use generic_array::typenum::{U0, U11, U15, U16, U2, U24, U36, U4, U8};
 use lazy_static::lazy_static;
 use merkletree::hash::{Algorithm as LightAlgorithm, Hashable as LightHashable};
 use merkletree::merkle::Element;
@@ -26,6 +26,8 @@ lazy_static! {
     pub static ref POSEIDON_CONSTANTS_2: PoseidonConstants::<Bls12, U2> = PoseidonConstants::new();
     pub static ref POSEIDON_CONSTANTS_4: PoseidonConstants::<Bls12, U4> = PoseidonConstants::new();
     pub static ref POSEIDON_CONSTANTS_8: PoseidonConstants::<Bls12, U8> = PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_15_BASE: PoseidonConstants::<Bls12, U15> =
+        PoseidonConstants::new_constant_length(15);
     pub static ref POSEIDON_CONSTANTS_16: PoseidonConstants::<Bls12, U16> =
         PoseidonConstants::new();
     pub static ref POSEIDON_CONSTANTS_24: PoseidonConstants::<Bls12, U24> =

--- a/storage-proofs/porep/Cargo.toml
+++ b/storage-proofs/porep/Cargo.toml
@@ -28,7 +28,7 @@ pretty_assertions = "0.6.1"
 generic-array = "0.13.2"
 anyhow = "1.0.23"
 once_cell = "1.3.1"
-neptune = { version = "1.0.1", features = ["gpu"] }
+neptune = { version = "2.0.0", features = ["gpu"] }
 num_cpus = "1.10.1"
 hex = "0.4.2"
 bincode = "1.1.2"

--- a/storage-proofs/post/Cargo.toml
+++ b/storage-proofs/post/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.7"
 hex = "0.4.0"
 generic-array = "0.13.2"
 anyhow = "1.0.23"
-neptune = { version = "1.0.1", features = ["gpu"] }
+neptune = { version = "2.0.0", features = ["gpu"] }
 num_cpus = "1.10.1"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR replaces a stopgap @dignifiedquire had implemented as a replacement for the previous unpadded MD construction. It depends on changes in neptune to add domain separation tags and support for a number of distinct hashing functions built over the Poseidon permutation: https://github.com/filecoin-project/neptune/pull/43

The new hash function allows for preimages which are shorter than the 'natural' size of the permutation — but whose actual size must be known such that the actual length is encoded in the domain tag.

We need (or would like to have) such a hash function so we can use fewer layers in test sectors/circuits but still use generic arrays with statically-typed sizes as required by the neptune API. This usage fits ideally with the new 'constant length' hash type.

To facilitate cheap creation of constants which vary only by their specified length, we use the `with_length` function provided for that purpose.

@dignifiedquire I think this is ready for review and will just need to update deps once the neptune PR works its way through.

cc: @DrPeterVanNostrand, since this change will need to land in the spec also.

cc: @nicola for interest re: domain separation tags.