### PR TITLE
feat: phase2-cli merge command

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -56,6 +56,7 @@ generic-array = "0.13.2"
 structopt = "0.3.12"
 humansize = "1.1.0"
 indicatif = "0.14.0"
+groupy = "0.3.0"
 
 [dependencies.reqwest]
 version = "0.10"


### PR DESCRIPTION
The phase2-cli `merge` command merges large and small param files.

The final phase2 participant generates small-raw params, which are converted into non-raw using `phase2 convert`. The final small-nonraw params are then merged into the large initial params to produce the final `MPCParameters` file for a circuit.