### PR TITLE
Add FaultySectors error to Fallback PoSt.

### DIFF
--- a/storage-proofs/core/src/error.rs
+++ b/storage-proofs/core/src/error.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 
+use crate::sector::SectorId;
 use bellperson::SynthesisError;
 
 pub use anyhow::Result;
@@ -37,6 +38,8 @@ pub enum Error {
     Unclassified(String),
     #[error("Missing Private Input {0} for sector {1}")]
     MissingPrivateInput(&'static str, u64),
+    #[error("faulty sectors {:?}", _0)]
+    FaultySectors(Vec<SectorId>),
 }
 
 impl From<Box<dyn Any + Send>> for Error {

--- a/storage-proofs/core/src/merkle/tree.rs
+++ b/storage-proofs/core/src/merkle/tree.rs
@@ -104,6 +104,8 @@ impl<
 
         let proof = self.inner.gen_cached_proof(i, rows_to_discard)?;
 
+        debug_assert!(proof.validate::<H::Function>().expect("validate failed"));
+
         MerkleProof::try_from_proof(proof)
     }
 

--- a/storage-proofs/core/src/merkle/tree.rs
+++ b/storage-proofs/core/src/merkle/tree.rs
@@ -104,8 +104,6 @@ impl<
 
         let proof = self.inner.gen_cached_proof(i, rows_to_discard)?;
 
-        debug_assert!(proof.validate::<H::Function>().expect("validate failed"));
-
         MerkleProof::try_from_proof(proof)
     }
 

--- a/storage-proofs/post/src/fallback/vanilla.rs
+++ b/storage-proofs/post/src/fallback/vanilla.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::marker::PhantomData;
 
 use anyhow::ensure;
@@ -297,7 +298,9 @@ impl<'a, Tree: 'a + MerkleTreeTrait> ProofScheme<'a> for FallbackPoSt<'a, Tree> 
         );
 
         let mut partition_proofs = Vec::new();
-        let mut faulty_sectors = Vec::new();
+
+        // Use `BTreeSet` so failure result will be canonically ordered (sorted).
+        let mut faulty_sectors = BTreeSet::new();
 
         for (j, (pub_sectors_chunk, priv_sectors_chunk)) in pub_inputs
             .sectors
@@ -345,6 +348,7 @@ impl<'a, Tree: 'a + MerkleTreeTrait> ProofScheme<'a> for FallbackPoSt<'a, Tree> 
                         );
                         let valid = if let Ok(proof) = &proof {
                             proof.validate(challenged_leaf_start as usize)
+                                && proof.root() == priv_sector.comm_r_last
                         } else {
                             false
                         };
@@ -357,8 +361,12 @@ impl<'a, Tree: 'a + MerkleTreeTrait> ProofScheme<'a> for FallbackPoSt<'a, Tree> 
                     .collect::<Result<Vec<_>>>()?
                 {
                     match proof_or_fault {
-                        ProofOrFault::Proof(proof) => inclusion_proofs.push(proof?),
-                        ProofOrFault::Fault(sector_id) => faulty_sectors.push(sector_id),
+                        ProofOrFault::Proof(proof) => {
+                            inclusion_proofs.push(proof?);
+                        }
+                        ProofOrFault::Fault(sector_id) => {
+                            faulty_sectors.insert(sector_id);
+                        }
                     }
                 }
 
@@ -378,10 +386,9 @@ impl<'a, Tree: 'a + MerkleTreeTrait> ProofScheme<'a> for FallbackPoSt<'a, Tree> 
             partition_proofs.push(Proof { sectors: proofs });
         }
 
-        ensure!(
-            faulty_sectors.is_empty(),
-            Error::FaultySectors(faulty_sectors)
-        );
+        ensure!(faulty_sectors.is_empty(), {
+            Error::FaultySectors(faulty_sectors.into_iter().collect())
+        });
 
         Ok(partition_proofs)
     }
@@ -593,9 +600,114 @@ mod tests {
         assert!(is_valid);
     }
 
