### PR TITLE
Improve preserve cache

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -596,7 +596,7 @@ pub fn run(
     // If 'preserve_cache' is specified, the 'cache' option must be specified and must not exist on disk.
     if preserve_cache {
         ensure!(
-            cache_dir_specified && !Path::new(&PathBuf::from(&cache)).exists(),
+            cache_dir_specified && !PathBuf::from(&cache).exists(),
             "The 'preserve_cache' option cannot be used with a cache_dir that already exists"
         );
     }

--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -595,8 +595,10 @@ pub fn run(
 
     // If 'preserve_cache' is specified, the 'cache' option must be specified and must not exist on disk.
     if preserve_cache {
-        ensure!(cache_dir_specified && !Path::new(&PathBuf::from(&cache)).exists(),
-                "The 'preserve_cache' option cannot be used with a cache_dir that already exists");
+        ensure!(
+            cache_dir_specified && !Path::new(&PathBuf::from(&cache)).exists(),
+            "The 'preserve_cache' option cannot be used with a cache_dir that already exists"
+        );
     }
 
     if skip_precommit_phase1 || skip_precommit_phase2 || skip_commit_phase1 || skip_commit_phase2 {

--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::fs::{create_dir, read, read_to_string, remove_dir_all, File, OpenOptions};
 use std::io::{stdout, Seek, SeekFrom, Write};
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{ensure, Context};
@@ -623,7 +623,7 @@ pub fn run(
         )
     };
 
-    if !Path::new(&cache_dir).exists() {
+    if !cache_dir.exists() {
         create_dir(&cache_dir)?;
     }
     info!("Using cache directory {:?}", cache_dir);

--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -592,6 +592,13 @@ pub fn run(
     info!("Benchy Window PoSt: sector-size={}, api_version={}, preserve_cache={}, skip_precommit_phase1={}, skip_precommit_phase2={}, skip_commit_phase1={}, skip_commit_phase2={}, test_resume={}", sector_size, api_version, preserve_cache, skip_precommit_phase1, skip_precommit_phase2, skip_commit_phase1, skip_commit_phase2, test_resume);
 
     let cache_dir_specified = !cache.is_empty();
+
+    // If 'preserve_cache' is specified, the 'cache' option must be specified and must not exist on disk.
+    if preserve_cache {
+        ensure!(cache_dir_specified && !Path::new(&PathBuf::from(&cache)).exists(),
+                "The 'preserve_cache' option cannot be used with a cache_dir that already exists");
+    }
+
     if skip_precommit_phase1 || skip_precommit_phase2 || skip_commit_phase1 || skip_commit_phase2 {
         ensure!(
             !preserve_cache,

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -86,7 +86,6 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         t_aux: &TemporaryAuxCache<Tree, G>,
         layer_challenges: &LayerChallenges,
         layers: usize,
-        _total_layers: usize,
         partition_count: usize,
     ) -> Result<Vec<Vec<Proof<Tree, G>>>> {
         assert!(layers > 0);

--- a/storage-proofs/porep/src/stacked/vanilla/proof_scheme.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof_scheme.rs
@@ -72,7 +72,6 @@ impl<'a, 'c, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> ProofScheme<'
             &priv_inputs.t_aux,
             &pub_params.layer_challenges,
             pub_params.layer_challenges.layers(),
-            pub_params.layer_challenges.layers(),
             partition_count,
         )
     }


### PR DESCRIPTION
Window post bench preserve_cache option should only be used on new/non-existent cache dirs.  This check enforces this.

This PR also removes an unrelated unused argument.