### PR TITLE
bind replication threads to specific cores

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,16 @@ jobs:
       - configure_environment_variables
       - checkout
       - run:
+          name: Install hwloc 1.11.9
+          command: |
+            cd /tmp
+            curl https://www.open-mpi.org/software/hwloc/v1.11/downloads/hwloc-1.11.9.tar.gz --location --output /tmp/hwloc-1.11.9.tar.gz
+            tar xzvf hwloc-1.11.9.tar.gz
+            cd hwloc-1.11.9
+            ./configure
+            make
+            sudo make install
+      - run:
           name: Install Rust
           command: |
             curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ The instructions below assume you have independently installed `rust-fil-proofs`
 
 **NOTE:** `rust-fil-proofs` can only be built for and run on 64-bit platforms; building will panic if the target architecture is not 64-bits.
 
-Before building you will need OpenCL to be installed, on Ubuntu this can be achieved with `apt install ocl-icd-opencl-dev`.  Other system dependencies such as 'gcc/clang', 'wall' and 'cmake' are also required.
+Before building you will need OpenCL to be installed. On Ubuntu, this can be achieved with `apt install ocl-icd-opencl-dev`.  Other system dependencies such as 'gcc/clang', 'wall' and 'cmake' are also required.
+
+You will also need to install the hwloc library. On Ubuntu, this can be achieved with `apt install hwloc libhwloc-dev`. For other platforms, please see the [hwloc-rs Prerequisites section](https://github.com/daschl/hwloc-rs).
+
 
 ```
 > cargo build --release --all
@@ -178,6 +181,18 @@ Best performance will also be achieved when it is possible to lock pages which h
 accomplished either by running the process as root, or by increasing the system limit for max locked memory with `ulimit
 -l`. Two sector size's worth of data (for current and previous layers) must be locked -- along with 56 *
 `FIL_PROOFS_PARENT_CACHE_SIZE` bytes for the parent cache.
+
+Default parameters have been tuned to provide good performance on the AMD Ryzen Threadripper 3970x. It may be useful to
+experiment with these, especially on different hardware. We have made an effort to use sensible heuristics and to ensure
+reasonable behavior for a range of configurations and hardware, but actual performance or behavior of mulitcore
+replication is not yet well tested except on our target. The following settings may be useful, but do expect some
+failure in the search for good parameters. This might take the form of failed replication (bad proofs), errors during
+replication, or even potentially crashes if parameters prove pathological. For now, this is an experimental feature, and
+only the default configuration on default hardware (3970x) is known to work well.
+
+`FIL_PROOFS_MULTICORE_SDR_PRODUCERS`: This is the number of worker threads loading node parents in parallel. The default is `3` so the producers and main thread together use a full core complex (but no more).
+`FIL_PROOFS_MULTICORE_SDR_PRODUCER_STRIDE`: This is the (max) number of nodes for which a producer thread will load parents in each iteration of its loop. The default is`128`.
+`FIL_PROOFS_MULTICORE_SDR_LOOKAHEAD`: This is the size of the lookahead buffer into which node parents are pre-loaded by the producer threads. The default is 800.
 
 ### GPU Usage
 

--- a/storage-proofs/core/src/settings.rs
+++ b/storage-proofs/core/src/settings.rs
@@ -31,6 +31,9 @@ pub struct Settings {
     pub parent_cache: String,
     pub use_fil_blst: bool,
     pub use_multicore_sdr: bool,
+    pub multicore_sdr_producers: usize,
+    pub multicore_sdr_producer_stride: u64,
+    pub multicore_sdr_lookahead: usize,
 }
 
 impl Default for Settings {
@@ -54,6 +57,9 @@ impl Default for Settings {
             parent_cache: cache("filecoin-parents"),
             use_fil_blst: false,
             use_multicore_sdr: false,
+            multicore_sdr_producers: 3,
+            multicore_sdr_producer_stride: 128,
+            multicore_sdr_lookahead: 800,
         }
     }
 }

--- a/storage-proofs/porep/Cargo.toml
+++ b/storage-proofs/porep/Cargo.toml
@@ -37,6 +37,8 @@ bincode = "1.1.2"
 byteorder = "1.3.4"
 lazy_static = "1.2"
 byte-slice-cast = "0.3.5"
+hwloc = "0.3.0"
+libc = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/storage-proofs/porep/src/stacked/vanilla/cores.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/cores.rs
@@ -1,0 +1,219 @@
+use log::*;
+use std::sync::{Mutex, MutexGuard};
+
+use anyhow::Result;
+use hwloc::{ObjectType, Topology, TopologyObject, CPUBIND_THREAD};
+use lazy_static::lazy_static;
+
+use storage_proofs_core::settings;
+
+type CoreGroup = Vec<CoreIndex>;
+lazy_static! {
+    pub static ref TOPOLOGY: Mutex<Topology> = Mutex::new(Topology::new());
+    pub static ref CORE_GROUPS: Option<Vec<Mutex<CoreGroup>>> = {
+        let settings = settings::SETTINGS.lock().expect("settings lock failure");
+        let num_producers = settings.multicore_sdr_producers;
+        let cores_per_unit = num_producers + 1;
+
+        core_groups(cores_per_unit)
+    };
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+/// `CoreIndex` is a simple wrapper type for indexes into the set of vixible cores. A `CoreIndex` should only ever be
+/// created with a value known to be less than the number of visible cores.
+pub struct CoreIndex(usize);
+
+pub fn checkout_core_group() -> Option<MutexGuard<'static, CoreGroup>> {
+    match &*CORE_GROUPS {
+        Some(groups) => {
+            for (i, group) in groups.iter().enumerate() {
+                match group.try_lock() {
+                    Ok(guard) => {
+                        debug!("checked out core group {}", i);
+                        return Some(guard);
+                    }
+                    Err(_) => debug!("core group {} locked, could not checkout", i),
+                }
+            }
+            None
+        }
+        None => None,
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub type ThreadId = libc::pthread_t;
+
+#[cfg(target_os = "windows")]
+pub type ThreadId = winapi::winnt::HANDLE;
+
+/// Helper method to get the thread id through libc, with current rust stable (1.5.0) its not
+/// possible otherwise I think.
+#[cfg(not(target_os = "windows"))]
+fn get_thread_id() -> ThreadId {
+    unsafe { libc::pthread_self() }
+}
+
+#[cfg(target_os = "windows")]
+fn get_thread_id() -> ThreadId {
+    unsafe { kernel32::GetCurrentThread() }
+}
+
+pub struct Cleanup {
+    tid: ThreadId,
+    prior_state: Option<hwloc::Bitmap>,
+}
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        match self.prior_state.take() {
+            Some(prior) => {
+                let child_topo = &TOPOLOGY;
+                let mut locked_topo = child_topo.lock().unwrap();
+                let _ = locked_topo.set_cpubind_for_thread(self.tid, prior, CPUBIND_THREAD);
+            }
+            None => (),
+        }
+    }
+}
+
+pub fn bind_core(core_index: CoreIndex) -> Result<Cleanup> {
+    let child_topo = &TOPOLOGY;
+    let tid = get_thread_id();
+    let mut locked_topo = child_topo.lock().unwrap();
+    let core = get_core_by_index(&locked_topo, core_index).map_err(|err| {
+        anyhow::format_err!("failed to get core at index {}: {:?}", core_index.0, err)
+    })?;
+
+    let cpuset = core.allowed_cpuset().ok_or_else(|| {
+        anyhow::format_err!("no allowed cpuset for core at index {}", core_index.0,)
+    })?;
+    debug!("allowed cpuset: {:?}", cpuset);
+    let mut bind_to = cpuset;
+
+    // Get only one logical processor (in case the core is SMT/hyper-threaded).
+    bind_to.singlify();
+
+    // Thread binding before explicit set.
+    let before = locked_topo.get_cpubind_for_thread(tid, CPUBIND_THREAD);
+
+    debug!("binding to {:?}", bind_to);
+    // Set the binding.
+    let result = locked_topo
+        .set_cpubind_for_thread(tid, bind_to, CPUBIND_THREAD)
+        .map_err(|err| anyhow::format_err!("failed to bind CPU: {:?}", err));
+
+    if result.is_err() {
+        warn!("error in bind_core, {:?}", result);
+    }
+
+    Ok(Cleanup {
+        tid,
+        prior_state: before,
+    })
+}
+
+fn get_core_by_index<'a>(topo: &'a Topology, index: CoreIndex) -> Result<&'a TopologyObject> {
+    let idx = index.0;
+
+    match topo.objects_with_type(&ObjectType::Core) {
+        Ok(all_cores) if idx < all_cores.len() => Ok(all_cores[idx]),
+        Ok(all_cores) => Err(anyhow::format_err!(
+            "idx ({}) out of range for {} cores",
+            idx,
+            all_cores.len()
+        )),
+        _e => Err(anyhow::format_err!("failed to get core by index {}", idx,)),
+    }
+}
+
+fn core_groups(cores_per_unit: usize) -> Option<Vec<Mutex<Vec<CoreIndex>>>> {
+    let topo = TOPOLOGY.lock().unwrap();
+
+    let core_depth = match topo.depth_or_below_for_type(&ObjectType::Core) {
+        Ok(depth) => depth,
+        Err(_) => return None,
+    };
+    let all_cores = topo.objects_with_type(&ObjectType::Core).unwrap();
+    let core_count = all_cores.len();
+
+    let mut cache_depth = core_depth;
+    let mut cache_count = 0;
+
+    while cache_depth > 0 {
+        let objs = topo.objects_at_depth(cache_depth);
+        let obj_count = objs.len();
+        if obj_count < core_count {
+            cache_count = obj_count;
+            break;
+        }
+
+        cache_depth -= 1;
+    }
+
+    assert_eq!(0, core_count % cache_count);
+    let mut group_size = core_count / cache_count;
+    let mut group_count = cache_count;
+
+    if cache_count <= 1 {
+        // If there are not more than one shared caches, there is no benefit in trying to group cores by cache.
+        // In that case, prefer more groups so we can still bind cores and also get some parallelism.
+        // Create as many full groups as possible. The last group may not be full.
+        group_count = core_count / cores_per_unit;
+        group_size = cores_per_unit;
+
+        info!(
+            "found only {} shared cache(s), heuristically grouping cores into {} groups",
+            cache_count, group_count
+        );
+    } else {
+        debug!(
+            "Cores: {}, Shared Caches: {}, cores per cache (group_size): {}",
+            core_count, cache_count, group_size
+        );
+    }
+
+    let core_groups = (0..group_count)
+        .map(|i| {
+            (0..group_size)
+                .map(|j| {
+                    let core_index = i * group_size + j;
+                    assert!(core_index < core_count);
+                    CoreIndex(core_index)
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    Some(
+        core_groups
+            .iter()
+            .map(|group| Mutex::new(group.clone()))
+            .collect::<Vec<_>>(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cores() {
+        core_groups(2);
+    }
+
+    #[test]
+    fn test_checkout_cores() {
+        let checkout1 = checkout_core_group();
+        dbg!(&checkout1);
+        let checkout2 = checkout_core_group();
+        dbg!(&checkout2);
+
+        // This test might fail if run on a machine with fewer than four cores.
+        match (checkout1, checkout2) {
+            (Some(c1), Some(c2)) => assert!(*c1 != *c2),
+            _ => panic!("failed to get two checkouts"),
+        }
+    }
+}

--- a/storage-proofs/porep/src/stacked/vanilla/memory_handling.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/memory_handling.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use byte_slice_cast::*;
 use log::*;
 use mapr::{Mmap, MmapMut, MmapOptions};
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering::SeqCst};
+use std::sync::atomic::{spin_loop_hint, AtomicU64, AtomicUsize, Ordering::SeqCst};
 
 pub struct CacheReader<T> {
     file: File,
@@ -16,12 +16,67 @@ pub struct CacheReader<T> {
     size: usize,
     degree: usize,
     window_size: usize,
-    cur_window: AtomicUsize,
-    cur_window_safe: AtomicUsize,
+    cursor: IncrementingCursor,
+    consumer: AtomicU64,
     _t: PhantomData<T>,
 }
 
 unsafe impl<T> Sync for CacheReader<T> {}
+
+struct IncrementingCursor {
+    cur: AtomicUsize,
+    cur_safe: AtomicUsize,
+}
+
+/// IncrementingCursor provides an atomic variable which can be incremented such that only one thread attempting the
+/// increment is selected to perform actions required to effect the transition. Unselected threads wait until the
+/// transition has completed. Transition and wait condition are both specified by closures supplied by the caller.
+impl IncrementingCursor {
+    fn new(val: usize) -> Self {
+        Self {
+            cur: AtomicUsize::new(val),
+            cur_safe: AtomicUsize::new(val),
+        }
+    }
+    fn store(&self, val: usize) {
+        self.cur.store(val, SeqCst);
+        self.cur_safe.store(val, SeqCst);
+    }
+    fn compare_and_swap(&self, before: usize, after: usize) {
+        self.cur.compare_and_swap(before, after, SeqCst);
+        self.cur_safe.compare_and_swap(before, after, SeqCst);
+    }
+    fn increment<F: Fn() -> bool, G: Fn()>(&self, target: usize, wait_fn: F, advance_fn: G) {
+        // Check using `cur_safe`, to ensure we wait until the current cursor value is safe to use.
+        // If we were to instead check `cur`, it could have been incremented but not yet safe.
+        let cur = self.cur_safe.load(SeqCst);
+        if target > cur {
+            // Only one producer will successfully increment `cur`. We need this second atomic because we cannot
+            // increment `cur_safe` until after the underlying resource has been advanced.
+            let instant_cur = self.cur.compare_and_swap(cur, cur + 1, SeqCst);
+
+            if instant_cur == cur {
+                // We successfully incremented `self.cur`, so we are responsible for advancing the resource.
+                {
+                    while wait_fn() {
+                        spin_loop_hint()
+                    }
+                }
+
+                advance_fn();
+
+                // Now it is safe to use the new window.
+                self.cur_safe.fetch_add(1, SeqCst);
+            } else {
+                // We failed to increment `self.cur_window`, so we must wait for the window to be advanced before
+                // continuing. Wait until it is safe to use the new current window.
+                while self.cur_safe.load(SeqCst) != cur + 1 {
+                    spin_loop_hint()
+                }
+            }
+        }
+    }
+}
 
 impl<T: FromByteSlice> CacheReader<T> {
     pub fn new(filename: &PathBuf, window_size: Option<usize>, degree: usize) -> Result<Self> {
@@ -55,10 +110,30 @@ impl<T: FromByteSlice> CacheReader<T> {
             degree,
             window_size,
             // The furthest window from which the cache has yet been read.
-            cur_window: AtomicUsize::new(0),
-            cur_window_safe: AtomicUsize::new(0),
+            cursor: IncrementingCursor::new(0),
+            consumer: AtomicU64::new(0),
             _t: PhantomData::<T>,
         })
+    }
+
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
+    pub fn window_nodes(&self) -> usize {
+        self.size() / (size_of::<T>() * self.degree)
+    }
+
+    /// Safety: incrementing the consumer at the end of a window will unblock the producer waiting to remap the
+    /// consumer's previous buffer. The buffer must not be accessed once this has happened.
+    pub unsafe fn increment_consumer(&self) {
+        self.consumer.fetch_add(1, SeqCst);
+    }
+    pub fn store_consumer(&self, val: u64) {
+        self.consumer.store(val, SeqCst);
+    }
+    pub fn get_consumer(&self) -> u64 {
+        self.consumer.load(SeqCst)
     }
 
     #[inline]
@@ -90,37 +165,18 @@ impl<T: FromByteSlice> CacheReader<T> {
         let buf1 = Self::map_buf(self.window_size as u64, self.window_size, &self.file)?;
         let bufs = unsafe { self.get_mut_bufs() };
         bufs[1] = buf1;
-        self.cur_window.store(0, SeqCst);
-        self.cur_window_safe.store(0, SeqCst);
+        self.cursor.store(0);
         Ok(())
     }
 
     fn map_buf(offset: u64, len: usize, file: &File) -> Result<Mmap> {
-        match unsafe {
+        unsafe {
             MmapOptions::new()
                 .offset(offset)
                 .len(len)
                 .private()
-                .lock()
                 .map(file)
-        }
-        .and_then(|mut parents| {
-            parents.mlock()?;
-            Ok(parents)
-        }) {
-            Ok(parents) => Ok(parents),
-            Err(err) => {
-                // fallback to not locked if permissions are not available
-                warn!("failed to lock map {:?}, falling back", err);
-                let parents = unsafe {
-                    MmapOptions::new()
-                        .offset(offset)
-                        .len(len)
-                        .private()
-                        .map(file)?
-                };
-                Ok(parents)
-            }
+                .map_err(|e| e.into())
         }
     }
 
@@ -131,7 +187,12 @@ impl<T: FromByteSlice> CacheReader<T> {
 
     /// `pos` is in units of `T`.
     #[inline]
-    pub fn consumer_slice_at(&self, pos: usize) -> &[T] {
+    /// Safety: A returned slice must not be accessed once the buffer from which it has been derived is remapped. A
+    /// buffer will never be remapped until the `consumer` atomic contained in `self` has been advanced past the end of
+    /// the window. NOTE: each time `consumer` is incremented, `self.degrees` elements of the cache are invalidated.
+    /// This means callers should only access slice elements sequentially. They should only call `increment_consumer`
+    /// once the next `self.degree` elements of the cache will never be accessed again.
+    pub unsafe fn consumer_slice_at(&self, pos: usize) -> &[T] {
         assert!(
             pos < self.size,
             "pos {} out of range for buffer of size {}",
@@ -147,7 +208,11 @@ impl<T: FromByteSlice> CacheReader<T> {
 
     /// `pos` is in units of `T`.
     #[inline]
-    pub fn slice_at(&self, pos: usize, consumer: &AtomicU64) -> &[T] {
+    /// Safety: This call may advance the rear buffer, making it unsafe to access slices derived from that buffer again.
+    /// It is the callers responsibility to ensure such illegal access is not attempted. This can be prevented if users
+    /// never access values past which the cache's `consumer` atomic has been incremented. NOTE: each time `consumer` is
+    /// incremented, `self.degrees` elements of the cache are invalidated.
+    pub unsafe fn slice_at(&self, pos: usize) -> &[T] {
         assert!(
             pos < self.size,
             "pos {} out of range for buffer of size {}",
@@ -156,39 +221,18 @@ impl<T: FromByteSlice> CacheReader<T> {
         );
         let window = pos / self.window_element_count();
         if window == 1 {
-            self.cur_window.compare_and_swap(0, 1, SeqCst);
-            self.cur_window_safe.compare_and_swap(0, 1, SeqCst);
+            self.cursor.compare_and_swap(0, 1);
         }
 
         let pos = pos % self.window_element_count();
 
-        // Check using `cur_window_safe`, to ensure we wait until the window is safe to use.
-        // If we were to instead check `cur_window`, it could have been incremented but the mapping not completed yet.
-        let cur = self.cur_window_safe.load(SeqCst);
-        if window > cur {
-            // Only one producer will successfully increment `cur_window`.
-            // We need this second atomic because we cannot increment `cur_window_safe` until after the window has been advanced.
-            let instant_cur = self.cur_window.compare_and_swap(cur, cur + 1, SeqCst);
+        let wait_fn = || {
+            let safe_consumer = (window - 1) * (self.window_element_count() / self.degree);
+            (self.consumer.load(SeqCst) as usize) < safe_consumer
+        };
 
-            if instant_cur == cur {
-                // We successfully incremented `self.cur_window`, so we are responsible for advancing the window.
-
-                {
-                    // Wait until the consumer has advanced far enough that it is safe to load the unused buffer.
-                    let safe_consumer = (window - 1) * (self.window_element_count() / self.degree);
-                    while (consumer.load(SeqCst) as usize) < safe_consumer {}
-                }
-
-                self.advance_rear_window(window);
-
-                // Now it is safe to use the new window.
-                self.cur_window_safe.fetch_add(1, SeqCst);
-            } else {
-                // We failed to increment `self.cur_window`, so we must wait for the window to be advanced before continuing.
-                // Wait until it is safe to use the new current window.
-                while self.cur_window_safe.load(SeqCst) != cur + 1 {}
-            }
-        }
+        self.cursor
+            .increment(window, &wait_fn, &|| self.advance_rear_window(window));
 
         let targeted_buf = &self.get_bufs()[window % 2];
 

--- a/storage-proofs/porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/mod.rs
@@ -5,6 +5,7 @@ mod cache;
 mod challenges;
 mod column;
 mod column_proof;
+mod cores;
 pub mod create_label;
 mod encoding_proof;
 mod graph;


### PR DESCRIPTION
In order to maximize replication (precommit phase 1) performance, bind all replication threads to a single core (distinct from other replication threads). Consumer and producer threads for each replication task should be on cores which share cache. If multiple such cores exist, keep threads for a single replication task together (on cores sharing a cache). Otherwise, group cores based on the number of threads required. We create groups even when they do not correspond to a shared cache in order to make use of the core binding facility used in the preferred case.

If a core cannot be bound, a message will be logged in a debug mode, but operation is not interrupted. The thread is simply scheduled without constraint as though no attempt to bind a core had been made.

NOTE: This implementation does not support currently support core binding on macos. 

- [x] Document in README.
- [x] Identify and remove minimal cause of perf regression (vs best seen in this work, not vs previous).

### PERF UPDATES

- I benchmarked replication of a 32GiB sector with the final code at 2:03:05 (on 3970x) — so regression is conquered.
- I benchmarked the currently-latest version without mlocked window pages (and not run as root) and saw a noticeably faster result: 2:02:23.
- 2 sectors, with window pages locked: 2:06:27
- 2 sectors, without window pages locked 2:06:17
