### PR TITLE
feat: split up window post API into separate calls

### DIFF
--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -569,8 +569,12 @@ pub fn generate_window_post_vanilla_proofs<Tree: 'static + MerkleTreeTrait>(
         sectors: &priv_sectors,
     };
 
-    let vanilla_proofs =
-        fallback::FallbackPoStCompound::prove_vanilla(&pub_params, &pub_inputs, &priv_inputs)?;
+    let vanilla_proofs = fallback::FallbackPoStCompound::prove_vanilla_with_challenges(
+        &pub_params,
+        &pub_inputs,
+        &priv_inputs,
+        &challenges.sector_challenges,
+    )?;
 
     info!("generate_window_post_vanilla_proofs:finish");
 

--- a/filecoin-proofs/src/parameters.rs
+++ b/filecoin-proofs/src/parameters.rs
@@ -6,10 +6,10 @@ use storage_proofs::proof::ProofScheme;
 use crate::constants::*;
 use crate::types::{MerkleTreeTrait, PaddedBytesAmount, PoStConfig};
 
-type WinningPostSetupParams = fallback::SetupParams;
+pub type WinningPostSetupParams = fallback::SetupParams;
 pub type WinningPostPublicParams = fallback::PublicParams;
 
-type WindowPostSetupParams = fallback::SetupParams;
+pub type WindowPostSetupParams = fallback::SetupParams;
 pub type WindowPostPublicParams = fallback::PublicParams;
 
 pub fn public_params<Tree: 'static + MerkleTreeTrait>(

--- a/filecoin-proofs/src/types/mod.rs
+++ b/filecoin-proofs/src/types/mod.rs
@@ -1,8 +1,13 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 use storage_proofs::hasher::Hasher;
 use storage_proofs::porep::stacked;
+use storage_proofs::post::fallback::*;
+use storage_proofs::sector::*;
 
 use crate::constants::*;
+use crate::parameters::*;
 
 mod bytes_amount;
 mod piece_info;
@@ -82,4 +87,31 @@ pub struct SealPreCommitPhase1Output<Tree: MerkleTreeTrait> {
     pub labels: Labels<Tree>,
     pub config: StoreConfig,
     pub comm_d: Commitment,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WindowPoStChallenges {
+    pub post_config: PoStConfig,
+    pub randomness: ChallengeSeed,
+    pub prover_id: ProverId,
+    pub sector_challenges: BTreeMap<SectorId, Vec<u64>>,
+}
+
+pub type SnarkProof = Vec<u8>;
+pub type VanillaProof<Tree> = Proof<<Tree as MerkleTreeTrait>::Proof>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WindowPoStVanillaProofs<Tree: MerkleTreeTrait> {
+    pub vanilla_params: WindowPostSetupParams,
+    pub partitions: Option<usize>,
+    #[serde(bound(
+        serialize = "Vec<PublicSector<<Tree::Hasher as Hasher>::Domain>>: Serialize",
+        deserialize = "Vec<PublicSector<<Tree::Hasher as Hasher>::Domain>>: Deserialize<'de>"
+    ))]
+    pub pub_sectors: Vec<PublicSector<<Tree::Hasher as Hasher>::Domain>>,
+    #[serde(bound(
+        serialize = "Vec<VanillaProof<Tree>>: Serialize",
+        deserialize = "Vec<VanillaProof<Tree>>: Deserialize<'de>"
+    ))]
+    pub vanilla_proofs: Vec<VanillaProof<Tree>>,
 }

--- a/filecoin-proofs/src/types/post_config.rs
+++ b/filecoin-proofs/src/types/post_config.rs
@@ -6,7 +6,7 @@ use storage_proofs::post::fallback;
 
 use crate::types::*;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct PoStConfig {
     pub sector_size: SectorSize,
     pub challenge_count: usize,
@@ -16,7 +16,7 @@ pub struct PoStConfig {
     pub priority: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PoStType {
     Winning,
     Window,

--- a/filecoin-proofs/src/types/sector_size.rs
+++ b/filecoin-proofs/src/types/sector_size.rs
@@ -1,7 +1,7 @@
 use crate::fr32::to_unpadded_bytes;
 use crate::types::*;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SectorSize(pub u64);
 
 impl From<u64> for SectorSize {

--- a/storage-proofs/core/src/proof.rs
+++ b/storage-proofs/core/src/proof.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::time::Instant;
 
 use log::info;
@@ -5,6 +6,7 @@ use serde::de::DeserializeOwned;
 use serde::ser::Serialize;
 
 use crate::error::Result;
+use crate::sector::SectorId;
 
 /// The ProofScheme trait provides the methods that any proof scheme needs to implement.
 pub trait ProofScheme<'a> {
@@ -56,6 +58,16 @@ pub trait ProofScheme<'a> {
         info!("total_groth_proof_time: {:?}", total_proof_time);
 
         result
+    }
+
+    fn prove_all_partitions_with_challenges(
+        _pub_params: &Self::PublicParams,
+        _pub_in: &Self::PublicInputs,
+        _priv_in: &Self::PrivateInputs,
+        _partition_count: usize,
+        _sector_challenges: &BTreeMap<SectorId, Vec<u64>>,
+    ) -> Result<Vec<Self::Proof>> {
+        unimplemented!();
     }
 
     /// verify returns true if the supplied proof is valid for the given public parameter and public inputs.

--- a/storage-proofs/post/src/fallback/vanilla.rs
+++ b/storage-proofs/post/src/fallback/vanilla.rs
@@ -19,7 +19,7 @@ use storage_proofs_core::{
     util::{default_rows_to_discard, NODE_SIZE},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetupParams {
     /// Size of the sector in bytes.
     pub sector_size: u64,
@@ -29,7 +29,7 @@ pub struct SetupParams {
     pub sector_count: usize,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublicParams {
     /// Size of the sector in bytes.
     pub sector_size: u64,


### PR DESCRIPTION
This is a draft PR that is trying to address #854.  This code affects Window PoSt only, and once that is nailed down, Winning PoSt will be updated after (using a similar split).