+    fn test_invalid_fallback_post<Tree: MerkleTreeTrait>(
+        total_sector_count: usize,
+        sector_count: usize,
+        partitions: usize,
+    ) where
+        Tree::Store: 'static,
+    {
+        let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
+
+        let leaves = 64 * get_base_tree_count::<Tree>();
+        let sector_size = leaves * NODE_SIZE;
+
+        let pub_params = PublicParams {
+            sector_size: sector_size as u64,
+            challenge_count: 10,
+            sector_count,
+        };
+
+        let randomness = <Tree::Hasher as Hasher>::Domain::random(rng);
+        let prover_id = <Tree::Hasher as Hasher>::Domain::random(rng);
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let temp_path = temp_dir.path();
+
+        let mut pub_sectors = Vec::new();
+        let mut priv_sectors = Vec::new();
+
+        let mut trees = Vec::new();
+
+        let mut faulty_sectors = Vec::<SectorId>::new();
+
+        for _i in 0..total_sector_count {
+            let (_data, tree) =
+                generate_tree::<Tree, _>(rng, leaves, Some(temp_path.to_path_buf()));
+            trees.push(tree);
+        }
+
+        let faulty_denominator = 3;
+
+        let (_data, wrong_tree) =
+            generate_tree::<Tree, _>(rng, leaves, Some(temp_path.to_path_buf()));
+
+        for (i, tree) in trees.iter().enumerate() {
+            let make_faulty = i % faulty_denominator == 0;
+
+            let comm_c = <Tree::Hasher as Hasher>::Domain::random(rng);
+            let comm_r_last = tree.root();
+
+            priv_sectors.push(PrivateSector {
+                tree: if make_faulty { &wrong_tree } else { tree },
+                comm_c,
+                comm_r_last,
+            });
+
+            let comm_r = <Tree::Hasher as Hasher>::Function::hash2(&comm_c, &comm_r_last);
+
+            if make_faulty {
+                faulty_sectors.push((i as u64).into());
+            }
+
+            pub_sectors.push(PublicSector {
+                id: (i as u64).into(),
+                comm_r,
+            });
+        }
+
+        let pub_inputs = PublicInputs {
+            randomness,
+            prover_id,
+            sectors: &pub_sectors,
+            k: None,
+        };
+
+        let priv_inputs = PrivateInputs::<Tree> {
+            sectors: &priv_sectors[..],
+        };
+
+        let proof = FallbackPoSt::<Tree>::prove_all_partitions(
+            &pub_params,
+            &pub_inputs,
+            &priv_inputs,
+            partitions,
+        );
+
+        match proof {
+            Ok(proof) => {
+                let is_valid =
+                    FallbackPoSt::<Tree>::verify_all_partitions(&pub_params, &pub_inputs, &proof)
+                        .expect("verification failed");
+                assert!(!is_valid, "PoSt returned a valid proof with invalid input");
+            }
+            Err(e) => match e.downcast::<Error>() {
+                Err(_) => panic!("failed to downcast to Error"),
+                Ok(Error::FaultySectors(sector_ids)) => assert_eq!(faulty_sectors, sector_ids),
+                Ok(_) => panic!("PoSt failed to return FaultySectors error."),
+                _ => (),
+            },
+        };
+    }
+
     #[test]
     fn fallback_post_pedersen_single_partition_matching_base_8() {
         test_fallback_post::<LCTree<PedersenHasher, U8, U0, U0>>(5, 5, 1);
+    }
+
+    #[test]
+    fn invalid_fallback_post_pedersen_single_partition_matching_base_8() {
+        test_invalid_fallback_post::<LCTree<PedersenHasher, U8, U0, U0>>(5, 5, 1);
     }
 
     #[test]
@@ -604,8 +716,18 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_poseidon_single_partition_matching_base_8() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 5, 1);
+    }
+
+    #[test]
     fn fallback_post_poseidon_single_partition_smaller_base_8() {
         test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 5, 1);
+    }
+
+    #[test]
+    fn invalid_fallback_post_poseidon_single_partition_smaller_base_8() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 5, 1);
     }
 
     #[test]
@@ -614,8 +736,18 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_matching_base_8() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2);
+    }
+
+    #[test]
     fn fallback_post_poseidon_two_partitions_smaller_base_8() {
         test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2);
+    }
+
+    #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_smaller_base_8() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2);
     }
 
     #[test]
