### PR TITLE
fix: fix log message

### DIFF
--- a/storage-proofs/post/src/fallback/vanilla.rs
+++ b/storage-proofs/post/src/fallback/vanilla.rs
@@ -506,7 +506,7 @@ impl<'a, Tree: 'a + MerkleTreeTrait> ProofScheme<'a> for FallbackPoSt<'a, Tree> 
                     &comm_r_last,
                 )) != AsRef::<[u8]>::as_ref(comm_r)
                 {
-                    error!("comm_c != comm_r_last: {:?}", sector_id);
+                    error!("hash(comm_c || comm_r_last) != comm_r: {:?}", sector_id);
                     return Ok(false);
                 }
 


### PR DESCRIPTION
The log message was wrong. It's about the hash of the concatenated
`comm_c` and `comm_r_last`.

This was brought up at
https://github.com/filecoin-project/rust-fil-proofs/issues/1308#issuecomment-706824651

For the notation I used `||` for concatenation as in the comment above.
I don't know about notations for hashes. I'm more familiar with `++` or `.` as concatenation
operator (in programming languages).