### PR TITLE
feat(storage-proofs-porep): implement prefetch macro for aarch64

### DIFF
--- a/storage-proofs/porep/src/lib.rs
+++ b/storage-proofs/porep/src/lib.rs
@@ -1,6 +1,8 @@
 //requires nightly, or later stable version
 //#![warn(clippy::unwrap_used)]
 
+#![cfg_attr(target_arch = "aarch64", feature(stdsimd))]
+
 pub mod drg;
 pub mod stacked;
 

--- a/storage-proofs/porep/src/stacked/vanilla/macros.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/macros.rs
@@ -55,6 +55,11 @@ macro_rules! prefetch {
 
             _mm_prefetch($val, _MM_HINT_T0);
         }
+        #[cfg(all(target_arch = "aarch64"))]
+        unsafe {
+            use std::arch::aarch64::*;
+            _prefetch($val, _PREFETCH_READ, _PREFETCH_LOCALITY3);
+        }
     };
 }
 


### PR DESCRIPTION
Co-authored-by: Wang Maozhang <wangmaozhang@huawei.com>

This implement prefetch marco for aarch64 in `storage-proofs/porep/src/stacked/vanilla/macros.rs`, with prefetch hints merged into core_arch library [rust-lang/stdarch-PR918](https://github.com/rust-lang/stdarch/pull/918) and [rust-lang/rust-PR77259](https://github.com/rust-lang/rust/pull/77259).

Patch delivers about 23% performance improvement in `(lotus-bench seal: preCommit phase 1)` with `--sector-size=512MB/32GiB` on Kunpeng920 aarch64 server.