### PR TITLE
Use two producers in all layers.

### DIFF
--- a/storage-proofs/porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/create_label/multi.rs
@@ -207,9 +207,7 @@ fn create_layer_labels(
 ) -> Result<()> {
     info!("Creating labels for layer {}", cur_layer);
     // num_producers is the number of producer threads
-    let (lookahead, num_producers, producer_stride) = if cur_layer == 1 {
-        (400, 1, 16)
-    } else {
+    let (lookahead, num_producers, producer_stride) = {
         // NOTE: Stride must not exceed `sdr_parents_cache_window_nodes`.
         // If it does, the process will deadlock with producers and consumers
         // waiting for each other.

--- a/storage-proofs/porep/src/stacked/vanilla/memory_handling.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/memory_handling.rs
@@ -72,18 +72,12 @@ impl<T: FromByteSlice> CacheReader<T> {
         std::slice::from_raw_parts_mut((*self.bufs.get()).as_mut_ptr(), 2)
     }
 
-    // TODO: is this actually needed?
     #[allow(dead_code)]
+    // This is unused, but included to document the meaning of its components.
+    // This allows splitting the reset in order to avoid a pause.
     pub fn reset(&self) -> Result<()> {
-        let buf0 = Self::map_buf(0, self.window_size, &self.file)?;
-        // FIXME: If window_size is more than half of size, then buf1 will map past end of file.
-        // This should never be accessed, but we should not map it.
-        let buf1 = Self::map_buf(self.window_size as u64, self.window_size, &self.file)?;
-        let bufs = unsafe { self.get_mut_bufs() };
-        bufs[0] = buf0;
-        bufs[1] = buf1;
-        self.cur_window.store(0, SeqCst);
-        self.cur_window_safe.store(0, SeqCst);
+        self.start_reset();
+        self.finish_reset();
         Ok(())
     }
 


### PR DESCRIPTION
This PR removes the special handling of layer 1 and uses two producers on all layers. This should never be worse than having only a single producer, and may improve the situation if some configuration is penalized (as possibly observed) by a too-slow producer (perhaps because of slower RAM). I have benchmarked this, and it is no worse (but also no better) than what it replaces on 3970x.

I also cleaned up the `reset` function in `memory_handling.rs`. If we want the `debug!` changes from #1295, we could include that here too.