### PR TITLE
feat: add scripts to validate phase2 output and parameter

### DIFF
--- a/scripts/verify-parameters-json.sh
+++ b/scripts/verify-parameters-json.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+# This script verifies that a given `.params` file (and the corresponding
+# `.vk` file) is part of `parameters.json` as has the correct digest.
+#
+# This script runs on POSIX compatible shells. You need to have standard
+# utilities (`basename`, `head`, `grep`) as well as have `jq` and `b2sum`
+# installed.
+#
+# The input a `parameter.json` file and a `.params' file.
+
+if [ "${#}" -ne 1 ]; then
+    echo "Verify that a given .params file (and the corresponding .vk file)"
+    echo "is part of parameters.json as has the correct digest."
+    echo ""
+    echo "Usage: $(basename "${0}") parameters.json parameter-file.params"
+    exit 1
+fi
+
+if ! command -v b2sum >/dev/null 2>&1
+then
+    echo "ERROR: 'b2sum' needs to be installed."
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1
+then
+    echo "ERROR: 'jq' needs to be installed."
+    exit 1
+fi
+
+PARAMS_JSON=${1}
+PARAMS_ID="${2%.*}"
+
+PARAMS_FILE="${PARAMS_ID}.params"
+VK_FILE="${PARAMS_ID}.vk"
+
+# Transforms the `parameters.json` into a string that consists of digest and
+# filename pairs.
+PARAMS_JSON_DATA=$(jq -r 'to_entries[] | "\(.value.digest) \(.key)"' "${PARAMS_JSON}")
+
+VK_HASH_SHORT=$(b2sum "${VK_FILE}"|head --bytes 32)
+if echo "${PARAMS_JSON_DATA}"|grep --silent "${VK_HASH_SHORT} ${VK_FILE}"; then
+    echo "ok Correct digest of VK file was found in ${PARAMS_JSON}."
+else
+    echo "not ok ERROR: Digest of VK file was *not* found/correct in ${PARAMS_JSON}."
+    exit 1
+fi
+
+PARAMS_HASH_SHORT=$(b2sum "${PARAMS_FILE}"|head --bytes 32)
+if echo "${PARAMS_JSON_DATA}"|grep --silent "${PARAMS_HASH_SHORT} ${PARAMS_FILE}"; then
+    echo "ok Correct digest of params file was found in ${PARAMS_JSON}."
+else
+    echo "not ok ERROR: Digest of params file was *not* found/correct in ${PARAMS_JSON}."
+    exit 1
+fi
+
+echo "# Verification successfully completed."

--- a/scripts/verify-phase2-params.sh
+++ b/scripts/verify-phase2-params.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+# This script verifies that the conversion from the trusted setup phase2
+# results to the published parameters is correct.
+#
+# It verifies that:
+#
+# - The `.vk` file is just an extract of the phase2 result, without further
+#   modifications
+# - The individual parts (`.params` and `.contribs`) are combined
+#   byte-identical to the phase2 result
+#
+# This script runs on POSIX compatible shells. You need to have standard
+# utilities (`basename`, `head`, `wc`) as well as `b2sum` installed.
+#
+# The input is a `.params` file.
+
+if [ "${#}" -ne 1 ]; then
+    echo "Verify that the conversion from the trusted setup phase2 results"
+    echo "to the published parameters is correct. It verifies that:"
+    echo " - The .vk file is just an extract of the phase2 result, without"
+    echo "   further modifications"
+    echo " - The individual parts (.params and .contribs) are combined"
+    echo "   byte-identical to the phase2 result"
+    echo ""
+    echo "Usage: $(basename "${0}") parameter-file.params"
+    exit 1
+fi
+
+if ! command -v b2sum >/dev/null 2>&1
+then
+    echo "ERROR: 'b2sum' needs to be installed."
+    exit 1
+fi
+
+PARAMS_ID="${1%.*}"
+
+PARAMS_FILE="${PARAMS_ID}.params"
+VK_FILE="${PARAMS_ID}.vk"
+CONTRIBS_FILE="${PARAMS_ID}.contribs"
+INFO_FILE="${PARAMS_ID}.info"
+PHASE2_FILE=$(cat "${INFO_FILE}")
+
+
+# Verify that the .vk file is extracted from the trusted setup phase2 file
+
+VK_SIZE=$(wc --bytes < "${VK_FILE}")
+VK_HASH=$(b2sum "${VK_FILE}"|head --bytes 128)
+# The hash of the vk data embedded in the trusted setup phase2 result
+PHASE2_VK_HASH=$(head --bytes "${VK_SIZE}" "${PHASE2_FILE}"|b2sum|head --bytes 128)
+if [ "${VK_HASH}" = "${PHASE2_VK_HASH}" ]; then
+    echo "ok VK hashes match."
+else
+    echo "not ok ERROR: VK hashes do *not* match."
+    exit 1
+fi
+
+
+# Verify that the trusted setup phase2 file can be re-assembled from its parts
+
+# The .params file already contain the contents of the .vk file. We only need
+# to combine .params and .contribs for verification.
+COMBINED_HASH=$(cat "${PARAMS_FILE}" "${CONTRIBS_FILE}"|b2sum|head --bytes 128)
+PHASE2_HASH=$(b2sum "${PHASE2_FILE}"|head --bytes 128)
+if [ "${COMBINED_HASH}" = "${PHASE2_HASH}" ]; then
+    echo "ok Combined file matches phase2 file ${PHASE2_FILE}."
+else
+    echo "not ok ERROR: Combined file and phase2 file ${PHASE2_FILE} do *not* match."
+    exit 1
+fi
+
+
+echo "# Verification successfully completed."


### PR DESCRIPTION
This commit adds two scripts. One is to validate that the trusted
setup phase2 result matches the published parameter files.

The other one is to verify that a `.params` file (and the corresponding
`.vk file`) is part of the `parameters.json`.