### PR TITLE
 test: add test for resumable sealing

### DIFF
--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -15,6 +15,9 @@ use tempfile::NamedTempFile;
 
 use filecoin_proofs::*;
 
+// Use a fixed PoRep ID, so that the parents cache can be re-used between different tests
+const ARBITRARY_POREP_ID: [u8; 32] = [28; 32];
+
 static INIT_LOGGER: Once = Once::new();
 fn init_logger() {
     INIT_LOGGER.call_once(|| {
@@ -143,8 +146,7 @@ fn run_resumable_seal(skip_proofs: bool, layer_to_delete: usize) {
     let sealed_sector_file = NamedTempFile::new().expect("failed to created sealed sector file");
     let cache_dir = tempfile::tempdir().expect("failed to create temp dir");
 
-    let arbitrary_porep_id = rng.gen();
-    let config = porep_config(sector_size, arbitrary_porep_id);
+    let config = porep_config(sector_size, ARBITRARY_POREP_ID);
     let ticket = rng.gen();
     let sector_id = rng.gen::<u64>().into();
 
@@ -724,8 +726,7 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
     let sealed_sector_file = NamedTempFile::new()?;
     let cache_dir = tempfile::tempdir().expect("failed to create temp dir");
 
-    let arbitrary_porep_id = rng.gen();
-    let config = porep_config(sector_size, arbitrary_porep_id);
+    let config = porep_config(sector_size, ARBITRARY_POREP_ID);
     let ticket = rng.gen();
     let seed = rng.gen();
     let sector_id = rng.gen::<u64>().into();
@@ -778,10 +779,9 @@ fn create_fake_seal<R: rand::Rng, Tree: 'static + MerkleTreeTrait>(
 ) -> Result<(SectorId, NamedTempFile, Commitment, tempfile::TempDir)> {
     init_logger();
 
-    let arbitrary_porep_id = [28; 32];
     let sealed_sector_file = NamedTempFile::new()?;
 
-    let config = porep_config(sector_size, arbitrary_porep_id);
+    let config = porep_config(sector_size, ARBITRARY_POREP_ID);
 
     let cache_dir = tempfile::tempdir().unwrap();
 

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -167,12 +167,12 @@ fn run_resumable_seal(skip_proofs: bool, layer_to_delete: usize) {
     // Delete one layer, keep the other
     clear_cache_dir_keep_data_layer(&cache_dir);
     std::fs::remove_file(&layers[layer_to_delete]).expect("failed to remove layer");
-    let layers_removed = get_layer_file_paths(&cache_dir);
-    assert_eq!(layers_removed.len(), 1, "found more than one layer");
+    let layers_remaining = get_layer_file_paths(&cache_dir);
+    assert_eq!(layers_remaining.len(), 1, "expected one layer only");
     if layer_to_delete == 0 {
-        assert_eq!(layers_removed[0], layers[1], "wrong layer was removed");
+        assert_eq!(layers_remaining[0], layers[1], "wrong layer was removed");
     } else {
-        assert_eq!(layers_removed[0], layers[0], "wrong layer was removed");
+        assert_eq!(layers_remaining[0], layers[0], "wrong layer was removed");
     }
 
     // Resume the seal

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -216,7 +216,7 @@ fn run_resumable_seal(skip_proofs: bool, layer_to_delete: usize) {
             .expect("failed to validate cache for commit");
 
         let seed = rng.gen();
-        run_proof::<Tree>(
+        proof_and_unseal::<Tree>(
             config,
             cache_dir.path(),
             &sealed_sector_file,
@@ -638,7 +638,7 @@ fn run_seal_pre_commit_phase1<Tree: 'static + MerkleTreeTrait>(
     Ok((piece_infos, phase1_output))
 }
 
-fn run_proof<Tree: 'static + MerkleTreeTrait>(
+fn proof_and_unseal<Tree: 'static + MerkleTreeTrait>(
     config: PoRepConfig,
     cache_dir_path: &Path,
     sealed_sector_file: &NamedTempFile,
@@ -755,7 +755,7 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
     if skip_proof {
         clear_cache::<Tree>(cache_dir.path())?;
     } else {
-        run_proof::<Tree>(
+        proof_and_unseal::<Tree>(
             config,
             cache_dir.path(),
             &sealed_sector_file,


### PR DESCRIPTION
There is a short running version, which doesn't run the proofs and
a longer running one, which does run the proofs.

Currently tests fail when the proofs are running. I don't know why,
perhaps I'm removing files that are needed/not keeping files around
that should be kept.

It can easily be reproduced locally via:

    RUST_LOG=debug cargo test test_resumable_seal -- --ignored --nocapture

@cryptonemo Can you please have a look at the test itself, if it does what
you expect and then please also check why it is failing?