### PR TITLE
fix: remove no longer used exports

### DIFF
--- a/filecoin-proofs/src/types/mod.rs
+++ b/filecoin-proofs/src/types/mod.rs
@@ -31,9 +31,6 @@ pub use stacked::TemporaryAux;
 pub type ProverId = [u8; 32];
 pub type Ticket = [u8; 32];
 
-pub type Tree = storage_proofs::merkle::OctMerkleTree<DefaultTreeHasher>;
-pub type LCTree = storage_proofs::merkle::OctLCMerkleTree<DefaultTreeHasher>;
-
 pub use storage_proofs::porep::stacked::Labels;
 pub type DataTree = storage_proofs::merkle::BinaryMerkleTree<DefaultPieceHasher>;
 

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -117,22 +117,22 @@ fn clear_cache_dir_keep_data_layer(cache_dir: &tempfile::TempDir) {
 
 #[test]
 fn test_resumable_seal_skip_proofs() {
-    run_resumable_seal(true, 0);
-    run_resumable_seal(true, 1);
+    run_resumable_seal::<SectorShape2KiB>(true, 0);
+    run_resumable_seal::<SectorShape2KiB>(true, 1);
 }
 
 #[test]
 #[ignore]
 fn test_resumable_seal() {
-    run_resumable_seal(false, 0);
-    run_resumable_seal(false, 1);
+    run_resumable_seal::<SectorShape2KiB>(false, 0);
+    run_resumable_seal::<SectorShape2KiB>(false, 1);
 }
 
 /// Create a seal, delete a layer and resume
 ///
 /// The current code works on two layers only. The `layer_to_delete` specifies (zero-based) which
 /// layer should be deleted.
-fn run_resumable_seal(skip_proofs: bool, layer_to_delete: usize) {
+fn run_resumable_seal<Tree: 'static + MerkleTreeTrait>(skip_proofs: bool, layer_to_delete: usize) {
     init_logger();
 
     let sector_size = SECTOR_SIZE_2_KIB;


### PR DESCRIPTION
Use `DefaultOctTree` and `DefaultOctLCTree` instead of `Tree` and `LCTree`.