### PR TITLE
Feat: pin params to the filecoin collab cluster.

### DIFF
--- a/scripts/pin-params.sh
+++ b/scripts/pin-params.sh
@@ -53,19 +53,31 @@ else
   exit 1
 fi
 
-CLUSTER_HOST="/dnsaddr/cluster.ipfs.io"
+CLUSTER_HOST="/dnsaddr/filecoin.collab.ipfscluster.io"
+ADDITIONAL_CLUSTER_HOST="/dnsaddr/cluster.ipfs.io"
 CLUSTER_PIN_NAME="filecoin-proof-parameters-$VERSION"
 DNSLINK_DOMAIN="proofs.filecoin.io"
 
-# Pin to cluster
+# Add and pin to collab cluster. After this it will be on 1 peer and pin requests
+# will have been triggered for the others.
 ROOT_CID=$(ipfs-cluster-ctl \
   --host $CLUSTER_HOST \
   --basic-auth $CLUSTER_TOKEN \
   add --quieter \
+  --local \
   --name $CLUSTER_PIN_NAME \
   --recursive $INPUT_DIR )
 
 echo "ok! root cid is $ROOT_CID"
+
+# Pin to main cluster additionally.
+ipfs-cluster-ctl \
+    --host $ADDITIONAL_CLUSTER_HOST \
+    --basic-auth $CLUSTER_TOKEN \
+    pin add $ROOT_CID \
+    --no-status
+
+echo "ok! Pin request sent to additional cluster"
 
 # Publist the new cid to the dnslink
 npx dnslink-dnsimple --domain $DNSLINK_DOMAIN --link "/ipfs/$ROOT_CID"


### PR DESCRIPTION
This cluster is way faster to ingest data.

The `--local` option makes ingestion even faster (it will put the data
on one peer only while adding and pin everywhere at the end).

Additionally, we trigger pin requests in the main cluster (async) so that
params will be replicated by those nodes too (at some point, once they finish
to fetch them) from the collab cluster.