@@ -624,8 +756,18 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_pedersen_single_partition_matching_sub_8_4() {
+        test_invalid_fallback_post::<LCTree<PedersenHasher, U8, U4, U0>>(5, 5, 1);
+    }
+
+    #[test]
     fn fallback_post_poseidon_single_partition_matching_sub_8_4() {
         test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 5, 1);
+    }
+
+    #[test]
+    fn invalid_fallback_post_poseidon_single_partition_matching_sub_8_4() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 5, 1);
     }
 
     #[test]
@@ -634,8 +776,18 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_poseidon_single_partition_smaller_sub_8_4() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 5, 1);
+    }
+
+    #[test]
     fn fallback_post_poseidon_two_partitions_matching_sub_8_4() {
         test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(4, 2, 2);
+    }
+
+    #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_matching_sub_8_4() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(4, 2, 2);
     }
 
     #[test]
@@ -644,8 +796,18 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_matching_sub_8_8() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(4, 2, 2);
+    }
+
+    #[test]
     fn fallback_post_poseidon_two_partitions_smaller_sub_8_4() {
         test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 3, 2);
+    }
+
+    #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_smaller_sub_8_4() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 3, 2);
     }
 
     #[test]
@@ -654,12 +816,28 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_smaller_sub_8_8() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(5, 3, 2);
+    }
+
+    #[test]
     fn fallback_post_pedersen_single_partition_matching_top_8_4_2() {
         test_fallback_post::<LCTree<PedersenHasher, U8, U4, U2>>(5, 5, 1);
     }
+
+    #[test]
+    fn invalid_fallback_post_pedersen_single_partition_matching_top_8_4_2() {
+        test_invalid_fallback_post::<LCTree<PedersenHasher, U8, U4, U2>>(5, 5, 1);
+    }
+
     #[test]
     fn fallback_post_pedersen_single_partition_matching_top_8_8_2() {
         test_fallback_post::<LCTree<PedersenHasher, U8, U8, U2>>(5, 5, 1);
+    }
+
+    #[test]
+    fn invalid_fallback_post_pedersen_single_partition_matching_top_8_8_2() {
+        test_invalid_fallback_post::<LCTree<PedersenHasher, U8, U8, U2>>(5, 5, 1);
     }
 
     #[test]
@@ -668,8 +846,18 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_poseidon_single_partition_matching_top_8_4_2() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 5, 1);
+    }
+
+    #[test]
     fn fallback_post_poseidon_single_partition_matching_top_8_8_2() {
         test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 5, 1);
+    }
+
+    #[test]
+    fn invalid_fallback_post_poseidon_single_partition_matching_top_8_8_2() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 5, 1);
     }
 
     #[test]
@@ -678,8 +866,18 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_poseidon_single_partition_smaller_top_8_4_2() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 5, 1);
+    }
+
+    #[test]
     fn fallback_post_poseidon_two_partitions_matching_top_8_4_2() {
         test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(4, 2, 2);
+    }
+
+    #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_matching_top_8_4_2() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(4, 2, 2);
     }
 
     #[test]
@@ -688,7 +886,17 @@ mod tests {
     }
 
     #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_smaller_top_8_4_2() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 3, 2);
+    }
+
+    #[test]
     fn fallback_post_poseidon_two_partitions_smaller_top_8_8_2() {
         test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 3, 2);
+    }
+
+    #[test]
+    fn invalid_fallback_post_poseidon_two_partitions_smaller_top_8_8_2() {
+        test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 3, 2);
     }
 }


### PR DESCRIPTION
Instead of just failing when trying to generate a Fallback PoSt which contains faulty sectors, instead return a new `FaultySectors` error which contains a vector of faulty `SectorId`s.

In order to make use of the information in the enhanced error, `filecoin-ffi` will need to handle:

https://github.com/filecoin-project/filecoin-ffi/blob/master/rust/src/proofs/api.rs#L606-L609
https://github.com/filecoin-project/filecoin-ffi/blob/master/rust/src/proofs/types.rs#L253-L258

This might entail a breaking change of the `filecoin-ffi` consumed by Go, but the current change to `rust-fil-proofs` is purely additive. It just adds a new, more informative, error in a case where an error would already have been returned.

The included test should give a clear example of how to extract the faulty `SectorId`s from a potentially faulty result.