### PR TITLE
Downgrade neptune to v1.1.x.

### DIFF
--- a/storage-proofs/core/Cargo.toml
+++ b/storage-proofs/core/Cargo.toml
@@ -40,7 +40,7 @@ hex = "0.4.0"
 generic-array = "0.13.2"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
-neptune = { version = "=1.2.1", features = ["gpu"] }
+neptune = { version = "=1.1", features = ["gpu"] }
 cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"

--- a/storage-proofs/porep/Cargo.toml
+++ b/storage-proofs/porep/Cargo.toml
@@ -30,7 +30,7 @@ log = "0.4.7"
 pretty_assertions = "0.6.1"
 generic-array = "0.13.2"
 anyhow = "1.0.23"
-neptune = { version = "=1.2.1", features = ["gpu"] }
+neptune = { version = "=1.1", features = ["gpu"] }
 num_cpus = "1.10.1"
 hex = "0.4.2"
 bincode = "1.1.2"

--- a/storage-proofs/post/Cargo.toml
+++ b/storage-proofs/post/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4.7"
 hex = "0.4.0"
 generic-array = "0.13.2"
 anyhow = "1.0.23"
-neptune = { version = "=1.2.1", features = ["gpu"] }
+neptune = { version = "=1.1", features = ["gpu"] }
 num_cpus = "1.10.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Some problems reported in #1320 appear to be caused by neptune v1.2.0 — which has not actually been incorporated in a `rust-fil-proofs` release yet. We should downgrade to `1.1.2` for now. I'm only specifying `1.1` here so we will get any further patches needed before moving to `2.x`. We may need new API/FFI releases or branches in order to get a revised version of https://github.com/filecoin-project/lotus/tree/feat/proofs-5.2.3 working. We should do that, though, so wider testing of multicore SDR can continue.