### PR TITLE
fix: remove artificial requirement that config sector count be 1

### DIFF
--- a/filecoin-proofs/src/api/post.rs
+++ b/filecoin-proofs/src/api/post.rs
@@ -537,17 +537,7 @@ pub fn generate_single_vanilla_proof<Tree: 'static + MerkleTreeTrait>(
     let comm_c = replica.safe_comm_c();
     let comm_r_last = replica.safe_comm_r_last();
 
-    // There is only enough information in the arguments to generate a
-    // single vanilla proof, so the behaviour is unexpected if the
-    // sector_count provided is > 1.
-    let sector_count = post_config.sector_count;
-    ensure!(
-        post_config.sector_count == 1,
-        "invalid post config sector size ({} required)",
-        sector_count
-    );
-
-    let mut priv_sectors = Vec::with_capacity(sector_count);
+    let mut priv_sectors = Vec::with_capacity(1);
     priv_sectors.push(fallback::PrivateSector {
         tree,
         comm_c,

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -387,25 +387,12 @@ fn window_post<Tree: 'static + MerkleTreeTrait>(
         prover_id,
     )?;
 
-    // This 'single config' is used when generating a single vanilla proof.
-    let single_config = PoStConfig {
-        sector_size: sector_size.into(),
-        sector_count: 1,
-        challenge_count: WINDOW_POST_CHALLENGE_COUNT,
-        typ: PoStType::Window,
-        priority: false,
-    };
-
     let mut vanilla_proofs = Vec::with_capacity(replica_sectors.len());
 
     for (sector_id, replica) in priv_replicas.iter() {
         let sector_challenges = &challenges[sector_id];
-        let single_proof = generate_single_vanilla_proof::<Tree>(
-            &single_config,
-            *sector_id,
-            replica,
-            sector_challenges,
-        )?;
+        let single_proof =
+            generate_single_vanilla_proof::<Tree>(&config, *sector_id, replica, sector_challenges)?;
 
         vanilla_proofs.push(single_proof);
     }


### PR DESCRIPTION
This is in the context of generating a single vanilla proof.  A specialized post config should not be required.