### PR TITLE
refactor: move fr32 into its own crate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -622,3 +622,15 @@ workflows:
             branches:
               only:
                 - master
+
+      - test:
+          name: test_fr32
+          crate: "fr32"
+          requires:
+            - cargo_fetch
+
+      - test_blst:
+          name: test_blst_fr32
+          crate: "fr32"
+          requires:
+            - cargo_fetch

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "storage-proofs/post",
   "fil-proofs-tooling",
   "fil-proofs-param",
+  "fr32",
   "sha2raw",
   "filecoin-hashers",
 ]

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -37,6 +37,7 @@ gperftools = { version = "0.2", optional = true }
 generic-array = "0.14.4"
 groupy = "0.3.0"
 byte-slice-cast = "1.0.0"
+fr32 = { path = "../fr32", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -51,9 +52,9 @@ cpu-profile = ["gperftools"]
 heap-profile = ["gperftools/heap"]
 simd = ["storage-proofs/simd"]
 asm = ["storage-proofs/asm"]
-gpu = ["storage-proofs/gpu", "bellperson/gpu", "filecoin-hashers/gpu"]
-pairing = ["storage-proofs/pairing", "bellperson/pairing", "filecoin-hashers/pairing"]
-blst = ["storage-proofs/blst", "bellperson/blst", "filecoin-hashers/blst"]
+gpu = ["storage-proofs/gpu", "bellperson/gpu", "filecoin-hashers/gpu", "fr32/gpu"]
+pairing = ["storage-proofs/pairing", "bellperson/pairing", "filecoin-hashers/pairing", "fr32/pairing"]
+blst = ["storage-proofs/blst", "bellperson/blst", "filecoin-hashers/blst", "fr32/blst"]
 
 [[bench]]
 name = "preprocessing"

--- a/filecoin-proofs/benches/preprocessing.rs
+++ b/filecoin-proofs/benches/preprocessing.rs
@@ -2,7 +2,8 @@ use std::io::{self, Read};
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion, ParameterizedBenchmark, Throughput};
-use filecoin_proofs::{add_piece, fr32_reader::Fr32Reader, PaddedBytesAmount, UnpaddedBytesAmount};
+use filecoin_proofs::{add_piece, PaddedBytesAmount, UnpaddedBytesAmount};
+use fr32::Fr32Reader;
 use rand::{thread_rng, Rng};
 
 #[cfg(feature = "cpu-profile")]

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{ensure, Context, Result};
 use bincode::deserialize;
 use filecoin_hashers::Hasher;
+use fr32::{write_unpadded, Fr32Reader};
 use log::info;
 use merkletree::store::{DiskStore, LevelCacheStore, StoreConfig};
 use storage_proofs::cache_key::CacheKey;
@@ -24,7 +25,6 @@ use crate::constants::{
     DefaultBinaryTree, DefaultOctTree, DefaultPieceDomain, DefaultPieceHasher,
     MINIMUM_RESERVED_BYTES_FOR_PIECE_IN_FULLY_ALIGNED_SECTOR as MINIMUM_PIECE_SIZE,
 };
