### PR TITLE
feat: accelerate SNARK verification

### DIFF
--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -416,12 +416,12 @@ pub fn verify_winning_post<Tree: 'static + MerkleTreeTrait>(
         k: None,
     };
 
-    let use_lotus_blst = settings::SETTINGS
+    let use_fil_blst = settings::SETTINGS
         .lock()
-        .expect("use_lotus_blst settings lock failure")
-        .use_lotus_blst;
+        .expect("use_fil_blst settings lock failure")
+        .use_fil_blst;
 
-    let is_valid = if use_lotus_blst {
+    let is_valid = if use_fil_blst {
         let verifying_key_path = post_config.get_cache_verifying_key_path::<Tree>()?;
         fallback::FallbackPoStCompound::verify_blst(
             &pub_params,

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -17,6 +17,7 @@ use storage_proofs::merkle::{
 use storage_proofs::multi_proof::MultiProof;
 use storage_proofs::post::fallback;
 use storage_proofs::sector::*;
+use storage_proofs::settings;
 use storage_proofs::util::default_rows_to_discard;
 
 use crate::api::util::{as_safe_commitment, get_base_tree_leafs, get_base_tree_size};
@@ -400,13 +401,6 @@ pub fn verify_winning_post<Tree: 'static + MerkleTreeTrait>(
     let pub_params: compound_proof::PublicParams<fallback::FallbackPoSt<Tree>> =
         fallback::FallbackPoStCompound::setup(&setup_params)?;
 
-    let verifying_key = get_post_verifying_key::<Tree>(&post_config)?;
-
-    let proof = MultiProof::new_from_reader(None, &proof[..], &verifying_key)?;
-    if proof.len() != 1 {
-        return Ok(false);
-    }
-
     let mut pub_sectors = Vec::with_capacity(param_sector_count);
     for _ in 0..param_sector_count {
         for (id, replica) in replicas.iter() {
@@ -422,14 +416,40 @@ pub fn verify_winning_post<Tree: 'static + MerkleTreeTrait>(
         k: None,
     };
 
-    let is_valid = fallback::FallbackPoStCompound::verify(
-        &pub_params,
-        &pub_inputs,
-        &proof,
-        &fallback::ChallengeRequirements {
-            minimum_challenge_count: post_config.challenge_count * post_config.sector_count,
-        },
-    )?;
+    let use_lotus_blst = settings::SETTINGS
+        .lock()
+        .expect("use_lotus_blst settings lock failure")
+        .use_lotus_blst;
+
+    let is_valid = if use_lotus_blst {
+        let verifying_key_path = post_config.get_cache_verifying_key_path::<Tree>()?;
+        fallback::FallbackPoStCompound::verify_blst(
+            &pub_params,
+            &pub_inputs,
+            &proof,
+            proof.len() / 192,
+            &fallback::ChallengeRequirements {
+                minimum_challenge_count: post_config.challenge_count * post_config.sector_count,
+            },
+            &verifying_key_path,
+        )?
+    } else {
+        let verifying_key = get_post_verifying_key::<Tree>(&post_config)?;
+
+        let single_proof = MultiProof::new_from_reader(None, &proof[..], &verifying_key)?;
+        if single_proof.len() != 1 {
+            return Ok(false);
+        }
+
+        fallback::FallbackPoStCompound::verify(
+            &pub_params,
+            &pub_inputs,
+            &single_proof,
+            &fallback::ChallengeRequirements {
+                minimum_challenge_count: post_config.challenge_count * post_config.sector_count,
+            },
+        )?
+    };
 
     if !is_valid {
         return Ok(false);

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -609,12 +609,12 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
             k: None,
         };
 
-    let use_lotus_blst = settings::SETTINGS
+    let use_fil_blst = settings::SETTINGS
         .lock()
-        .expect("use_lotus_blst settings lock failure")
-        .use_lotus_blst;
+        .expect("use_fil_blst settings lock failure")
+        .use_fil_blst;
 
-    let result = if use_lotus_blst {
+    let result = if use_fil_blst {
         let verifying_key_path = porep_config.get_cache_verifying_key_path::<Tree>()?;
 
         StackedCompound::verify_blst(

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -21,6 +21,7 @@ use storage_proofs::porep::stacked::{
 };
 use storage_proofs::proof::ProofScheme;
 use storage_proofs::sector::SectorId;
+use storage_proofs::settings;
 use storage_proofs::util::default_rows_to_discard;
 
 use crate::api::util::{
@@ -574,7 +575,6 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
     ensure!(comm_d_in != [0; 32], "Invalid all zero commitment (comm_d)");
     ensure!(comm_r_in != [0; 32], "Invalid all zero commitment (comm_r)");
 
-    let sector_bytes = PaddedBytesAmount::from(porep_config);
     let comm_r: <Tree::Hasher as Hasher>::Domain = as_safe_commitment(&comm_r_in, "comm_r")?;
     let comm_d: DefaultPieceDomain = as_safe_commitment(&comm_d_in, "comm_d")?;
 
@@ -609,32 +609,56 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
             k: None,
         };
 
-    let verifying_key = get_stacked_verifying_key::<Tree>(porep_config)?;
+    let use_lotus_blst = settings::SETTINGS
+        .lock()
+        .expect("use_lotus_blst settings lock failure")
+        .use_lotus_blst;
 
-    info!(
-        "got verifying key ({}) while verifying seal",
-        u64::from(sector_bytes)
-    );
+    let result = if use_lotus_blst {
+        let verifying_key_path = porep_config.get_cache_verifying_key_path::<Tree>()?;
 
-    let proof = MultiProof::new_from_reader(
-        Some(usize::from(PoRepProofPartitions::from(porep_config))),
-        proof_vec,
-        &verifying_key,
-    )?;
+        StackedCompound::verify_blst(
+            &compound_public_params,
+            &public_inputs,
+            &proof_vec,
+            proof_vec.len() / 192,
+            &ChallengeRequirements {
+                minimum_challenges: *POREP_MINIMUM_CHALLENGES
+                    .read()
+                    .expect("POREP_MINIMUM_CHALLENGES poisoned")
+                    .get(&u64::from(SectorSize::from(porep_config)))
+                    .expect("unknown sector size") as usize,
+            },
+            &verifying_key_path,
+        )
+    } else {
+        let sector_bytes = PaddedBytesAmount::from(porep_config);
+        let verifying_key = get_stacked_verifying_key::<Tree>(porep_config)?;
 
-    let result = StackedCompound::verify(
-        &compound_public_params,
-        &public_inputs,
-        &proof,
-        &ChallengeRequirements {
-            minimum_challenges: *POREP_MINIMUM_CHALLENGES
-                .read()
-                .expect("POREP_MINIMUM_CHALLENGES poisoned")
-                .get(&u64::from(SectorSize::from(porep_config)))
-                .expect("unknown sector size") as usize,
-        },
-    )
-    .map_err(Into::into);
+        info!(
+            "got verifying key ({}) while verifying seal",
+            u64::from(sector_bytes)
+        );
+
+        let proof = MultiProof::new_from_reader(
+            Some(usize::from(PoRepProofPartitions::from(porep_config))),
+            proof_vec,
+            &verifying_key,
+        )?;
+
+        StackedCompound::verify(
+            &compound_public_params,
+            &public_inputs,
+            &proof,
+            &ChallengeRequirements {
+                minimum_challenges: *POREP_MINIMUM_CHALLENGES
+                    .read()
+                    .expect("POREP_MINIMUM_CHALLENGES poisoned")
+                    .get(&u64::from(SectorSize::from(porep_config)))
+                    .expect("unknown sector size") as usize,
+            },
+        )
+    };
 
     info!("verify_seal:finish");
     result

--- a/rust-fil-proofs.config.toml.sample
+++ b/rust-fil-proofs.config.toml.sample
@@ -35,3 +35,6 @@ rows_to_discard = 2
 
 # Window size for pedersen hashing.
 pedersen_hash_exp_window_size = 16
+
+# This enables accelerate snark verification
+use_lotus_blst = false

--- a/rust-fil-proofs.config.toml.sample
+++ b/rust-fil-proofs.config.toml.sample
@@ -37,4 +37,4 @@ rows_to_discard = 2
 pedersen_hash_exp_window_size = 16
 
 # This enables accelerate snark verification
-use_lotus_blst = false
+use_fil_blst = false

--- a/storage-proofs/core/Cargo.toml
+++ b/storage-proofs/core/Cargo.toml
@@ -44,7 +44,7 @@ neptune = { version = "1.0.1", features = ["gpu"] }
 cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"
-lotus_blst = { git = "https://github.com/simonatsn/lotus-blst" }
+lotus_blst = { git = "https://github.com/vmx/lotus-blst", branch = "update-build" }
 
 [dev-dependencies]
 proptest = "0.10"

--- a/storage-proofs/core/Cargo.toml
+++ b/storage-proofs/core/Cargo.toml
@@ -44,7 +44,7 @@ neptune = { version = "1.0.1", features = ["gpu"] }
 cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"
-lotus_blst = { git = "https://github.com/vmx/lotus-blst", branch = "update-build" }
+fil-blst = "0.1.1"
 
 [dev-dependencies]
 proptest = "0.10"

--- a/storage-proofs/core/Cargo.toml
+++ b/storage-proofs/core/Cargo.toml
@@ -44,6 +44,7 @@ neptune = { version = "1.0.1", features = ["gpu"] }
 cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"
+lotus_blst = { git = "https://github.com/simonatsn/lotus-blst" }
 
 [dev-dependencies]
 proptest = "0.10"

--- a/storage-proofs/core/src/compound_proof.rs
+++ b/storage-proofs/core/src/compound_proof.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::{ensure, Context};
 use bellperson::{groth16, Circuit};
 use log::info;
-use lotus_blst::{blst_fr, blst_scalar, scalar_from_u64, verify_batch_proof};
+use fil_blst::{blst_fr, blst_scalar, scalar_from_u64, verify_batch_proof};
 use paired::bls12_381::{Bls12, Fr};
 use rand::{rngs::OsRng, RngCore};
 use rayon::prelude::*;

--- a/storage-proofs/core/src/compound_proof.rs
+++ b/storage-proofs/core/src/compound_proof.rs
@@ -1,6 +1,9 @@
+use std::path::Path;
+
 use anyhow::{ensure, Context};
 use bellperson::{groth16, Circuit};
 use log::info;
+use lotus_blst::{blst_fr, blst_scalar, scalar_from_u64, verify_batch_proof};
 use paired::bls12_381::{Bls12, Fr};
 use rand::{rngs::OsRng, RngCore};
 use rayon::prelude::*;
@@ -132,6 +135,66 @@ where
         let proofs: Vec<_> = multi_proof.circuit_proofs.iter().collect();
 
         let res = groth16::verify_proofs_batch(&pvk, &mut rand::rngs::OsRng, &proofs, &inputs)?;
+        Ok(res)
+    }
+
+    // verify_blst is equivalent to ProofScheme::verify.
+    fn verify_blst(
+        public_params: &PublicParams<'a, S>,
+        public_inputs: &S::PublicInputs,
+        proof_vec: &[u8],
+        num_proofs: usize,
+        requirements: &S::Requirements,
+        vk_path: &Path,
+    ) -> Result<bool> {
+        ensure!(
+            num_proofs == Self::partition_count(public_params),
+            "Inconsistent inputs"
+        );
+
+        let vanilla_public_params = &public_params.vanilla_params;
+
+        if !<S as ProofScheme>::satisfies_requirements(
+            &public_params.vanilla_params,
+            requirements,
+            num_proofs,
+        ) {
+            return Ok(false);
+        }
+
+        let inputs: Vec<_> = (0..num_proofs)
+            .into_par_iter()
+            .map(|k| Self::generate_public_inputs(public_inputs, vanilla_public_params, Some(k)))
+            .collect::<Result<_>>()?;
+
+        let blst_inputs: Vec<_> = inputs
+            .iter()
+            .flat_map(|pis| pis.iter().map(|pi| blst_fr::from(*pi)))
+            .collect();
+
+        // choose random coefficients for combining the proofs
+        let mut r: Vec<blst_scalar> = Vec::with_capacity(num_proofs);
+        let mut rng = rand::rngs::OsRng;
+        for _ in 0..num_proofs {
+            use rand::Rng;
+            let t: u128 = rng.gen();
+
+            let mut limbs: [u64; 4] = [0, 0, 0, 0];
+            limbs[1] = (t >> 64) as u64;
+            limbs[0] = (t & (-1i64 as u128) >> 64) as u64;
+
+            r.push(scalar_from_u64(&limbs));
+        }
+
+        let res = verify_batch_proof(
+            proof_vec,
+            num_proofs,
+            &blst_inputs,
+            inputs[0].len(),
+            &r,
+            128,
+            vk_path,
+        );
         Ok(res)
     }
 

--- a/storage-proofs/core/src/compound_proof.rs
+++ b/storage-proofs/core/src/compound_proof.rs
@@ -2,8 +2,8 @@ use std::path::Path;
 
 use anyhow::{ensure, Context};
 use bellperson::{groth16, Circuit};
-use log::info;
 use fil_blst::{blst_fr, blst_scalar, scalar_from_u64, verify_batch_proof};
+use log::info;
 use paired::bls12_381::{Bls12, Fr};
 use rand::{rngs::OsRng, RngCore};
 use rayon::prelude::*;

--- a/storage-proofs/core/src/settings.rs
+++ b/storage-proofs/core/src/settings.rs
@@ -28,6 +28,7 @@ pub struct Settings {
     pub window_post_synthesis_num_cpus: u32,
     pub parameter_cache: String,
     pub parent_cache: String,
+    pub use_lotus_blst: bool,
 }
 
 impl Default for Settings {
@@ -48,6 +49,7 @@ impl Default for Settings {
             // The name is retained for backwards compatibility.
             parameter_cache: "/var/tmp/filecoin-proof-parameters/".to_string(),
             parent_cache: cache("filecoin-parents"),
+            use_lotus_blst: false,
         }
     }
 }

--- a/storage-proofs/core/src/settings.rs
+++ b/storage-proofs/core/src/settings.rs
@@ -28,7 +28,7 @@ pub struct Settings {
     pub window_post_synthesis_num_cpus: u32,
     pub parameter_cache: String,
     pub parent_cache: String,
-    pub use_lotus_blst: bool,
+    pub use_fil_blst: bool,
 }
 
 impl Default for Settings {
@@ -49,7 +49,7 @@ impl Default for Settings {
             // The name is retained for backwards compatibility.
             parameter_cache: "/var/tmp/filecoin-proof-parameters/".to_string(),
             parent_cache: cache("filecoin-parents"),
-            use_lotus_blst: false,
+            use_fil_blst: false,
         }
     }
 }


### PR DESCRIPTION
This PR integrates lotus-blst in order to accelerate the SNARK verification.

This feature can be enabled with the `use_lotus_blst` setting.