### PR TITLE
fix: update tree usage when using the gpu builder

### DIFF
--- a/storage-proofs/core/src/settings.rs
+++ b/storage-proofs/core/src/settings.rs
@@ -28,7 +28,7 @@ pub struct Settings {
     pub window_post_synthesis_num_cpus: u32,
     pub parameter_cache: String,
     pub parent_cache: String,
-    pub use_gpu_nse: bool
+    pub use_gpu_nse: bool,
 }
 
 impl Default for Settings {

--- a/storage-proofs/porep/src/nse/vanilla/porep.rs
+++ b/storage-proofs/porep/src/nse/vanilla/porep.rs
@@ -116,6 +116,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> PoRep<'a, Tree::H
 
         let trees = labels::encode_with_trees_all::<Tree, _>(
             config,
+            store_config.rows_to_discard,
             data.as_mut()
                 .chunks_mut(config.window_size())
                 .enumerate()


### PR DESCRIPTION
fix: update merkletree inconsistent usage as lc trees