### PR TITLE
Make fil-blst usage in Window PoSt possible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,6 +127,33 @@ jobs:
             RUST_TEST_THREADS: 1
           no_output_timeout: 30m
 
+  # Running with `use_fil_blst=true` should be integrated directly into the test code. For now we
+  # just re-run the tests that exercise the fil-blst code path with that setting set.
+  test_fil_blst:
+    docker:
+      - image: filecoin/rust:latest
+    working_directory: /mnt/crate
+    resource_class: 2xlarge+
+    steps:
+      - configure_environment_variables
+      - checkout
+      - attach_workspace:
+          at: "."
+      - restore_cache:
+          keys:
+            - cargo-v28-{{ checksum "rust-toolchain" }}-{{ checksum "Cargo.toml" }}-{{ checksum "Cargo.lock" }}-{{ arch }}
+      - restore_parameter_cache
+      - run:
+          name: Test with fil-blst enabled
+          command: |
+            ulimit -n 20000
+            ulimit -u 20000
+            ulimit -n 20000
+            cargo +$(cat rust-toolchain) test --verbose --release --test api -- --ignored
+          environment:
+            RUST_TEST_THREADS: 1
+            FIL_PROOFS_USE_FIL_BLST: true
+
   bench:
     docker:
       - image: filecoin/rust:latest
@@ -348,6 +375,10 @@ workflows:
       - test_ignored_release:
           name: test_ignored_release_filecoin_proofs
           crate: "filecoin-proofs"
+          requires:
+            - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
+      - test_fil_blst:
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -422,6 +422,7 @@ pub fn verify_winning_post<Tree: 'static + MerkleTreeTrait>(
         .use_fil_blst;
 
     let is_valid = if use_fil_blst {
+        info!("verify_winning_post: use_fil_blst=true");
         let verifying_key_path = post_config.get_cache_verifying_key_path::<Tree>()?;
         fallback::FallbackPoStCompound::verify_blst(
             &pub_params,
@@ -590,6 +591,7 @@ pub fn verify_window_post<Tree: 'static + MerkleTreeTrait>(
         .use_fil_blst;
 
     let is_valid = if use_fil_blst {
+        info!("verify_window_post: use_fil_blst=true");
         let verifying_key_path = post_config.get_cache_verifying_key_path::<Tree>()?;
         fallback::FallbackPoStCompound::verify_blst(
             &pub_params,

--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -566,10 +566,6 @@ pub fn verify_window_post<Tree: 'static + MerkleTreeTrait>(
     let pub_params: compound_proof::PublicParams<fallback::FallbackPoSt<Tree>> =
         fallback::FallbackPoStCompound::setup(&setup_params)?;
 
-    let verifying_key = get_post_verifying_key::<Tree>(&post_config)?;
-
-    let proof = MultiProof::new_from_reader(partitions, &proof[..], &verifying_key)?;
-
     let pub_sectors: Vec<_> = replicas
         .iter()
         .map(|(sector_id, replica)| {
@@ -588,15 +584,36 @@ pub fn verify_window_post<Tree: 'static + MerkleTreeTrait>(
         k: None,
     };
 
-    let is_valid = fallback::FallbackPoStCompound::verify(
-        &pub_params,
-        &pub_inputs,
-        &proof,
-        &fallback::ChallengeRequirements {
-            minimum_challenge_count: post_config.challenge_count * post_config.sector_count,
-        },
-    )?;
+    let use_fil_blst = settings::SETTINGS
+        .lock()
+        .expect("use_fil_blst settings lock failure")
+        .use_fil_blst;
 
+    let is_valid = if use_fil_blst {
+        let verifying_key_path = post_config.get_cache_verifying_key_path::<Tree>()?;
+        fallback::FallbackPoStCompound::verify_blst(
+            &pub_params,
+            &pub_inputs,
+            &proof,
+            proof.len() / 192,
+            &fallback::ChallengeRequirements {
+                minimum_challenge_count: post_config.challenge_count * post_config.sector_count,
+            },
+            &verifying_key_path,
+        )?
+    } else {
+        let verifying_key = get_post_verifying_key::<Tree>(&post_config)?;
+        let multi_proof = MultiProof::new_from_reader(partitions, &proof[..], &verifying_key)?;
+
+        fallback::FallbackPoStCompound::verify(
+            &pub_params,
+            &pub_inputs,
+            &multi_proof,
+            &fallback::ChallengeRequirements {
+                minimum_challenge_count: post_config.challenge_count * post_config.sector_count,
+            },
+        )?
+    };
     if !is_valid {
         return Ok(false);
     }

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -615,6 +615,7 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
         .use_fil_blst;
 
     let result = if use_fil_blst {
+        info!("verify_seal: use_fil_blst=true");
         let verifying_key_path = porep_config.get_cache_verifying_key_path::<Tree>()?;
 
         StackedCompound::verify_blst(


### PR DESCRIPTION
This PR consists of three parts:

 - fil-blst based verification to Window PoSt.
 - Logging so that you can easily verify when fil-blst is used.
 - a new CI job is added to run the tests that use the flt-blst code path with `use_fil_blst` enabled.

On the [CI logs](https://app.circleci.com/pipelines/github/filecoin-project/rust-fil-proofs/2318/workflows/2e947ebe-581c-4533-a015-0aadf4ff01d4/jobs/55260) you can see that fil_blst was used (search for `use_fil_blst=true`).