-use crate::fr32::write_unpadded;
 use crate::parameters::public_params;
 use crate::types::{
     Commitment, MerkleTreeTrait, PaddedBytesAmount, PieceInfo, PoRepConfig, PoRepProofPartitions,
@@ -217,7 +217,7 @@ pub fn generate_piece_commitment<T: std::io::Read>(
 
         // send the source through the preprocessor
         let source = std::io::BufReader::new(source);
-        let mut fr32_reader = crate::fr32_reader::Fr32Reader::new(source);
+        let mut fr32_reader = Fr32Reader::new(source);
 
         let commitment = generate_piece_commitment_bytes_from_source::<DefaultPieceHasher>(
             &mut fr32_reader,
@@ -270,7 +270,7 @@ where
 
         let written_bytes = crate::pieces::sum_piece_bytes_with_alignment(&piece_lengths);
         let piece_alignment = crate::pieces::get_piece_alignment(written_bytes, piece_size);
-        let fr32_reader = crate::fr32_reader::Fr32Reader::new(source);
+        let fr32_reader = Fr32Reader::new(source);
 
         // write left alignment
         for _ in 0..usize::from(PaddedBytesAmount::from(piece_alignment.left_bytes)) {

--- a/filecoin-proofs/src/api/util.rs
+++ b/filecoin-proofs/src/api/util.rs
@@ -1,8 +1,8 @@
 use anyhow::{Context, Result};
 use bellperson::bls::Fr;
 use filecoin_hashers::{Domain, Hasher};
+use fr32::{bytes_into_fr, fr_into_bytes};
 use merkletree::merkle::{get_merkle_tree_leafs, get_merkle_tree_len};
-use storage_proofs::fr32::{bytes_into_fr, fr_into_bytes};
 use storage_proofs::merkle::{get_base_tree_count, MerkleTreeTrait};
 use typenum::Unsigned;
 

--- a/filecoin-proofs/src/commitment_reader.rs
+++ b/filecoin-proofs/src/commitment_reader.rs
@@ -90,13 +90,14 @@ mod tests {
 
     use crate::types::*;
 
+    use fr32::Fr32Reader;
     use storage_proofs::pieces::generate_piece_commitment_bytes_from_source;
 
     #[test]
     fn test_commitment_reader() {
         let piece_size = 127 * 8;
         let source = vec![255u8; piece_size];
-        let mut fr32_reader = crate::fr32_reader::Fr32Reader::new(io::Cursor::new(&source));
+        let mut fr32_reader = Fr32Reader::new(io::Cursor::new(&source));
 
         let commitment1 = generate_piece_commitment_bytes_from_source::<DefaultPieceHasher>(
             &mut fr32_reader,
@@ -104,7 +105,7 @@ mod tests {
         )
         .expect("failed to generate piece commitment bytes from source");
 
-        let fr32_reader = crate::fr32_reader::Fr32Reader::new(io::Cursor::new(&source));
+        let fr32_reader = Fr32Reader::new(io::Cursor::new(&source));
         let mut commitment_reader = CommitmentReader::new(fr32_reader);
         io::copy(&mut commitment_reader, &mut io::sink()).expect("io copy failed");
 

--- a/filecoin-proofs/src/lib.rs
+++ b/filecoin-proofs/src/lib.rs
@@ -6,8 +6,6 @@ mod caches;
 mod commitment_reader;
 
 pub mod constants;
-pub mod fr32;
-pub mod fr32_reader;
 pub mod param;
 pub mod parameters;
 pub mod pieces;

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 
 use anyhow::{ensure, Context, Result};
 use filecoin_hashers::{HashFunction, Hasher};
+use fr32::Fr32Reader;
 use lazy_static::lazy_static;
 use log::info;
 use storage_proofs::util::NODE_SIZE;
@@ -33,7 +34,6 @@ lazy_static! {
     static ref COMMITMENTS: Mutex<HashMap<SectorSize, Commitment>> = Mutex::new(HashMap::new());
 }
 use crate::commitment_reader::CommitmentReader;
-use crate::fr32_reader::Fr32Reader;
 
 #[derive(Debug, Clone)]
 pub struct EmptySource {

--- a/filecoin-proofs/src/types/bytes_amount.rs
+++ b/filecoin-proofs/src/types/bytes_amount.rs
@@ -1,8 +1,7 @@
 use std::ops::{Add, Sub};
 
+use fr32::{to_padded_bytes, to_unpadded_bytes};
 use serde::{Deserialize, Serialize};
-
-use crate::fr32::{to_padded_bytes, to_unpadded_bytes};
 
 pub struct PoStProofBytesAmount(pub usize);
 

--- a/filecoin-proofs/src/types/sector_size.rs
+++ b/filecoin-proofs/src/types/sector_size.rs
@@ -1,4 +1,5 @@
-use crate::fr32::to_unpadded_bytes;
+use fr32::to_unpadded_bytes;
+
 use crate::types::*;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/filecoin-proofs/tests/mod.rs
+++ b/filecoin-proofs/tests/mod.rs
@@ -1,10 +1,10 @@
 use bellperson::bls::Fr;
 use ff::Field;
+use fr32::bytes_into_fr;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 
 use storage_proofs::api_version::ApiVersion;
-use storage_proofs::fr32::bytes_into_fr;
 use storage_proofs::sector::SectorId;
 
 use filecoin_proofs::as_safe_commitment;

--- a/fr32/Cargo.toml
+++ b/fr32/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "fr32"
+version = "0.1.0"
+authors = ["dignifiedquire <me@dignifiedquire.com>"]
+description = "Filecoin proofs Fr/32-byte conversion tooling"
+license = "MIT OR Apache-2.0"
+edition = "2018"
+repository = "https://github.com/filecoin-project/rust-fil-proofs"
+
+[dependencies]
+anyhow = "1.0.23"
+bellperson = { version = "0.12.3", default-features = false }
+byte-slice-cast = "1.0.0"
+byteorder = "1"
+ff = { version = "0.2.3", package = "fff" }
+thiserror = "1.0.6"
+
+[dev-dependencies]
+bitvec = "0.17"
+criterion = "0.3"
+itertools = "0.9"
+pretty_assertions = "0.6.1"
+rand = "0.7"
+rand_xorshift = "0.2.0"
+
+[features]
+default = ["pairing"]
+blst = ["bellperson/blst"]
+gpu = ["bellperson/gpu"]
+pairing = ["bellperson/pairing"]
+
+[[bench]]
+name = "fr"
+harness = false

--- a/fr32/benches/fr.rs
+++ b/fr32/benches/fr.rs
@@ -1,8 +1,8 @@
 use bellperson::bls::Fr;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ff::Field;
+use fr32::{bytes_into_fr, fr_into_bytes};
 use rand::thread_rng;
-use storage_proofs_core::fr32::{bytes_into_fr, fr_into_bytes};
 
 fn fr_benchmark(c: &mut Criterion) {
     c.bench_function("fr-to-bytes-32", move |b| {

--- a/fr32/src/convert.rs
+++ b/fr32/src/convert.rs
@@ -1,59 +1,48 @@
-use crate::error::*;
-
-use anyhow::ensure;
+#[cfg(any(feature = "pairing", feature = "blst"))]
+use anyhow::Result;
 use bellperson::bls::{Fr, FrRepr};
-use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
+use byteorder::{ByteOrder, LittleEndian};
+use ff::PrimeField;
+#[cfg(feature = "pairing")]
+use ff::PrimeFieldRepr;
 
-// Contains 32 bytes whose little-endian value represents an Fr.
-// Invariants:
-// - Value MUST represent a valid Fr.
-// - Length must be 32.
-pub type Fr32 = [u8];
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("Bytes could not be converted to Fr")]
+    BadFrBytes,
+}
 
-// Contains one or more 32-byte chunks whose little-endian values represent Frs.
-// Invariants:
-// - Value of each 32-byte chunks MUST represent valid Frs.
-// - Total length must be a multiple of 32.
-// That is to say: each 32-byte chunk taken alone must be a valid Fr32.
+/// Contains one or more 32-byte chunks whose little-endian values represent Frs.
+/// Invariants:
+/// - Value of each 32-byte chunks MUST represent valid Frs.
+/// - Total length must be a multiple of 32.
+/// That is to say: each 32-byte chunk taken alone must be a valid Fr32.
 pub type Fr32Vec = Vec<u8>;
 
-// Array whose little-endian value represents an Fr.
-// Invariants:
-// - Value MUST represent a valid Fr.
+/// Array whose little-endian value represents an Fr.
+/// Invariants:
+/// - Value MUST represent a valid Fr.
 pub type Fr32Ary = [u8; 32];
 
-// Takes a slice of bytes and returns an Fr if byte slice is exactly 32 bytes and does not overflow.
-// Otherwise, returns a BadFrBytesError.
+/// Takes a slice of bytes and returns an Fr if byte slice is exactly 32 bytes and does not overflow.
+/// Otherwise, returns a BadFrBytesError.
 #[cfg(feature = "pairing")]
 pub fn bytes_into_fr(bytes: &[u8]) -> Result<Fr> {
-    use anyhow::Context;
-    use ff::{PrimeField, PrimeFieldRepr};
-
+    use anyhow::{ensure, Context};
     ensure!(bytes.len() == 32, Error::BadFrBytes);
-
-    let mut fr_repr = <<Fr as PrimeField>::Repr as Default>::default();
+    let mut fr_repr = FrRepr::default();
     fr_repr.read_le(bytes).context(Error::BadFrBytes)?;
-
     Fr::from_repr(fr_repr).map_err(|_| Error::BadFrBytes.into())
 }
 
 #[cfg(feature = "blst")]
 pub fn bytes_into_fr(bytes: &[u8]) -> Result<Fr> {
     use std::convert::TryInto;
-
     Fr::from_bytes_le(bytes.try_into().map_err(|_| Error::BadFrBytes)?)
         .ok_or_else(|| Error::BadFrBytes.into())
 }
 
-#[inline]
-pub fn trim_bytes_to_fr_safe(r: &[u8]) -> Result<Vec<u8>> {
-    ensure!(r.len() == 32, Error::BadFrBytes);
-    let mut res = r[..32].to_vec();
-    // strip last two bits, to ensure result is in Fr.
-    res[31] &= 0b0011_1111;
-    Ok(res)
-}
-
+/// Bytes is little-endian.
 #[inline]
 pub fn bytes_into_fr_repr_safe(r: &[u8]) -> FrRepr {
     debug_assert!(r.len() == 32);
@@ -75,11 +64,9 @@ pub fn bytes_into_fr_repr_safe(r: &[u8]) -> FrRepr {
     FrRepr(repr)
 }
 
-// Takes an Fr and returns a vector of exactly 32 bytes guaranteed to contain a valid Fr.
+/// Takes an Fr and returns a vector of exactly 32 bytes guaranteed to contain a valid Fr.
 #[cfg(feature = "pairing")]
 pub fn fr_into_bytes(fr: &Fr) -> Fr32Vec {
-    use ff::{PrimeField, PrimeFieldRepr};
-
     let mut out = Vec::with_capacity(32);
     fr.into_repr().write_le(&mut out).expect("write_le failure");
     out
@@ -90,37 +77,8 @@ pub fn fr_into_bytes(fr: &Fr) -> Fr32Vec {
     fr.to_bytes_le().to_vec()
 }
 
-// Takes a slice of bytes and returns a vector of Fr -- or an error if either bytes is not a multiple of 32 bytes
-// or any 32-byte chunk overflows and does not contain a valid Fr.
-pub fn bytes_into_frs(bytes: &[u8]) -> Result<Vec<Fr>> {
-    bytes
-        .chunks(32)
-        .map(|ref chunk| bytes_into_fr(chunk))
-        .collect()
-}
-
-// Takes a slice of Frs and returns a vector of bytes, guaranteed to have a size which is a multiple of 32,
-// with every 32-byte chunk representing a valid Fr.
-pub fn frs_into_bytes(frs: &[Fr]) -> Fr32Vec {
-    frs.iter().flat_map(|fr| fr_into_bytes(fr)).collect()
-}
-
-// Takes a u32 and returns an Fr.
-pub fn u32_into_fr(n: u32) -> Fr {
-    let mut buf: Fr32Vec = vec![0u8; 32];
-    let mut w = &mut buf[0..4];
-    w.write_u32::<LittleEndian>(n).expect("write_u32 failure");
-
-    bytes_into_fr(&buf).expect("should never fail since u32 is in the field")
-}
-
-// Takes a u64 and returns an Fr.
 pub fn u64_into_fr(n: u64) -> Fr {
-    let mut buf: Fr32Vec = vec![0u8; 32];
-    let mut w = &mut buf[0..8];
-    w.write_u64::<LittleEndian>(n).expect("write_u64 failure");
-
-    bytes_into_fr(&buf).expect("should never fail since u64 is in the field")
+    Fr::from_repr(FrRepr::from(n)).expect("failed to convert u64 into Fr (should never fail)")
 }
 
 #[cfg(test)]
@@ -133,12 +91,12 @@ mod tests {
         if expect_success {
             let f = fr_result.expect("Failed to convert bytes to `Fr`");
             let b2 = fr_into_bytes(&f);
-
             assert_eq!(bytes.to_vec(), b2);
         } else {
             assert!(fr_result.is_err(), "expected a decoding error")
         }
     }
+
     #[test]
     fn test_bytes_into_fr_into_bytes() {
         bytes_fr_test(
@@ -180,22 +138,5 @@ mod tests {
             ],
             false,
         );
-    }
-
-    fn bytes_into_frs_into_bytes_test(bytes: &Fr32) {
-        let frs = bytes_into_frs(bytes).expect("Failed to convert bytes into a `Vec<Fr>`");
-        assert!(frs.len() == 3);
-        let bytes_back = frs_into_bytes(&frs);
-        assert!(bytes.to_vec() == bytes_back);
-    }
-
-    #[test]
-    fn test_bytes_into_frs_into_bytes() {
-        let bytes = b"012345678901234567890123456789--012345678901234567890123456789--012345678901234567890123456789--";
-        bytes_into_frs_into_bytes_test(&bytes[..]);
-
-        let _short_bytes = b"012345678901234567890123456789--01234567890123456789";
-        // This will panic because _short_bytes is not a multiple of 32 bytes.
-        // bytes_into_frs_into_bytes_test(&_short_bytes[..]);
     }
 }

--- a/fr32/src/lib.rs
+++ b/fr32/src/lib.rs
@@ -1,0 +1,7 @@
+mod convert;
+mod padding;
+mod reader;
+
+pub use convert::*;
+pub use padding::*;
+pub use reader::*;

--- a/fr32/src/reader.rs
+++ b/fr32/src/reader.rs
@@ -1,5 +1,6 @@
-use byte_slice_cast::*;
 use std::io;
+
+use byte_slice_cast::{AsByteSlice, AsSliceOf};
 
 /// The number of Frs per Block.
 const NUM_FRS_PER_BLOCK: usize = 4;
@@ -169,8 +170,12 @@ impl<R: io::Read> io::Read for Fr32Reader<R> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pretty_assertions::assert_eq;
+
     use std::io::Read;
+
+    use pretty_assertions::assert_eq;
+
+    use crate::bytes_into_fr;
 
     const DATA_BITS: u64 = 254;
     const TARGET_BITS: u64 = 256;
@@ -334,7 +339,7 @@ mod tests {
     fn validate_fr32(bytes: &[u8]) {
         let chunks = (bytes.len() as f64 / 32_f64).ceil() as usize;
         for (i, chunk) in bytes.chunks(32).enumerate() {
-            let _ = storage_proofs::fr32::bytes_into_fr(chunk).unwrap_or_else(|_| {
+            let _ = bytes_into_fr(chunk).unwrap_or_else(|_| {
                 panic!(
                     "chunk {}/{} cannot be converted to valid Fr: {:?}",
                     i + 1,

--- a/storage-proofs/core/Cargo.toml
+++ b/storage-proofs/core/Cargo.toml
@@ -44,6 +44,7 @@ cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"
 semver = "0.11.0"
+fr32 = { path = "../../fr32", default-features = false }
 
 [dev-dependencies]
 proptest = "0.10"
@@ -62,9 +63,9 @@ big-sector-sizes-bench = []
 measurements = ["cpu-time", "gperftools"]
 profile = ["measurements"]
 
-gpu = ["bellperson/gpu", "neptune/gpu", "filecoin-hashers/gpu"]
-pairing = ["bellperson/pairing", "neptune/pairing", "bellperson/pairing-serde", "filecoin-hashers/pairing"]
-blst = ["bellperson/blst", "neptune/blst", "bellperson/blst-serde", "filecoin-hashers/blst"]
+gpu = ["bellperson/gpu", "neptune/gpu", "filecoin-hashers/gpu", "fr32/gpu"]
+pairing = ["bellperson/pairing", "neptune/pairing", "bellperson/pairing-serde", "filecoin-hashers/pairing", "fr32/pairing"]
+blst = ["bellperson/blst", "neptune/blst", "bellperson/blst-serde", "filecoin-hashers/blst", "fr32/blst"]
 
 [[bench]]
 name = "sha256"
@@ -80,10 +81,6 @@ harness = false
 
 [[bench]]
 name = "xor"
-harness = false
-
-[[bench]]
-name = "fr"
 harness = false
 
 [[bench]]

--- a/storage-proofs/core/src/drgraph.rs
+++ b/storage-proofs/core/src/drgraph.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 
 use anyhow::ensure;
 use filecoin_hashers::{Hasher, PoseidonArity};
+use fr32::bytes_into_fr_repr_safe;
 use generic_array::typenum;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
@@ -11,7 +12,6 @@ use sha2::{Digest, Sha256};
 use crate::api_version::ApiVersion;
 use crate::crypto::{derive_porep_domain_seed, DRSAMPLE_DST};
 use crate::error::*;
-use crate::fr32::bytes_into_fr_repr_safe;
 use crate::parameter_cache::ParameterSetMetadata;
 use crate::util::{data_at_node_offset, NODE_SIZE};
 use crate::PoRepID;

--- a/storage-proofs/core/src/error.rs
+++ b/storage-proofs/core/src/error.rs
@@ -8,8 +8,6 @@ pub use anyhow::Result;
 /// Custom error types
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("Bytes could not be converted to Fr")]
-    BadFrBytes,
     #[error("Could not create PieceInclusionProof (probably bad piece commitment: comm_p)")]
     BadPieceCommitment,
     #[error("Out of bounds access {} > {}", _0, _1)]

--- a/storage-proofs/core/src/gadgets/por.rs
+++ b/storage-proofs/core/src/gadgets/por.rs
@@ -513,6 +513,7 @@ mod tests {
 
     use bellperson::gadgets::multipack;
     use ff::Field;
+    use fr32::{bytes_into_fr, fr_into_bytes};
     use generic_array::typenum;
     use merkletree::store::VecStore;
     use pretty_assertions::assert_eq;
@@ -520,7 +521,6 @@ mod tests {
     use rand_xorshift::XorShiftRng;
 
     use crate::compound_proof;
-    use crate::fr32::{bytes_into_fr, fr_into_bytes};
     use crate::merkle::{
         create_base_merkle_tree, generate_tree, get_base_tree_count, MerkleProofTrait,
         MerkleTreeWrapper, ResTree,

--- a/storage-proofs/core/src/lib.rs
+++ b/storage-proofs/core/src/lib.rs
@@ -14,7 +14,6 @@ pub mod crypto;
 pub mod data;
 pub mod drgraph;
 pub mod error;
-pub mod fr32;
 pub mod gadgets;
 pub mod measurements;
 pub mod merkle;

--- a/storage-proofs/core/src/pieces.rs
+++ b/storage-proofs/core/src/pieces.rs
@@ -2,10 +2,10 @@ use std::io::Read;
 
 use anyhow::{ensure, Context};
 use filecoin_hashers::{Domain, Hasher};
+use fr32::Fr32Ary;
 use merkletree::merkle::next_pow2;
 
 use crate::error::*;
-use crate::fr32::Fr32Ary;
 use crate::merkle::BinaryMerkleTree;
 use crate::util::NODE_SIZE;
 

--- a/storage-proofs/core/src/util.rs
+++ b/storage-proofs/core/src/util.rs
@@ -178,7 +178,6 @@ pub fn default_rows_to_discard(leafs: usize, arity: usize) -> usize {
 mod tests {
     use super::*;
 
-    use crate::fr32::fr_into_bytes;
     use bellperson::bls::*;
     use bellperson::gadgets::boolean::Boolean;
     use bellperson::gadgets::num;
@@ -186,6 +185,7 @@ mod tests {
     use bellperson::ConstraintSystem;
     use ff::Field;
     use filecoin_hashers::{sha256::*, HashFunction};
+    use fr32::fr_into_bytes;
     use merkletree::hash::Algorithm;
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;

--- a/storage-proofs/core/tests/por_circuit.rs
+++ b/storage-proofs/core/tests/por_circuit.rs
@@ -8,6 +8,7 @@ use ff::Field;
 use filecoin_hashers::{
     blake2s::Blake2sHasher, poseidon::PoseidonHasher, sha256::Sha256Hasher, Domain, Hasher,
 };
+use fr32::{bytes_into_fr, fr_into_bytes};
 use generic_array::typenum::{Unsigned, U0, U2, U4, U8};
 use merkletree::store::VecStore;
 use pretty_assertions::assert_eq;
@@ -15,7 +16,6 @@ use rand::{Rng, SeedableRng};
 use rand_xorshift::XorShiftRng;
 use storage_proofs_core::{
     compound_proof::CompoundProof,
-    fr32::{bytes_into_fr, fr_into_bytes},
     gadgets::por::{
         challenge_into_auth_path_bits, por_no_challenge_input, PoRCircuit, PoRCompound,
     },

--- a/storage-proofs/core/tests/por_compound.rs
+++ b/storage-proofs/core/tests/por_compound.rs
@@ -5,6 +5,7 @@ use bellperson::{
 };
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, Hasher};
+use fr32::{bytes_into_fr, fr_into_bytes};
 use generic_array::typenum::{U0, U2, U4, U8};
 use merkletree::store::VecStore;
 use pretty_assertions::assert_eq;
@@ -12,7 +13,6 @@ use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use storage_proofs_core::{
     compound_proof::{self, CompoundProof},
-    fr32::{bytes_into_fr, fr_into_bytes},
     gadgets::por::PoRCompound,
     merkle::{
         create_base_merkle_tree, generate_tree, get_base_tree_count, MerkleTreeTrait,

--- a/storage-proofs/core/tests/por_vanilla.rs
+++ b/storage-proofs/core/tests/por_vanilla.rs
@@ -5,13 +5,13 @@ use ff::Field;
 use filecoin_hashers::{
     blake2s::Blake2sHasher, poseidon::PoseidonHasher, sha256::Sha256Hasher, Domain, Hasher,
 };
+use fr32::fr_into_bytes;
 use generic_array::typenum::{U0, U2, U4};
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
 use storage_proofs_core::{
     api_version::ApiVersion,
     drgraph::{BucketGraph, Graph, BASE_DEGREE},
-    fr32::fr_into_bytes,
     merkle::{create_base_merkle_tree, DiskStore, MerkleTreeTrait, MerkleTreeWrapper},
     por::{self, PoR},
     proof::ProofScheme,

--- a/storage-proofs/porep/Cargo.toml
+++ b/storage-proofs/porep/Cargo.toml
@@ -39,6 +39,7 @@ byte-slice-cast = "1.0.0"
 hwloc = "0.3.0"
 libc = "0.2"
 fdlimit = "0.2.0"
+fr32 = { path = "../../fr32", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"
@@ -50,9 +51,9 @@ filecoin-hashers = { path = "../../filecoin-hashers", version = "1.0.0", default
 
 [features]
 default = ["pairing", "gpu"]
-gpu = ["storage-proofs-core/gpu", "filecoin-hashers/gpu", "neptune/gpu", "bellperson/gpu"]
-pairing = ["storage-proofs-core/pairing", "bellperson/pairing", "neptune/pairing", "filecoin-hashers/pairing"]
-blst = ["storage-proofs-core/blst", "bellperson/blst", "neptune/blst", "filecoin-hashers/blst"]
+gpu = ["storage-proofs-core/gpu", "filecoin-hashers/gpu", "neptune/gpu", "bellperson/gpu", "fr32/gpu"]
+pairing = ["storage-proofs-core/pairing", "bellperson/pairing", "neptune/pairing", "filecoin-hashers/pairing", "fr32/pairing"]
+blst = ["storage-proofs-core/blst", "bellperson/blst", "neptune/blst", "filecoin-hashers/blst", "fr32/blst"]
 single-threaded = []
 
 [[bench]]

--- a/storage-proofs/porep/benches/encode.rs
+++ b/storage-proofs/porep/benches/encode.rs
@@ -5,9 +5,9 @@ use filecoin_hashers::{
     sha256::Sha256Hasher,
     {Domain, Hasher},
 };
+use fr32::fr_into_bytes;
 use rand::thread_rng;
 use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::fr32::fr_into_bytes;
 use storage_proofs_porep::stacked::{
     create_label::single::{create_label, create_label_exp},
     StackedBucketGraph,

--- a/storage-proofs/porep/src/drg/vanilla.rs
+++ b/storage-proofs/porep/src/drg/vanilla.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::{ensure, Context};
 use filecoin_hashers::{Domain, HashFunction, Hasher, PoseidonArity};
+use fr32::bytes_into_fr_repr_safe;
 use generic_array::typenum;
 use merkletree::store::{ReplicaConfig, StoreConfig};
 use rayon::prelude::*;
@@ -14,7 +15,6 @@ use storage_proofs_core::{
     crypto::sloth,
     drgraph::Graph,
     error::Result,
-    fr32::bytes_into_fr_repr_safe,
     merkle::{
         create_base_lcmerkle_tree, create_base_merkle_tree, BinaryLCMerkleTree, BinaryMerkleTree,
         LCMerkleTree, MerkleProof, MerkleProofTrait, MerkleTreeTrait,

--- a/storage-proofs/porep/src/stacked/circuit/create_label.rs
+++ b/storage-proofs/porep/src/stacked/circuit/create_label.rs
@@ -74,12 +74,12 @@ mod tests {
     use bellperson::util_cs::test_cs::TestConstraintSystem;
     use ff::Field;
     use filecoin_hashers::sha256::Sha256Hasher;
+    use fr32::{bytes_into_fr, fr_into_bytes};
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
     use storage_proofs_core::{
         api_version::ApiVersion,
         drgraph::{Graph, BASE_DEGREE},
-        fr32::{bytes_into_fr, fr_into_bytes},
         util::{bytes_into_boolean_vec_be, data_at_node, NODE_SIZE},
         TEST_SEED,
     };

--- a/storage-proofs/porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs/porep/src/stacked/circuit/proof.rs
@@ -5,11 +5,11 @@ use bellperson::bls::{Bls12, Fr};
 use bellperson::gadgets::num;
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
 use filecoin_hashers::{HashFunction, Hasher};
+use fr32::u64_into_fr;
 use storage_proofs_core::{
     compound_proof::{CircuitComponent, CompoundProof},
     drgraph::Graph,
     error::Result,
-    fr32::u64_into_fr,
     gadgets::constraint,
     gadgets::por::PoRCompound,
     merkle::{BinaryMerkleTree, MerkleTreeTrait},

--- a/storage-proofs/porep/src/stacked/vanilla/encoding_proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/encoding_proof.rs
@@ -3,9 +3,9 @@ use std::marker::PhantomData;
 
 use bellperson::bls::Fr;
 use filecoin_hashers::Hasher;
+use fr32::bytes_into_fr_repr_safe;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use storage_proofs_core::fr32::bytes_into_fr_repr_safe;
 
 use crate::encode::encode;
 

--- a/storage-proofs/porep/src/stacked/vanilla/labeling_proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/labeling_proof.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
 use filecoin_hashers::Hasher;
+use fr32::bytes_into_fr_repr_safe;
 use log::trace;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use storage_proofs_core::fr32::bytes_into_fr_repr_safe;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LabelingProof<H: Hasher> {

--- a/storage-proofs/porep/src/stacked/vanilla/params.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/params.rs
@@ -4,14 +4,15 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use filecoin_hashers::{Domain, Hasher};
+use fr32::bytes_into_fr_repr_safe;
 use generic_array::typenum::{self, Unsigned};
 use log::trace;
 use merkletree::merkle::get_merkle_tree_leafs;
 use merkletree::store::{DiskStore, Store, StoreConfig};
 use serde::{Deserialize, Serialize};
 use storage_proofs_core::{
-    api_version::ApiVersion, drgraph::Graph, error::Result, fr32::bytes_into_fr_repr_safe,
-    merkle::*, parameter_cache::ParameterSetMetadata, util::data_at_node,
+    api_version::ApiVersion, drgraph::Graph, error::Result, merkle::*,
+    parameter_cache::ParameterSetMetadata, util::data_at_node,
 };
 
 use super::{

--- a/storage-proofs/porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs/porep/src/stacked/vanilla/proof.rs
@@ -434,12 +434,12 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     {
         use bellperson::bls::Fr;
         use ff::Field;
+        use fr32::fr_into_bytes;
         use generic_array::{sequence::GenericSequence, GenericArray};
         use merkletree::store::DiskStore;
         use neptune::batch_hasher::BatcherType;
         use neptune::column_tree_builder::{ColumnTreeBuilder, ColumnTreeBuilderTrait};
         use std::sync::{mpsc, Arc, RwLock};
-        use storage_proofs_core::fr32::fr_into_bytes;
 
         info!("generating tree c using the GPU");
         // Build the tree for CommC
@@ -788,13 +788,13 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         TreeArity: PoseidonArity,
     {
         use bellperson::bls::Fr;
+        use fr32::fr_into_bytes;
         use merkletree::merkle::{get_merkle_tree_cache_size, get_merkle_tree_leafs};
         use neptune::batch_hasher::BatcherType;
         use neptune::tree_builder::{TreeBuilder, TreeBuilderTrait};
         use std::fs::OpenOptions;
         use std::io::Write;
         use std::sync::mpsc;
-        use storage_proofs_core::fr32::fr_into_bytes;
 
         let (configs, replica_config) = split_config_and_replica(
             tree_r_last_config.clone(),
@@ -1299,12 +1299,12 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     {
         use bellperson::bls::Fr;
         use ff::Field;
+        use fr32::fr_into_bytes;
         use merkletree::merkle::{get_merkle_tree_cache_size, get_merkle_tree_leafs};
         use neptune::batch_hasher::BatcherType;
         use neptune::tree_builder::{TreeBuilder, TreeBuilderTrait};
         use std::fs::OpenOptions;
         use std::io::Write;
-        use storage_proofs_core::fr32::fr_into_bytes;
 
         let (configs, replica_config) = split_config_and_replica(
             tree_r_last_config.clone(),

--- a/storage-proofs/porep/tests/drg_circuit.rs
+++ b/storage-proofs/porep/tests/drg_circuit.rs
@@ -5,6 +5,7 @@ use bellperson::{
 };
 use ff::Field;
 use filecoin_hashers::poseidon::PoseidonHasher;
+use fr32::{bytes_into_fr, fr_into_bytes};
 use generic_array::typenum::U2;
 use merkletree::store::StoreConfig;
 use pretty_assertions::assert_eq;
@@ -15,7 +16,6 @@ use storage_proofs_core::{
     cache_key::CacheKey,
     compound_proof,
     drgraph::{graph_height, BucketGraph, BASE_DEGREE},
-    fr32::{bytes_into_fr, fr_into_bytes},
     gadgets::variables::Root,
     merkle::MerkleProofTrait,
     proof::ProofScheme,

--- a/storage-proofs/porep/tests/drg_compound.rs
+++ b/storage-proofs/porep/tests/drg_compound.rs
@@ -5,6 +5,7 @@ use bellperson::{
 };
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, Hasher};
+use fr32::fr_into_bytes;
 use merkletree::store::StoreConfig;
 use pretty_assertions::assert_eq;
 use rand::SeedableRng;
@@ -14,7 +15,6 @@ use storage_proofs_core::{
     cache_key::CacheKey,
     compound_proof::{self, CompoundProof},
     drgraph::{BucketGraph, BASE_DEGREE},
-    fr32::fr_into_bytes,
     merkle::{BinaryMerkleTree, MerkleTreeTrait},
     proof::NoRequirements,
     test_helper::setup_replica,

--- a/storage-proofs/porep/tests/drg_vanilla.rs
+++ b/storage-proofs/porep/tests/drg_vanilla.rs
@@ -1,6 +1,7 @@
 use bellperson::bls::Fr;
 use ff::Field;
 use filecoin_hashers::{blake2s::Blake2sHasher, sha256::Sha256Hasher, Domain, Hasher};
+use fr32::fr_into_bytes;
 use merkletree::store::StoreConfig;
 use pretty_assertions::assert_eq;
 use rand::SeedableRng;
@@ -9,7 +10,6 @@ use storage_proofs_core::{
     api_version::ApiVersion,
     cache_key::CacheKey,
     drgraph::{BucketGraph, BASE_DEGREE},
-    fr32::fr_into_bytes,
     merkle::{BinaryMerkleTree, MerkleTreeTrait},
     proof::ProofScheme,
     table_tests,

--- a/storage-proofs/porep/tests/stacked_circuit.rs
+++ b/storage-proofs/porep/tests/stacked_circuit.rs
@@ -5,6 +5,7 @@ use bellperson::{
 };
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, sha256::Sha256Hasher, Hasher};
+use fr32::fr_into_bytes;
 use generic_array::typenum::{U0, U2, U4, U8};
 use merkletree::store::StoreConfig;
 use rand::{Rng, SeedableRng};
@@ -14,7 +15,6 @@ use storage_proofs_core::{
     cache_key::CacheKey,
     compound_proof::CompoundProof,
     drgraph::BASE_DEGREE,
-    fr32::fr_into_bytes,
     merkle::{get_base_tree_count, DiskTree, MerkleTreeTrait},
     proof::ProofScheme,
     test_helper::setup_replica,

--- a/storage-proofs/porep/tests/stacked_compound.rs
+++ b/storage-proofs/porep/tests/stacked_compound.rs
@@ -5,6 +5,7 @@ use bellperson::{
 };
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, sha256::Sha256Hasher, Hasher};
+use fr32::fr_into_bytes;
 use generic_array::typenum::{U0, U2, U4, U8};
 use merkletree::store::StoreConfig;
 use rand::{Rng, SeedableRng};
@@ -14,7 +15,6 @@ use storage_proofs_core::{
     cache_key::CacheKey,
     compound_proof::{self, CompoundProof},
     drgraph::BASE_DEGREE,
-    fr32::fr_into_bytes,
     merkle::{get_base_tree_count, DiskTree, MerkleTreeTrait},
     test_helper::setup_replica,
     util::default_rows_to_discard,

--- a/storage-proofs/porep/tests/stacked_vanilla.rs
+++ b/storage-proofs/porep/tests/stacked_vanilla.rs
@@ -3,6 +3,7 @@ use ff::{Field, PrimeField};
 use filecoin_hashers::{
     blake2s::Blake2sHasher, poseidon::PoseidonHasher, sha256::Sha256Hasher, Domain, Hasher,
 };
+use fr32::fr_into_bytes;
 use generic_array::typenum::{U0, U2, U4, U8};
 use merkletree::store::{Store, StoreConfig};
 use rand::{Rng, SeedableRng};
@@ -11,7 +12,6 @@ use storage_proofs_core::{
     api_version::ApiVersion,
     cache_key::CacheKey,
     drgraph::BASE_DEGREE,
-    fr32::fr_into_bytes,
     merkle::{get_base_tree_count, DiskTree, MerkleTreeTrait},
     proof::ProofScheme,
     table_tests,

--- a/storage-proofs/post/Cargo.toml
+++ b/storage-proofs/post/Cargo.toml
@@ -28,6 +28,7 @@ generic-array = "0.14.4"
 anyhow = "1.0.23"
 neptune = { version = "2.2.0", default-features = false }
 num_cpus = "1.10.1"
+fr32 = { path = "../../fr32", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"
@@ -37,6 +38,6 @@ filecoin-hashers = { path = "../../filecoin-hashers", version = "1.0.0", default
 
 [features]
 default = ["pairing", "gpu"]
-gpu = ["storage-proofs-core/gpu", "filecoin-hashers/gpu"]
-pairing = ["storage-proofs-core/pairing", "bellperson/pairing", "neptune/pairing", "filecoin-hashers/pairing"]
-blst = ["storage-proofs-core/blst", "bellperson/blst", "neptune/blst", "filecoin-hashers/blst"]
+gpu = ["storage-proofs-core/gpu", "filecoin-hashers/gpu", "fr32/gpu"]
+pairing = ["storage-proofs-core/pairing", "bellperson/pairing", "neptune/pairing", "filecoin-hashers/pairing", "fr32/pairing"]
+blst = ["storage-proofs-core/blst", "bellperson/blst", "neptune/blst", "filecoin-hashers/blst", "fr32/blst"]

--- a/storage-proofs/post/src/election/vanilla.rs
+++ b/storage-proofs/post/src/election/vanilla.rs
@@ -9,6 +9,7 @@ use filecoin_hashers::{
     poseidon::{PoseidonDomain, PoseidonFunction},
     Domain, HashFunction, Hasher, PoseidonMDArity,
 };
+use fr32::fr_into_bytes;
 use generic_array::typenum;
 use log::trace;
 use rayon::prelude::*;
@@ -18,7 +19,6 @@ use typenum::Unsigned;
 
 use storage_proofs_core::{
     error::{Error, Result},
-    fr32::fr_into_bytes,
     measurements::{measure_op, Operation},
     merkle::{MerkleProof, MerkleProofTrait, MerkleTreeTrait, MerkleTreeWrapper},
     parameter_cache::ParameterSetMetadata,


### PR DESCRIPTION
Moves `storage-proofs::fr32` into it's own crate. 

Issue #1343