### PR TITLE
refactor: cleanup imports and remove globs

### DIFF
--- a/fil-proofs-param/tests/paramfetch/mod.rs
+++ b/fil-proofs-param/tests/paramfetch/mod.rs
@@ -1,29 +1,30 @@
-mod session;
-
-use std::collections::btree_map::BTreeMap;
+use std::collections::BTreeMap;
 use std::fs::File;
-use std::io::{BufReader, Write};
+use std::io::{self, BufReader, Write};
 use std::path::PathBuf;
 
 use blake2b_simd::State as Blake2b;
 use failure::Error as FailureError;
-use rand::Rng;
+use rand::{thread_rng, Rng};
 use storage_proofs_core::parameter_cache::{ParameterData, ParameterMap};
 
 use crate::support::tmp_manifest;
+
+mod session;
+
 use session::ParamFetchSessionBuilder;
 
 /// Produce a random sequence of bytes and first 32 characters of hex encoded
 /// BLAKE2b checksum. This helper function must be kept up-to-date with the
 /// parampublish implementation.
 fn rand_bytes_with_blake2b() -> Result<(Vec<u8>, String), FailureError> {
-    let bytes = rand::thread_rng().gen::<[u8; 32]>();
+    let bytes = thread_rng().gen::<[u8; 32]>();
 
     let mut hasher = Blake2b::new();
 
     let mut as_slice = &bytes[..];
 
-    std::io::copy(&mut as_slice, &mut hasher)?;
+    io::copy(&mut as_slice, &mut hasher)?;
 
     Ok((
         bytes.iter().cloned().collect(),

--- a/fil-proofs-param/tests/paramfetch/session.rs
+++ b/fil-proofs-param/tests/paramfetch/session.rs
@@ -1,11 +1,10 @@
 use std::fs::File;
-use std::io::Read;
+use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 
 use failure::SyncFailure;
 use rexpect::session::PtyReplSession;
-use tempfile;
-use tempfile::TempDir;
+use tempfile::{tempdir, TempDir};
 
 use crate::support::{cargo_bin, spawn_bash_with_retries};
 
@@ -19,7 +18,7 @@ pub struct ParamFetchSessionBuilder {
 
 impl ParamFetchSessionBuilder {
     pub fn new(manifest: Option<PathBuf>) -> ParamFetchSessionBuilder {
-        let temp_dir = tempfile::tempdir().expect("could not create temp dir");
+        let temp_dir = tempdir().expect("could not create temp dir");
 
         ParamFetchSessionBuilder {
             cache_dir: temp_dir,
@@ -56,7 +55,7 @@ impl ParamFetchSessionBuilder {
 
         let mut file = File::create(&pbuf).expect("failed to create file in temp dir");
 
-        std::io::copy(r, &mut file).expect("failed to copy bytes to file");
+        io::copy(r, &mut file).expect("failed to copy bytes to file");
 
         self
     }

--- a/fil-proofs-param/tests/parampublish/mod.rs
+++ b/fil-proofs-param/tests/parampublish/mod.rs
@@ -1,5 +1,4 @@
 pub mod prompts_to_publish;
 pub mod read_metadata_files;
-pub mod write_json_manifest;
-
 pub mod support;
+pub mod write_json_manifest;

--- a/fil-proofs-param/tests/parampublish/write_json_manifest.rs
+++ b/fil-proofs-param/tests/parampublish/write_json_manifest.rs
@@ -1,16 +1,16 @@
-use std::collections::btree_map::BTreeMap;
+use std::collections::BTreeMap;
 use std::fs::File;
 use std::path::Path;
 
-use failure::Error as FailureError;
-
 use storage_proofs_core::parameter_cache::{CacheEntryMetadata, ParameterData};
 
-use crate::parampublish::support::session::ParamPublishSessionBuilder;
-use crate::support::{tmp_manifest, FakeIpfsBin};
+use crate::{
+    parampublish::support::session::ParamPublishSessionBuilder,
+    support::{tmp_manifest, FakeIpfsBin},
+};
 
 #[test]
-fn writes_json_manifest() -> Result<(), FailureError> {
+fn writes_json_manifest() -> Result<(), failure::Error> {
     let filenames = vec!["v10-aaa.vk", "v10-aaa.params"];
 
     let manifest_path = tmp_manifest(None)?;

--- a/fil-proofs-param/tests/support/mod.rs
+++ b/fil-proofs-param/tests/support/mod.rs
@@ -1,15 +1,15 @@
+use std::collections::BTreeMap;
+use std::env;
+use std::fs::File;
 use std::path::{Path, PathBuf};
-use std::{env, thread};
+use std::process::Command;
+use std::thread;
+use std::time::Duration;
 
 use failure::format_err;
-use rexpect::session::PtyReplSession;
-use rexpect::spawn_bash;
+use rexpect::{session::PtyReplSession, spawn_bash};
 use storage_proofs_core::parameter_cache::ParameterData;
-
-use std::collections::btree_map::BTreeMap;
-use std::fs::File;
-use std::process::Command;
-use std::time::Duration;
+use tempfile::tempdir;
 
 pub struct FakeIpfsBin {
     bin_path: PathBuf,
@@ -87,7 +87,7 @@ pub fn spawn_bash_with_retries(
 pub fn tmp_manifest(
     opt_manifest: Option<BTreeMap<String, ParameterData>>,
 ) -> Result<PathBuf, failure::Error> {
-    let manifest_dir = tempfile::tempdir()?;
+    let manifest_dir = tempdir()?;
     let mut pbuf = manifest_dir.into_path();
     pbuf.push("parameters.json");
 

--- a/fil-proofs-tooling/src/bin/circuitinfo/main.rs
+++ b/fil-proofs-tooling/src/bin/circuitinfo/main.rs
@@ -1,23 +1,22 @@
 use std::str::FromStr;
 
+use bellperson::{bls::Bls12, util_cs::bench_cs::BenchCS, Circuit};
 use dialoguer::{theme::ColorfulTheme, MultiSelect};
+use filecoin_proofs::{
+    parameters::{public_params, window_post_public_params, winning_post_public_params},
+    with_shape, DefaultPieceHasher, PaddedBytesAmount, PoRepConfig, PoRepProofPartitions,
+    PoStConfig, PoStType, SectorSize, POREP_PARTITIONS, PUBLISHED_SECTOR_SIZES,
+    WINDOW_POST_CHALLENGE_COUNT, WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT,
+    WINNING_POST_SECTOR_COUNT,
+};
 use humansize::{file_size_opts, FileSize};
 use log::{info, warn};
-use structopt::StructOpt;
-
-use bellperson::util_cs::bench_cs::BenchCS;
-use bellperson::{bls::Bls12, Circuit};
-use filecoin_proofs::constants::*;
-use filecoin_proofs::parameters::{
-    public_params, window_post_public_params, winning_post_public_params,
+use storage_proofs_core::{
+    api_version::ApiVersion, compound_proof::CompoundProof, merkle::MerkleTreeTrait,
 };
-use filecoin_proofs::types::*;
-use filecoin_proofs::with_shape;
-use filecoin_proofs::PoStType;
-use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::compound_proof::CompoundProof;
 use storage_proofs_porep::stacked::{StackedCompound, StackedDrg};
 use storage_proofs_post::fallback::{FallbackPoSt, FallbackPoStCircuit, FallbackPoStCompound};
+use structopt::StructOpt;
 
 struct CircuitInfo {
     constraints: usize,

--- a/fil-proofs-tooling/src/bin/gen_graph_cache/main.rs
+++ b/fil-proofs-tooling/src/bin/gen_graph_cache/main.rs
@@ -5,14 +5,13 @@ use std::path::Path;
 
 use anyhow::Result;
 use clap::{value_t, App, Arg};
-use serde::{Deserialize, Serialize};
-
 use filecoin_hashers::sha256::Sha256Hasher;
-use filecoin_proofs::constants::*;
-use filecoin_proofs::types::*;
-use filecoin_proofs::with_shape;
-use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::proof::ProofScheme;
+use filecoin_proofs::{
+    with_shape, DRG_DEGREE, EXP_DEGREE, SECTOR_SIZE_2_KIB, SECTOR_SIZE_32_GIB, SECTOR_SIZE_512_MIB,
+    SECTOR_SIZE_64_GIB, SECTOR_SIZE_8_MIB,
+};
+use serde::{Deserialize, Serialize};
+use storage_proofs_core::{api_version::ApiVersion, merkle::MerkleTreeTrait, proof::ProofScheme};
 use storage_proofs_porep::stacked::{LayerChallenges, SetupParams, StackedDrg};
 
 const PARENT_CACHE_JSON_OUTPUT: &str = "./parent_cache.json";
@@ -32,8 +31,6 @@ fn gen_graph_cache<Tree: 'static + MerkleTreeTrait>(
     parent_cache_summary_map: &mut ParentCacheSummaryMap,
 ) -> Result<()> {
     let nodes = (sector_size / 32) as usize;
-    let drg_degree = filecoin_proofs::constants::DRG_DEGREE;
-    let expansion_degree = filecoin_proofs::constants::EXP_DEGREE;
 
     // Note that layers and challenge_count don't affect the graph, so
     // we just use dummy values of 1 for the setup params.
@@ -43,8 +40,8 @@ fn gen_graph_cache<Tree: 'static + MerkleTreeTrait>(
 
     let sp = SetupParams {
         nodes,
-        degree: drg_degree,
-        expansion_degree,
+        degree: DRG_DEGREE,
+        expansion_degree: EXP_DEGREE,
         porep_id,
         layer_challenges,
         api_version,

--- a/filecoin-hashers/src/poseidon_types.rs
+++ b/filecoin-hashers/src/poseidon_types.rs
@@ -1,7 +1,9 @@
+use std::fmt::Debug;
+
 use bellperson::bls::{Bls12, Fr};
 use generic_array::typenum::{U0, U11, U16, U2, U24, U36, U4, U8};
 use lazy_static::lazy_static;
-use neptune::poseidon::PoseidonConstants;
+use neptune::{poseidon::PoseidonConstants, Arity};
 
 pub type PoseidonBinaryArity = U2;
 pub type PoseidonQuadArity = U4;
@@ -30,7 +32,7 @@ lazy_static! {
         PoseidonConstants::new();
 }
 
-pub trait PoseidonArity: neptune::Arity<Fr> + Send + Sync + Clone + std::fmt::Debug {
+pub trait PoseidonArity: Arity<Fr> + Send + Sync + Clone + Debug {
     #[allow(non_snake_case)]
     fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self>;
 }

--- a/filecoin-proofs/benches/preprocessing.rs
+++ b/filecoin-proofs/benches/preprocessing.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Read};
+use std::io::{Cursor, Read};
 use std::time::Duration;
 
 use criterion::{criterion_group, criterion_main, Criterion, ParameterizedBenchmark, Throughput};
@@ -50,7 +50,7 @@ fn preprocessing_benchmark(c: &mut Criterion) {
 
                 start_profile(&format!("write_padded_{}", *size));
                 b.iter(|| {
-                    let mut reader = Fr32Reader::new(io::Cursor::new(&data));
+                    let mut reader = Fr32Reader::new(Cursor::new(&data));
                     reader.read_to_end(&mut buf).expect("in memory read error");
                     assert!(buf.len() >= data.len());
                     buf.clear();
@@ -79,7 +79,7 @@ fn add_piece_benchmark(c: &mut Criterion) {
                 start_profile(&format!("add_piece_{}", *size));
                 b.iter(|| {
                     add_piece(
-                        io::Cursor::new(&data),
+                        Cursor::new(&data),
                         &mut buf,
                         unpadded_size,
                         &[unpadded_size][..],

--- a/filecoin-proofs/src/api/fake_seal.rs
+++ b/filecoin-proofs/src/api/fake_seal.rs
@@ -1,38 +1,33 @@
 use std::fs::File;
-use std::io::prelude::*;
+use std::io::Write;
 use std::path::Path;
 
 use anyhow::{Context, Result};
 use bincode::serialize;
 use filecoin_hashers::{Domain, Hasher};
-use storage_proofs_core::cache_key::CacheKey;
-use storage_proofs_core::merkle::MerkleTreeTrait;
+use rand::{thread_rng, Rng};
+use storage_proofs_core::{cache_key::CacheKey, merkle::MerkleTreeTrait};
 use storage_proofs_porep::stacked::StackedDrg;
 
-use crate::constants::DefaultPieceHasher;
-pub use crate::pieces;
-pub use crate::pieces::verify_pieces;
-use crate::types::{Commitment, PaddedBytesAmount, PoRepConfig};
+use crate::{
+    constants::DefaultPieceHasher,
+    types::{Commitment, PaddedBytesAmount, PoRepConfig},
+};
 
 pub fn fauxrep<R: AsRef<Path>, S: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
     porep_config: PoRepConfig,
     cache_path: R,
     out_path: S,
 ) -> Result<Commitment> {
-    let mut rng = rand::thread_rng();
+    let mut rng = thread_rng();
     fauxrep_aux::<_, R, S, Tree>(&mut rng, porep_config, cache_path, out_path)
 }
 
-pub fn fauxrep_aux<
-    Rng: rand::Rng,
-    R: AsRef<Path>,
-    S: AsRef<Path>,
-    Tree: 'static + MerkleTreeTrait,
->(
-    mut rng: &mut Rng,
+pub fn fauxrep_aux<R: Rng, S: AsRef<Path>, T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
+    mut rng: &mut R,
     porep_config: PoRepConfig,
-    cache_path: R,
-    out_path: S,
+    cache_path: S,
+    out_path: T,
 ) -> Result<Commitment> {
     let sector_bytes = PaddedBytesAmount::from(porep_config).0;
 
@@ -67,7 +62,7 @@ pub fn fauxrep2<R: AsRef<Path>, S: AsRef<Path>, Tree: 'static + MerkleTreeTrait>
     cache_path: R,
     existing_p_aux_path: S,
 ) -> Result<Commitment> {
-    let mut rng = rand::thread_rng();
+    let mut rng = thread_rng();
 
     let fake_comm_c = <Tree::Hasher as Hasher>::Domain::random(&mut rng);
 

--- a/filecoin-proofs/src/api/util.rs
+++ b/filecoin-proofs/src/api/util.rs
@@ -1,3 +1,5 @@
+use std::mem::size_of;
+
 use anyhow::{Context, Result};
 use bellperson::bls::Fr;
 use filecoin_hashers::{Domain, Hasher};
@@ -25,14 +27,14 @@ pub fn commitment_from_fr(fr: Fr) -> Commitment {
     commitment
 }
 
-pub(crate) fn get_base_tree_size<Tree: MerkleTreeTrait>(sector_size: SectorSize) -> Result<usize> {
+pub fn get_base_tree_size<Tree: MerkleTreeTrait>(sector_size: SectorSize) -> Result<usize> {
     let base_tree_leaves = u64::from(sector_size) as usize
-        / std::mem::size_of::<<Tree::Hasher as Hasher>::Domain>()
+        / size_of::<<Tree::Hasher as Hasher>::Domain>()
         / get_base_tree_count::<Tree>();
 
     get_merkle_tree_len(base_tree_leaves, Tree::Arity::to_usize())
 }
 
-pub(crate) fn get_base_tree_leafs<Tree: MerkleTreeTrait>(base_tree_size: usize) -> Result<usize> {
+pub fn get_base_tree_leafs<Tree: MerkleTreeTrait>(base_tree_size: usize) -> Result<usize> {
     get_merkle_tree_leafs(base_tree_size, Tree::Arity::to_usize())
 }

--- a/filecoin-proofs/src/api/winning_post.rs
+++ b/filecoin-proofs/src/api/winning_post.rs
@@ -1,22 +1,27 @@
 use anyhow::{ensure, Context, Result};
-use log::info;
-
 use filecoin_hashers::Hasher;
-use storage_proofs_core::compound_proof::{self, CompoundProof};
-use storage_proofs_core::merkle::MerkleTreeTrait;
-use storage_proofs_core::multi_proof::MultiProof;
-use storage_proofs_core::sector::*;
-use storage_proofs_post::fallback;
-
-use crate::api::post_util::partition_vanilla_proofs;
-use crate::api::util::as_safe_commitment;
-use crate::caches::{get_post_params, get_post_verifying_key};
-use crate::parameters::winning_post_setup_params;
-use crate::types::{
-    ChallengeSeed, Commitment, FallbackPoStSectorProof, PoStConfig, PrivateReplicaInfo, ProverId,
-    PublicReplicaInfo, SnarkProof,
+use log::info;
+use storage_proofs_core::{
+    compound_proof::{self, CompoundProof},
+    merkle::MerkleTreeTrait,
+    multi_proof::MultiProof,
+    sector::SectorId,
 };
-use crate::PoStType;
+use storage_proofs_post::fallback::{
+    self, generate_sector_challenges, FallbackPoSt, FallbackPoStCompound, PrivateSector,
+    PublicSector,
+};
+
+use crate::{
+    api::{as_safe_commitment, partition_vanilla_proofs},
+    caches::{get_post_params, get_post_verifying_key},
+    parameters::winning_post_setup_params,
+    types::{
+        ChallengeSeed, Commitment, FallbackPoStSectorProof, PoStConfig, PrivateReplicaInfo,
+        ProverId, PublicReplicaInfo, SnarkProof,
+    },
+    PoStType,
+};
 
 /// Generates a Winning proof-of-spacetime with provided vanilla proofs.
 pub fn generate_winning_post_with_vanilla<Tree: 'static + MerkleTreeTrait>(
@@ -48,13 +53,13 @@ pub fn generate_winning_post_with_vanilla<Tree: 'static + MerkleTreeTrait>(
         partitions: None,
         priority: post_config.priority,
     };
-    let pub_params: compound_proof::PublicParams<'_, fallback::FallbackPoSt<'_, Tree>> =
-        fallback::FallbackPoStCompound::setup(&setup_params)?;
+    let pub_params: compound_proof::PublicParams<'_, FallbackPoSt<'_, Tree>> =
+        FallbackPoStCompound::setup(&setup_params)?;
     let groth_params = get_post_params::<Tree>(&post_config)?;
 
     let mut pub_sectors = Vec::with_capacity(vanilla_proofs.len());
     for vanilla_proof in &vanilla_proofs {
-        pub_sectors.push(fallback::PublicSector {
+        pub_sectors.push(PublicSector {
             id: vanilla_proof.sector_id,
             comm_r: vanilla_proof.comm_r,
         });
@@ -79,7 +84,7 @@ pub fn generate_winning_post_with_vanilla<Tree: 'static + MerkleTreeTrait>(
         &vanilla_proofs,
     )?;
 
-    let proof = fallback::FallbackPoStCompound::prove_with_vanilla(
+    let proof = FallbackPoStCompound::prove_with_vanilla(
         &pub_params,
         &pub_inputs,
         partitioned_proofs,
@@ -123,8 +128,8 @@ pub fn generate_winning_post<Tree: 'static + MerkleTreeTrait>(
         partitions: None,
         priority: post_config.priority,
     };
-    let pub_params: compound_proof::PublicParams<'_, fallback::FallbackPoSt<'_, Tree>> =
-        fallback::FallbackPoStCompound::setup(&setup_params)?;
+    let pub_params: compound_proof::PublicParams<'_, FallbackPoSt<'_, Tree>> =
+        FallbackPoStCompound::setup(&setup_params)?;
     let groth_params = get_post_params::<Tree>(&post_config)?;
 
     let trees = replicas
@@ -149,11 +154,11 @@ pub fn generate_winning_post<Tree: 'static + MerkleTreeTrait>(
             let comm_c = replica.safe_comm_c();
             let comm_r_last = replica.safe_comm_r_last();
 
-            pub_sectors.push(fallback::PublicSector::<<Tree::Hasher as Hasher>::Domain> {
+            pub_sectors.push(PublicSector::<<Tree::Hasher as Hasher>::Domain> {
                 id: *sector_id,
                 comm_r,
             });
-            priv_sectors.push(fallback::PrivateSector {
+            priv_sectors.push(PrivateSector {
                 tree,
                 comm_c,
                 comm_r_last,
@@ -172,12 +177,8 @@ pub fn generate_winning_post<Tree: 'static + MerkleTreeTrait>(
         sectors: &priv_sectors,
     };
 
-    let proof = fallback::FallbackPoStCompound::<Tree>::prove(
-        &pub_params,
-        &pub_inputs,
-        &priv_inputs,
-        &groth_params,
-    )?;
+    let proof =
+        FallbackPoStCompound::<Tree>::prove(&pub_params, &pub_inputs, &priv_inputs, &groth_params)?;
     let proof = proof.to_vec()?;
 
     info!("generate_winning_post:finish");
@@ -207,7 +208,7 @@ pub fn generate_winning_post_sector_challenge<Tree: MerkleTreeTrait>(
 
     let randomness_safe: <Tree::Hasher as Hasher>::Domain =
         as_safe_commitment(randomness, "randomness")?;
-    let result = fallback::generate_sector_challenges(
+    let result = generate_sector_challenges(
         randomness_safe,
         post_config.sector_count,
         sector_set_size,
@@ -255,8 +256,8 @@ pub fn verify_winning_post<Tree: 'static + MerkleTreeTrait>(
         partitions: None,
         priority: false,
     };
-    let pub_params: compound_proof::PublicParams<'_, fallback::FallbackPoSt<'_, Tree>> =
-        fallback::FallbackPoStCompound::setup(&setup_params)?;
+    let pub_params: compound_proof::PublicParams<'_, FallbackPoSt<'_, Tree>> =
+        FallbackPoStCompound::setup(&setup_params)?;
 
     let mut pub_sectors = Vec::with_capacity(param_sector_count);
     for _ in 0..param_sector_count {
@@ -264,7 +265,7 @@ pub fn verify_winning_post<Tree: 'static + MerkleTreeTrait>(
             let comm_r = replica.safe_comm_r().with_context(|| {
                 format!("verify_winning_post: safe_comm_r failed: {:?}", sector_id)
             })?;
-            pub_sectors.push(fallback::PublicSector {
+            pub_sectors.push(PublicSector {
                 id: *sector_id,
                 comm_r,
             });
@@ -286,7 +287,7 @@ pub fn verify_winning_post<Tree: 'static + MerkleTreeTrait>(
             return Ok(false);
         }
 
-        fallback::FallbackPoStCompound::verify(
+        FallbackPoStCompound::verify(
             &pub_params,
             &pub_inputs,
             &single_proof,

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -1,10 +1,16 @@
 use std::collections::HashMap;
 use std::sync::RwLock;
 
-use filecoin_hashers::Hasher;
+pub use storage_proofs_core::drgraph::BASE_DEGREE as DRG_DEGREE;
+pub use storage_proofs_porep::stacked::EXP_DEGREE;
+
+use filecoin_hashers::{poseidon::PoseidonHasher, sha256::Sha256Hasher, Hasher};
 use lazy_static::lazy_static;
-use storage_proofs_core::util::NODE_SIZE;
-use storage_proofs_core::MAX_LEGACY_POREP_REGISTERED_PROOF_ID;
+use storage_proofs_core::{
+    merkle::{BinaryMerkleTree, LCTree, OctLCMerkleTree, OctMerkleTree},
+    util::NODE_SIZE,
+    MAX_LEGACY_POREP_REGISTERED_PROOF_ID,
+};
 use typenum::{U0, U2, U8};
 
 use crate::types::UnpaddedBytesAmount;
@@ -24,9 +30,6 @@ pub const WINNING_POST_CHALLENGE_COUNT: usize = 66;
 pub const WINNING_POST_SECTOR_COUNT: usize = 1;
 
 pub const WINDOW_POST_CHALLENGE_COUNT: usize = 10;
-
-pub const DRG_DEGREE: usize = storage_proofs_core::drgraph::BASE_DEGREE;
-pub const EXP_DEGREE: usize = storage_proofs_porep::stacked::EXP_DEGREE;
 
 pub const MAX_LEGACY_REGISTERED_SEAL_PROOF_ID: u64 = MAX_LEGACY_POREP_REGISTERED_PROOF_ID;
 
@@ -131,16 +134,16 @@ pub const MINIMUM_RESERVED_BYTES_FOR_PIECE_IN_FULLY_ALIGNED_SECTOR: u64 =
 pub const MIN_PIECE_SIZE: UnpaddedBytesAmount = UnpaddedBytesAmount(127);
 
 /// The hasher used for creating comm_d.
-pub type DefaultPieceHasher = filecoin_hashers::sha256::Sha256Hasher;
+pub type DefaultPieceHasher = Sha256Hasher;
 pub type DefaultPieceDomain = <DefaultPieceHasher as Hasher>::Domain;
 
 /// The default hasher for merkle trees currently in use.
-pub type DefaultTreeHasher = filecoin_hashers::poseidon::PoseidonHasher;
+pub type DefaultTreeHasher = PoseidonHasher;
 pub type DefaultTreeDomain = <DefaultTreeHasher as Hasher>::Domain;
 
-pub type DefaultBinaryTree = storage_proofs_core::merkle::BinaryMerkleTree<DefaultTreeHasher>;
-pub type DefaultOctTree = storage_proofs_core::merkle::OctMerkleTree<DefaultTreeHasher>;
-pub type DefaultOctLCTree = storage_proofs_core::merkle::OctLCMerkleTree<DefaultTreeHasher>;
+pub type DefaultBinaryTree = BinaryMerkleTree<DefaultTreeHasher>;
+pub type DefaultOctTree = OctMerkleTree<DefaultTreeHasher>;
+pub type DefaultOctLCTree = OctLCMerkleTree<DefaultTreeHasher>;
 
 // Generic shapes
 pub type SectorShapeBase = LCTree<DefaultTreeHasher, U8, U0, U0>;
@@ -190,11 +193,6 @@ pub fn is_sector_shape_top2(sector_size: u64) -> bool {
         _ => false,
     }
 }
-
-pub use storage_proofs_core::merkle::{DiskTree, LCTree};
-pub use storage_proofs_core::parameter_cache::{
-    get_parameter_data, get_parameter_data_from_id, get_verifying_key_data,
-};
 
 /// Calls a function with the type hint of the sector shape matching the provided sector.
 /// Panics if provided with an unknown sector size.

--- a/filecoin-proofs/src/lib.rs
+++ b/filecoin-proofs/src/lib.rs
@@ -1,20 +1,17 @@
 #![deny(clippy::all, clippy::perf, clippy::correctness, rust_2018_idioms)]
 #![warn(clippy::unwrap_used)]
 
-mod api;
-mod caches;
-mod commitment_reader;
-
 pub mod constants;
 pub mod param;
 pub mod parameters;
 pub mod pieces;
 pub mod types;
 
-pub use self::api::*;
-pub use self::commitment_reader::*;
-pub use self::constants::SINGLE_PARTITION_PROOF_LEN;
-pub use self::constants::*;
-pub use self::types::*;
+mod api;
+mod caches;
+mod commitment_reader;
 
-pub use storage_proofs_core;
+pub use api::*;
+pub use commitment_reader::*;
+pub use constants::*;
+pub use types::*;

--- a/filecoin-proofs/src/param.rs
+++ b/filecoin-proofs/src/param.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
 use std::fs::File;
+use std::io;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
@@ -22,7 +23,7 @@ pub fn get_digest_for_file_within_cache(filename: &str) -> Result<String> {
     let mut file = File::open(&path).with_context(|| format!("could not open path={:?}", path))?;
     let mut hasher = Blake2b::new();
 
-    std::io::copy(&mut file, &mut hasher)?;
+    io::copy(&mut file, &mut hasher)?;
 
     Ok(hasher.finalize().to_hex()[..32].into())
 }

--- a/filecoin-proofs/src/parameters.rs
+++ b/filecoin-proofs/src/parameters.rs
@@ -1,11 +1,12 @@
 use anyhow::{ensure, Result};
-use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::proof::ProofScheme;
+use storage_proofs_core::{api_version::ApiVersion, proof::ProofScheme};
 use storage_proofs_porep::stacked::{self, LayerChallenges, StackedDrg};
-use storage_proofs_post::fallback;
+use storage_proofs_post::fallback::{self, FallbackPoSt};
 
-use crate::constants::*;
-use crate::types::{MerkleTreeTrait, PaddedBytesAmount, PoStConfig};
+use crate::{
+    constants::{DefaultPieceHasher, DRG_DEGREE, EXP_DEGREE, LAYERS, POREP_MINIMUM_CHALLENGES},
+    types::{MerkleTreeTrait, PaddedBytesAmount, PoStConfig},
+};
 
 type WinningPostSetupParams = fallback::SetupParams;
 pub type WinningPostPublicParams = fallback::PublicParams;
@@ -30,7 +31,7 @@ pub fn public_params<Tree: 'static + MerkleTreeTrait>(
 pub fn winning_post_public_params<Tree: 'static + MerkleTreeTrait>(
     post_config: &PoStConfig,
 ) -> Result<WinningPostPublicParams> {
-    fallback::FallbackPoSt::<Tree>::setup(&winning_post_setup_params(&post_config)?)
+    FallbackPoSt::<Tree>::setup(&winning_post_setup_params(&post_config)?)
 }
 
 pub fn winning_post_setup_params(post_config: &PoStConfig) -> Result<WinningPostSetupParams> {
@@ -61,7 +62,7 @@ pub fn winning_post_setup_params(post_config: &PoStConfig) -> Result<WinningPost
 pub fn window_post_public_params<Tree: 'static + MerkleTreeTrait>(
     post_config: &PoStConfig,
 ) -> Result<WindowPostPublicParams> {
-    fallback::FallbackPoSt::<Tree>::setup(&window_post_setup_params(&post_config))
+    FallbackPoSt::<Tree>::setup(&window_post_setup_params(&post_config))
 }
 
 pub fn window_post_setup_params(post_config: &PoStConfig) -> WindowPostSetupParams {
@@ -132,8 +133,7 @@ fn select_challenges(
 mod tests {
     use super::*;
 
-    use crate::types::PoStType;
-    use storage_proofs_core::api_version::ApiVersion;
+    use crate::{DefaultOctLCTree, PoRepProofPartitions, PoStType};
 
     #[test]
     fn partition_layer_challenges_test() {
@@ -143,7 +143,7 @@ mod tests {
                 .challenges_count_all()
         };
         // Update to ensure all supported PoRepProofPartitions options are represented here.
-        assert_eq!(6, f(usize::from(crate::PoRepProofPartitions(2))));
+        assert_eq!(6, f(usize::from(PoRepProofPartitions(2))));
 
         assert_eq!(12, f(1));
         assert_eq!(6, f(2));

--- a/filecoin-proofs/src/pieces.rs
+++ b/filecoin-proofs/src/pieces.rs
@@ -1,6 +1,6 @@
+use std::cmp::min;
 use std::collections::HashMap;
-use std::io::Read;
-use std::io::{self, Cursor};
+use std::io::{self, Cursor, Read};
 use std::iter::Iterator;
 use std::sync::Mutex;
 
@@ -11,12 +11,16 @@ use lazy_static::lazy_static;
 use log::info;
 use storage_proofs_core::util::NODE_SIZE;
 
-use crate::constants::{
-    DefaultPieceHasher,
-    MINIMUM_RESERVED_BYTES_FOR_PIECE_IN_FULLY_ALIGNED_SECTOR as MINIMUM_PIECE_SIZE,
-};
-use crate::types::{
-    Commitment, PaddedBytesAmount, PieceInfo, SectorSize, UnpaddedByteIndex, UnpaddedBytesAmount,
+use crate::{
+    commitment_reader::CommitmentReader,
+    constants::{
+        DefaultPieceHasher,
+        MINIMUM_RESERVED_BYTES_FOR_PIECE_IN_FULLY_ALIGNED_SECTOR as MINIMUM_PIECE_SIZE,
+    },
+    types::{
+        Commitment, PaddedBytesAmount, PieceInfo, SectorSize, UnpaddedByteIndex,
+        UnpaddedBytesAmount,
+    },
 };
 
 /// Verify that the provided `piece_infos` and `comm_d` match.
@@ -33,7 +37,6 @@ pub fn verify_pieces(
 lazy_static! {
     static ref COMMITMENTS: Mutex<HashMap<SectorSize, Commitment>> = Mutex::new(HashMap::new());
 }
-use crate::commitment_reader::CommitmentReader;
 
 #[derive(Debug, Clone)]
 pub struct EmptySource {
@@ -48,7 +51,7 @@ impl EmptySource {
 
 impl Read for EmptySource {
     fn read(&mut self, target: &mut [u8]) -> io::Result<usize> {
-        let to_read = std::cmp::min(self.size, target.len());
+        let to_read = min(self.size, target.len());
         self.size -= to_read;
         for val in target {
             *val = 0;

--- a/filecoin-proofs/src/types/mod.rs
+++ b/filecoin-proofs/src/types/mod.rs
@@ -1,10 +1,14 @@
+pub use merkletree::store::StoreConfig;
+pub use storage_proofs_core::merkle::{MerkleProof, MerkleTreeTrait};
+pub use storage_proofs_porep::stacked::{Labels, PersistentAux, TemporaryAux};
+
 use filecoin_hashers::Hasher;
 use serde::{Deserialize, Serialize};
-use storage_proofs_core::sector::*;
+use storage_proofs_core::{merkle::BinaryMerkleTree, sector::SectorId};
 use storage_proofs_porep::stacked;
-use storage_proofs_post::fallback::*;
+use storage_proofs_post::fallback;
 
-use crate::constants::*;
+use crate::constants::DefaultPieceHasher;
 
 mod bytes_amount;
 mod piece_info;
@@ -17,29 +21,22 @@ mod public_replica_info;
 mod sector_class;
 mod sector_size;
 
-pub use self::bytes_amount::*;
-pub use self::piece_info::*;
-pub use self::porep_config::*;
-pub use self::porep_proof_partitions::*;
-pub use self::post_config::*;
-pub use self::post_proof_partitions::*;
-pub use self::private_replica_info::*;
-pub use self::public_replica_info::*;
-pub use self::sector_class::*;
-pub use self::sector_size::*;
+pub use bytes_amount::*;
+pub use piece_info::*;
+pub use porep_config::*;
+pub use porep_proof_partitions::*;
+pub use post_config::*;
+pub use post_proof_partitions::*;
+pub use private_replica_info::*;
+pub use public_replica_info::*;
+pub use sector_class::*;
+pub use sector_size::*;
 
 pub type Commitment = [u8; 32];
 pub type ChallengeSeed = [u8; 32];
-pub use stacked::PersistentAux;
-pub use stacked::TemporaryAux;
 pub type ProverId = [u8; 32];
 pub type Ticket = [u8; 32];
-
-pub use storage_proofs_porep::stacked::Labels;
-pub type DataTree = storage_proofs_core::merkle::BinaryMerkleTree<DefaultPieceHasher>;
-
-pub use storage_proofs_core::merkle::MerkleProof;
-pub use storage_proofs_core::merkle::MerkleTreeTrait;
+pub type DataTree = BinaryMerkleTree<DefaultPieceHasher>;
 
 /// Arity for oct trees, used for comm_r_last.
 pub const OCT_ARITY: usize = 8;
@@ -53,7 +50,7 @@ pub struct SealPreCommitOutput {
     pub comm_d: Commitment,
 }
 
-pub type VanillaSealProof<Tree> = storage_proofs_porep::stacked::Proof<Tree, DefaultPieceHasher>;
+pub type VanillaSealProof<Tree> = stacked::Proof<Tree, DefaultPieceHasher>;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SealCommitPhase1Output<Tree: MerkleTreeTrait> {
@@ -74,8 +71,6 @@ pub struct SealCommitOutput {
     pub proof: Vec<u8>,
 }
 
-pub use merkletree::store::StoreConfig;
-
 #[derive(Debug, Serialize, Deserialize)]
 pub struct SealPreCommitPhase1Output<Tree: MerkleTreeTrait> {
     #[serde(bound(
@@ -88,7 +83,7 @@ pub struct SealPreCommitPhase1Output<Tree: MerkleTreeTrait> {
 }
 
 pub type SnarkProof = Vec<u8>;
-pub type VanillaProof<Tree> = Proof<<Tree as MerkleTreeTrait>::Proof>;
+pub type VanillaProof<Tree> = fallback::Proof<<Tree as MerkleTreeTrait>::Proof>;
 
 // This FallbackPoStSectorProof is used during Fallback PoSt, but
 // contains only Vanilla proof information and is not a full Fallback

--- a/filecoin-proofs/src/types/piece_info.rs
+++ b/filecoin-proofs/src/types/piece_info.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Debug, Formatter};
 
 use anyhow::{ensure, Result};
 use serde::{Deserialize, Serialize};
@@ -11,8 +11,8 @@ pub struct PieceInfo {
     pub size: UnpaddedBytesAmount,
 }
 
-impl fmt::Debug for PieceInfo {
-    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Debug for PieceInfo {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("PieceInfo")
             .field("commitment", &hex::encode(&self.commitment))
             .field("size", &self.size)

--- a/filecoin-proofs/src/types/porep_config.rs
+++ b/filecoin-proofs/src/types/porep_config.rs
@@ -1,12 +1,21 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::parameter_cache::{self, CacheableParameters};
+use storage_proofs_core::{
+    api_version::ApiVersion,
+    merkle::MerkleTreeTrait,
+    parameter_cache::{
+        parameter_cache_metadata_path, parameter_cache_params_path,
+        parameter_cache_verifying_key_path, CacheableParameters,
+    },
+};
 use storage_proofs_porep::stacked::{StackedCircuit, StackedCompound};
 
-use crate::constants::DefaultPieceHasher;
-use crate::types::*;
+use crate::{
+    constants::DefaultPieceHasher,
+    parameters::public_params,
+    types::{PaddedBytesAmount, PoRepProofPartitions, SectorSize, UnpaddedBytesAmount},
+};
 
 #[derive(Clone, Copy, Debug)]
 pub struct PoRepConfig {
@@ -47,7 +56,7 @@ impl From<PoRepConfig> for SectorSize {
 impl PoRepConfig {
     /// Returns the cache identifier as used by `storage-proofs::paramater_cache`.
     pub fn get_cache_identifier<Tree: 'static + MerkleTreeTrait>(&self) -> Result<String> {
-        let params = crate::parameters::public_params::<Tree>(
+        let params = public_params::<Tree>(
             self.sector_size.into(),
             self.partitions.into(),
             self.porep_id,
@@ -64,16 +73,16 @@ impl PoRepConfig {
 
     pub fn get_cache_metadata_path<Tree: 'static + MerkleTreeTrait>(&self) -> Result<PathBuf> {
         let id = self.get_cache_identifier::<Tree>()?;
-        Ok(parameter_cache::parameter_cache_metadata_path(&id))
+        Ok(parameter_cache_metadata_path(&id))
     }
 
     pub fn get_cache_verifying_key_path<Tree: 'static + MerkleTreeTrait>(&self) -> Result<PathBuf> {
         let id = self.get_cache_identifier::<Tree>()?;
-        Ok(parameter_cache::parameter_cache_verifying_key_path(&id))
+        Ok(parameter_cache_verifying_key_path(&id))
     }
 
     pub fn get_cache_params_path<Tree: 'static + MerkleTreeTrait>(&self) -> Result<PathBuf> {
         let id = self.get_cache_identifier::<Tree>()?;
-        Ok(parameter_cache::parameter_cache_params_path(&id))
+        Ok(parameter_cache_params_path(&id))
     }
 }

--- a/filecoin-proofs/src/types/post_config.rs
+++ b/filecoin-proofs/src/types/post_config.rs
@@ -1,11 +1,20 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::parameter_cache::{self, CacheableParameters};
-use storage_proofs_post::fallback;
+use storage_proofs_core::{
+    api_version::ApiVersion,
+    merkle::MerkleTreeTrait,
+    parameter_cache::{
+        parameter_cache_metadata_path, parameter_cache_params_path,
+        parameter_cache_verifying_key_path, CacheableParameters,
+    },
+};
+use storage_proofs_post::fallback::{FallbackPoStCircuit, FallbackPoStCompound};
 
-use crate::types::*;
+use crate::{
+    parameters::{window_post_public_params, winning_post_public_params},
+    types::{PaddedBytesAmount, SectorSize, UnpaddedBytesAmount},
+};
 
 #[derive(Clone, Debug)]
 pub struct PoStConfig {
@@ -51,40 +60,36 @@ impl PoStConfig {
     pub fn get_cache_identifier<Tree: 'static + MerkleTreeTrait>(&self) -> Result<String> {
         match self.typ {
             PoStType::Winning => {
-                let params = crate::parameters::winning_post_public_params::<Tree>(self)?;
+                let params = winning_post_public_params::<Tree>(self)?;
 
-                Ok(
-                    <fallback::FallbackPoStCompound<Tree> as CacheableParameters<
-                        fallback::FallbackPoStCircuit<Tree>,
-                        _,
-                    >>::cache_identifier(&params),
-                )
+                Ok(<FallbackPoStCompound<Tree> as CacheableParameters<
+                    FallbackPoStCircuit<Tree>,
+                    _,
+                >>::cache_identifier(&params))
             }
             PoStType::Window => {
-                let params = crate::parameters::window_post_public_params::<Tree>(self)?;
+                let params = window_post_public_params::<Tree>(self)?;
 
-                Ok(
-                    <fallback::FallbackPoStCompound<Tree> as CacheableParameters<
-                        fallback::FallbackPoStCircuit<Tree>,
-                        _,
-                    >>::cache_identifier(&params),
-                )
+                Ok(<FallbackPoStCompound<Tree> as CacheableParameters<
+                    FallbackPoStCircuit<Tree>,
+                    _,
+                >>::cache_identifier(&params))
             }
         }
     }
 
     pub fn get_cache_metadata_path<Tree: 'static + MerkleTreeTrait>(&self) -> Result<PathBuf> {
         let id = self.get_cache_identifier::<Tree>()?;
-        Ok(parameter_cache::parameter_cache_metadata_path(&id))
+        Ok(parameter_cache_metadata_path(&id))
     }
 
     pub fn get_cache_verifying_key_path<Tree: 'static + MerkleTreeTrait>(&self) -> Result<PathBuf> {
         let id = self.get_cache_identifier::<Tree>()?;
-        Ok(parameter_cache::parameter_cache_verifying_key_path(&id))
+        Ok(parameter_cache_verifying_key_path(&id))
     }
 
     pub fn get_cache_params_path<Tree: 'static + MerkleTreeTrait>(&self) -> Result<PathBuf> {
         let id = self.get_cache_identifier::<Tree>()?;
-        Ok(parameter_cache::parameter_cache_params_path(&id))
+        Ok(parameter_cache_params_path(&id))
     }
 }

--- a/filecoin-proofs/src/types/post_proof_partitions.rs
+++ b/filecoin-proofs/src/types/post_proof_partitions.rs
@@ -1,5 +1,4 @@
-use crate::constants::SINGLE_PARTITION_PROOF_LEN;
-use crate::types::*;
+use crate::{constants::SINGLE_PARTITION_PROOF_LEN, types::PoStProofBytesAmount};
 
 #[derive(Clone, Copy, Debug)]
 pub struct PoStProofPartitions(pub u8);

--- a/filecoin-proofs/src/types/public_replica_info.rs
+++ b/filecoin-proofs/src/types/public_replica_info.rs
@@ -1,10 +1,10 @@
+use std::cmp::Ordering;
 use std::hash::Hash;
 
 use anyhow::{ensure, Result};
 use filecoin_hashers::Domain;
 
-use crate::api::util::as_safe_commitment;
-use crate::types::Commitment;
+use crate::{api::as_safe_commitment, types::Commitment};
 
 /// The minimal information required about a replica, in order to be able to verify
 /// a PoSt over it.
@@ -14,14 +14,14 @@ pub struct PublicReplicaInfo {
     comm_r: Commitment,
 }
 
-impl std::cmp::Ord for PublicReplicaInfo {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+impl Ord for PublicReplicaInfo {
+    fn cmp(&self, other: &Self) -> Ordering {
         self.comm_r.as_ref().cmp(other.comm_r.as_ref())
     }
 }
 
-impl std::cmp::PartialOrd for PublicReplicaInfo {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+impl PartialOrd for PublicReplicaInfo {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }

--- a/filecoin-proofs/src/types/sector_class.rs
+++ b/filecoin-proofs/src/types/sector_class.rs
@@ -1,6 +1,6 @@
 use storage_proofs_core::api_version::ApiVersion;
 
-use crate::types::*;
+use crate::types::{PoRepConfig, PoRepProofPartitions, SectorSize};
 
 #[derive(Clone, Copy, Debug)]
 pub struct SectorClass {

--- a/filecoin-proofs/src/types/sector_size.rs
+++ b/filecoin-proofs/src/types/sector_size.rs
@@ -1,6 +1,6 @@
 use fr32::to_unpadded_bytes;
 
-use crate::types::*;
+use crate::types::{PaddedBytesAmount, UnpaddedBytesAmount};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct SectorSize(pub u64);

--- a/filecoin-proofs/tests/constants.rs
+++ b/filecoin-proofs/tests/constants.rs
@@ -1,6 +1,7 @@
-use filecoin_proofs::constants::*;
-use filecoin_proofs::with_shape;
-
+use filecoin_proofs::{
+    with_shape, SECTOR_SIZE_16_MIB, SECTOR_SIZE_1_GIB, SECTOR_SIZE_2_KIB, SECTOR_SIZE_32_GIB,
+    SECTOR_SIZE_4_KIB, SECTOR_SIZE_512_MIB, SECTOR_SIZE_64_GIB, SECTOR_SIZE_8_MIB,
+};
 use generic_array::typenum::Unsigned;
 use storage_proofs_core::merkle::MerkleTreeTrait;
 

--- a/filecoin-proofs/tests/mod.rs
+++ b/filecoin-proofs/tests/mod.rs
@@ -1,16 +1,13 @@
 use bellperson::bls::Fr;
 use ff::Field;
+use filecoin_proofs::{
+    as_safe_commitment, verify_seal, DefaultOctLCTree, DefaultTreeDomain, PoRepConfig,
+    PoRepProofPartitions, SectorSize, POREP_PARTITIONS, SECTOR_SIZE_2_KIB, TEST_SEED,
+};
 use fr32::bytes_into_fr;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
-
-use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::sector::SectorId;
-
-use filecoin_proofs::as_safe_commitment;
-use filecoin_proofs::constants::*;
-use filecoin_proofs::types::{PoRepConfig, PoRepProofPartitions, SectorSize};
-use filecoin_proofs::verify_seal;
+use storage_proofs_core::{api_version::ApiVersion, sector::SectorId};
 
 #[test]
 fn test_verify_seal_fr32_validation() {

--- a/fr32/src/padding.rs
+++ b/fr32/src/padding.rs
@@ -1,4 +1,4 @@
-use std::cmp::min;
+use std::cmp::{min, Ordering};
 use std::io::{self, Error, ErrorKind, Write};
 
 /** PaddingMap represents a mapping between data and its padded equivalent.
@@ -489,7 +489,6 @@ fn extract_bits_and_shift(input: &[u8], pos: usize, num_bits: usize, new_offset:
     let input = &input[..BitByte::from_bits(extraction_offset + num_bits).bytes_needed()];
 
     // (2).
-    use std::cmp::Ordering;
     let mut output = match new_offset.cmp(&extraction_offset) {
         Ordering::Less => {
             // Shift right.
@@ -751,7 +750,7 @@ where
 mod tests {
     use super::*;
 
-    use std::io::Read;
+    use std::io::{Cursor, Read};
 
     use bitvec::{order::Lsb0 as LittleEndian, vec::BitVec};
     use itertools::Itertools;
@@ -872,7 +871,7 @@ mod tests {
         let len = 1016; // Use a multiple of 254.
         let data = vec![255u8; len];
         let mut padded = Vec::new();
-        let mut reader = Fr32Reader::new(io::Cursor::new(&data));
+        let mut reader = Fr32Reader::new(Cursor::new(&data));
         reader
             .read_to_end(&mut padded)
             .expect("in-memory read failed");
@@ -900,7 +899,7 @@ mod tests {
         let data: Vec<u8> = (0..len).map(|_| rng.gen()).collect();
 
         let mut padded = Vec::new();
-        let mut reader = Fr32Reader::new(io::Cursor::new(&data));
+        let mut reader = Fr32Reader::new(Cursor::new(&data));
         reader
             .read_to_end(&mut padded)
             .expect("in-memory read failed");

--- a/fr32/src/reader.rs
+++ b/fr32/src/reader.rs
@@ -1,4 +1,6 @@
-use std::io;
+use std::cmp::min;
+use std::io::{self, Read};
+use std::mem::size_of;
 
 use byte_slice_cast::{AsByteSlice, AsSliceOf};
 
@@ -12,7 +14,7 @@ const OUT_BITS_FR: usize = 256;
 const NUM_BYTES_IN_BLOCK: usize = NUM_FRS_PER_BLOCK * IN_BITS_FR / 8;
 const NUM_BYTES_OUT_BLOCK: usize = NUM_FRS_PER_BLOCK * OUT_BITS_FR / 8;
 
-const NUM_U128S_PER_BLOCK: usize = NUM_BYTES_OUT_BLOCK / std::mem::size_of::<u128>();
+const NUM_U128S_PER_BLOCK: usize = NUM_BYTES_OUT_BLOCK / size_of::<u128>();
 
 const MASK_SKIP_HIGH_2: u128 = 0b0011_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111_1111;
 
@@ -49,7 +51,7 @@ macro_rules! process_fr {
     }};
 }
 
-impl<R: io::Read> Fr32Reader<R> {
+impl<R: Read> Fr32Reader<R> {
     pub fn new(source: R) -> Self {
         Fr32Reader {
             source,
@@ -95,7 +97,7 @@ impl<R: io::Read> Fr32Reader<R> {
                     buf = &mut buf[n..];
                     bytes_read += n;
                 }
-                Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => {}
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {}
                 Err(e) => return Err(e),
             }
         }
@@ -116,7 +118,7 @@ const fn div_ceil(x: usize, y: usize) -> usize {
     1 + ((x - 1) / y)
 }
 
-impl<R: io::Read> io::Read for Fr32Reader<R> {
+impl<R: Read> Read for Fr32Reader<R> {
     fn read(&mut self, target: &mut [u8]) -> io::Result<usize> {
         if self.done || target.is_empty() {
             return Ok(0);
@@ -149,7 +151,7 @@ impl<R: io::Read> io::Read for Fr32Reader<R> {
                 let available_bytes = self.available_frs * (OUT_BITS_FR / 8);
 
                 let target_start = bytes_read;
-                let target_end = std::cmp::min(target_start + available_bytes, bytes_to_read);
+                let target_end = min(target_start + available_bytes, bytes_to_read);
                 let len = target_end - target_start;
 
                 let out_start = self.out_offset;
@@ -171,9 +173,12 @@ impl<R: io::Read> io::Read for Fr32Reader<R> {
 mod tests {
     use super::*;
 
-    use std::io::Read;
+    use std::io::Cursor;
 
+    use bitvec::{order::Lsb0 as LittleEndian, vec::BitVec};
+    use itertools::Itertools;
     use pretty_assertions::assert_eq;
+    use rand::random;
 
     use crate::bytes_into_fr;
 
@@ -184,7 +189,7 @@ mod tests {
     fn test_simple_short() {
         // Source is shorter than 1 padding cycle.
         let data = vec![3u8; 30];
-        let mut reader = Fr32Reader::new(io::Cursor::new(&data));
+        let mut reader = Fr32Reader::new(Cursor::new(&data));
         let mut padded = Vec::new();
         reader
             .read_to_end(&mut padded)
@@ -199,7 +204,7 @@ mod tests {
     fn test_simple_single() {
         let data = vec![255u8; 32];
         let mut padded = Vec::new();
-        let mut reader = Fr32Reader::new(io::Cursor::new(&data));
+        let mut reader = Fr32Reader::new(Cursor::new(&data));
         reader
             .read_to_end(&mut padded)
             .expect("in-memory read failed");
@@ -217,7 +222,7 @@ mod tests {
     fn test_simple_127() {
         let data = vec![255u8; 127];
         let mut padded = Vec::new();
-        let mut reader = Fr32Reader::new(io::Cursor::new(&data));
+        let mut reader = Fr32Reader::new(Cursor::new(&data));
         reader
             .read_to_end(&mut padded)
             .expect("in-memory read failed");
@@ -233,11 +238,11 @@ mod tests {
 
     #[test]
     fn test_chained_byte_source() {
-        let random_bytes: Vec<u8> = (0..127).map(|_| rand::random::<u8>()).collect();
+        let random_bytes: Vec<u8> = (0..127).map(|_| random::<u8>()).collect();
 
         // read 127 bytes from a non-chained source
         let output_x = {
-            let input_x = io::Cursor::new(random_bytes.clone());
+            let input_x = Cursor::new(random_bytes.clone());
 
             let mut reader = Fr32Reader::new(input_x);
             let mut buf_x = Vec::new();
@@ -251,10 +256,9 @@ mod tests {
             // read 127 bytes from a n-byte buffer and then the rest
             let output_y = {
                 let input_y =
-                    io::Cursor::new(random_bytes.iter().take(n).cloned().collect::<Vec<u8>>())
-                        .chain(io::Cursor::new(
-                            random_bytes.iter().skip(n).cloned().collect::<Vec<u8>>(),
-                        ));
+                    Cursor::new(random_bytes.iter().take(n).cloned().collect::<Vec<u8>>()).chain(
+                        Cursor::new(random_bytes.iter().skip(n).cloned().collect::<Vec<u8>>()),
+                    );
 
                 let mut reader = Fr32Reader::new(input_y);
                 let mut buf_y = Vec::new();
@@ -276,7 +280,7 @@ mod tests {
         let data = vec![255u8; 127];
 
         let mut buf = Vec::new();
-        let mut reader = Fr32Reader::new(io::Cursor::new(&data));
+        let mut reader = Fr32Reader::new(Cursor::new(&data));
         reader.read_to_end(&mut buf).expect("in-memory read failed");
 
         assert_eq!(buf.clone().into_boxed_slice(), bit_vec_padding(data));
@@ -286,16 +290,16 @@ mod tests {
     #[test]
     #[ignore]
     fn test_long() {
-        use rand::RngCore;
+        use rand::{thread_rng, RngCore};
 
-        let mut rng = rand::thread_rng();
+        let mut rng = thread_rng();
         for i in 1..100 {
             for j in 1..50 {
                 let mut data = vec![0u8; i * j];
                 rng.fill_bytes(&mut data);
 
                 let mut buf = Vec::new();
-                let mut reader = Fr32Reader::new(io::Cursor::new(&data));
+                let mut reader = Fr32Reader::new(Cursor::new(&data));
                 reader.read_to_end(&mut buf).expect("in-memory read failed");
 
                 assert_eq!(
@@ -310,9 +314,6 @@ mod tests {
     }
 
     fn bit_vec_padding(raw_data: Vec<u8>) -> Box<[u8]> {
-        use bitvec::{order::Lsb0 as LittleEndian, vec::BitVec};
-        use itertools::Itertools;
-
         let mut padded_data: BitVec<LittleEndian, u8> = BitVec::new();
         let raw_data: BitVec<LittleEndian, u8> = BitVec::from(raw_data);
 
@@ -363,7 +364,7 @@ mod tests {
         source.extend(vec![9, 0xff]);
 
         let mut buf = Vec::new();
-        let mut reader = Fr32Reader::new(io::Cursor::new(&source));
+        let mut reader = Fr32Reader::new(Cursor::new(&source));
         reader.read_to_end(&mut buf).expect("in-memory read failed");
 
         for (i, &byte) in buf.iter().enumerate().take(31) {

--- a/sha2raw/src/lib.rs
+++ b/sha2raw/src/lib.rs
@@ -5,13 +5,13 @@
 #![deny(clippy::all, clippy::perf, clippy::correctness)]
 #![allow(clippy::unreadable_literal)]
 
-mod consts;
+pub use digest::Digest;
 
+mod consts;
 mod platform;
 mod sha256;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod sha256_intrinsics;
 mod sha256_utils;
 
-pub use digest::Digest;
 pub use sha256::Sha256;

--- a/sha2raw/src/platform.rs
+++ b/sha2raw/src/platform.rs
@@ -1,3 +1,5 @@
+use crate::{sha256_intrinsics, sha256_utils};
+
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Platform {
@@ -65,12 +67,10 @@ impl Implementation {
     pub fn compress256(self, state: &mut [u32; 8], blocks: &[&[u8]]) {
         match self.0 {
             Platform::Portable => {
-                use crate::sha256_utils;
                 sha256_utils::compress256(state, blocks);
             }
             #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
             Platform::Sha => {
-                use crate::sha256_intrinsics;
                 unsafe { sha256_intrinsics::compress256(state, blocks) };
             }
             #[cfg(feature = "asm")]

--- a/sha2raw/src/sha256.rs
+++ b/sha2raw/src/sha256.rs
@@ -1,9 +1,9 @@
 use byteorder::{ByteOrder, BE};
+use lazy_static::lazy_static;
 
-use crate::consts::H256;
-use crate::platform::Implementation;
+use crate::{consts::H256, platform::Implementation};
 
-lazy_static::lazy_static! {
+lazy_static! {
     static ref IMPL: Implementation = Implementation::detect();
 }
 

--- a/sha2raw/src/sha256_intrinsics.rs
+++ b/sha2raw/src/sha256_intrinsics.rs
@@ -2,9 +2,15 @@
 #![allow(clippy::cast_ptr_alignment)] // Safe to cast without alignment checks as the loads and stores do not require alignment.
 
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use std::arch::x86;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
+use std::arch::x86_64 as x86;
+
+use x86::{
+    __m128i, _mm_add_epi32, _mm_alignr_epi8, _mm_blend_epi16, _mm_loadu_si128, _mm_set_epi64x,
+    _mm_sha256msg1_epu32, _mm_sha256msg2_epu32, _mm_sha256rnds2_epu32, _mm_shuffle_epi32,
+    _mm_shuffle_epi8, _mm_storeu_si128,
+};
 
 /// Process a block with the SHA-256 algorithm.
 /// Based on https://github.com/noloader/SHA-Intrinsics/blob/master/sha256-x86.c

--- a/sha2raw/src/sha256_utils.rs
+++ b/sha2raw/src/sha256_utils.rs
@@ -1,6 +1,9 @@
 #![allow(clippy::many_single_char_names)]
 
+use byteorder::{ByteOrder, BE};
 use fake_simd::u32x4;
+
+use crate::consts::{BLOCK_LEN, K32X4};
 
 /// Not an intrinsic, but works like an unaligned load.
 #[inline]
@@ -121,9 +124,7 @@ fn sha256_digest_round_x2(cdgh: u32x4, abef: u32x4, wk: u32x4) -> u32x4 {
 
 /// Process a block with the SHA-256 algorithm.
 fn sha256_digest_block_u32(state: &mut [u32; 8], block: &[u32; 16]) {
-    use crate::consts;
-
-    let k = &consts::K32X4;
+    let k = &K32X4;
 
     macro_rules! schedule {
         ($v0:expr, $v1:expr, $v2:expr, $v3:expr) => {
@@ -282,9 +283,6 @@ fn sha256_digest_block_u32(state: &mut [u32; 8], block: &[u32; 16]) {
 ///  support in LLVM (and GCC, etc.).
 #[inline]
 pub fn compress256(state: &mut [u32; 8], blocks: &[&[u8]]) {
-    use crate::consts::BLOCK_LEN;
-    use byteorder::{ByteOrder, BE};
-
     let mut block_u32 = [0u32; BLOCK_LEN];
 
     for block in blocks.chunks(2) {

--- a/storage-proofs-core/benches/drgraph.rs
+++ b/storage-proofs-core/benches/drgraph.rs
@@ -1,7 +1,9 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
-use filecoin_hashers::poseidon::*;
-use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::drgraph::*;
+use filecoin_hashers::poseidon::PoseidonHasher;
+use storage_proofs_core::{
+    api_version::ApiVersion,
+    drgraph::{BucketGraph, Graph, BASE_DEGREE},
+};
 
 #[allow(clippy::unit_arg)]
 fn drgraph(c: &mut Criterion) {

--- a/storage-proofs-core/benches/merkle.rs
+++ b/storage-proofs-core/benches/merkle.rs
@@ -7,10 +7,11 @@ use rand::{thread_rng, Rng};
 use storage_proofs_core::merkle::{create_base_merkle_tree, BinaryMerkleTree};
 
 fn merkle_benchmark_sha256(c: &mut Criterion) {
-    #[cfg(feature = "big-sector-sizes-bench")]
-    let params = vec![128, 1024, 1_048_576];
-    #[cfg(not(feature = "big-sector-sizes-bench"))]
-    let params = vec![128, 1024];
+    let params = if cfg!(feature = "big-sector-sizes-bench") {
+        vec![128, 1024, 1_048_576]
+    } else {
+        vec![128, 1024]
+    };
 
     c.bench(
         "merkletree-binary",
@@ -34,10 +35,11 @@ fn merkle_benchmark_sha256(c: &mut Criterion) {
 }
 
 fn merkle_benchmark_poseidon(c: &mut Criterion) {
-    #[cfg(feature = "big-sector-sizes-bench")]
-    let params = vec![64, 128, 1024, 1_048_576];
-    #[cfg(not(feature = "big-sector-sizes-bench"))]
-    let params = vec![64, 128, 1024];
+    let params = if cfg!(feature = "big-sector-sizes-bench") {
+        vec![64, 128, 1024, 1_048_576]
+    } else {
+        vec![64, 128, 1024]
+    };
 
     c.bench(
         "merkletree-binary",

--- a/storage-proofs-core/benches/misc.rs
+++ b/storage-proofs-core/benches/misc.rs
@@ -1,4 +1,4 @@
-use std::io::{Read, Seek, Write};
+use std::io::{Read, Seek, SeekFrom, Write};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use rand::{thread_rng, Rng};
@@ -21,7 +21,7 @@ fn read_bytes_benchmark(c: &mut Criterion) {
 
                 b.iter(|| {
                     let mut res = vec![0u8; *bytes];
-                    f.seek(std::io::SeekFrom::Start(0)).unwrap();
+                    f.seek(SeekFrom::Start(0)).unwrap();
                     f.read_exact(&mut res).unwrap();
 
                     black_box(res)

--- a/storage-proofs-core/benches/xor.rs
+++ b/storage-proofs-core/benches/xor.rs
@@ -1,12 +1,13 @@
-use bellperson::bls::Bls12;
-use bellperson::gadgets::boolean::{self, Boolean};
-use bellperson::groth16::*;
-use bellperson::util_cs::bench_cs::BenchCS;
-use bellperson::{Circuit, ConstraintSystem, SynthesisError};
+use bellperson::{
+    bls::Bls12,
+    gadgets::boolean::{AllocatedBit, Boolean},
+    groth16::{create_random_proof, generate_random_parameters},
+    util_cs::bench_cs::BenchCS,
+    Circuit, ConstraintSystem, SynthesisError,
+};
 use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use rand::{thread_rng, Rng};
-use storage_proofs_core::crypto::xor;
-use storage_proofs_core::gadgets;
+use storage_proofs_core::{crypto::xor, gadgets::xor::xor as xor_circuit};
 
 struct XorExample<'a> {
     key: &'a [Option<bool>],
@@ -20,7 +21,7 @@ impl<'a> Circuit<Bls12> for XorExample<'a> {
             .iter()
             .enumerate()
             .map(|(i, b)| {
-                Ok(Boolean::from(boolean::AllocatedBit::alloc(
+                Ok(Boolean::from(AllocatedBit::alloc(
                     cs.namespace(|| format!("key_bit {}", i)),
                     *b,
                 )?))
@@ -31,7 +32,7 @@ impl<'a> Circuit<Bls12> for XorExample<'a> {
             .iter()
             .enumerate()
             .map(|(i, b)| {
-                Ok(Boolean::from(boolean::AllocatedBit::alloc(
+                Ok(Boolean::from(AllocatedBit::alloc(
                     cs.namespace(|| format!("data_bit {}", i)),
                     *b,
                 )?))
@@ -39,7 +40,7 @@ impl<'a> Circuit<Bls12> for XorExample<'a> {
             .collect::<Result<Vec<_>, SynthesisError>>()?;
 
         let mut cs = cs.namespace(|| "xor");
-        let _res = gadgets::xor::xor(&mut cs, &key, &data)?;
+        let _res = xor_circuit(&mut cs, &key, &data)?;
 
         Ok(())
     }

--- a/storage-proofs-core/src/api_version.rs
+++ b/storage-proofs-core/src/api_version.rs
@@ -1,7 +1,7 @@
-use std::fmt;
+use std::fmt::{self, Debug, Display, Formatter};
 use std::str::FromStr;
 
-use anyhow::{self, Result};
+use anyhow::{format_err, Error, Result};
 use semver::Version;
 
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -11,7 +11,7 @@ pub enum ApiVersion {
 }
 
 impl ApiVersion {
-    pub fn as_semver(&self) -> semver::Version {
+    pub fn as_semver(&self) -> Version {
         match self {
             ApiVersion::V1_0_0 => Version::new(1, 0, 0),
             ApiVersion::V1_1_0 => Version::new(1, 1, 0),
@@ -19,34 +19,34 @@ impl ApiVersion {
     }
 }
 
-impl fmt::Debug for ApiVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Debug for ApiVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let semver = self.as_semver();
         write!(f, "{}.{}.{}", semver.major, semver.minor, semver.patch)
     }
 }
 
-impl fmt::Display for ApiVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for ApiVersion {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let semver = self.as_semver();
         write!(f, "{}.{}.{}", semver.major, semver.minor, semver.patch)
     }
 }
 
 impl FromStr for ApiVersion {
-    type Err = anyhow::Error;
+    type Err = Error;
     fn from_str(api_version_str: &str) -> Result<Self> {
         let api_version = Version::parse(api_version_str)?;
         match (api_version.major, api_version.minor, api_version.patch) {
             (1, 0, 0) => Ok(ApiVersion::V1_0_0),
             (1, 1, 0) => Ok(ApiVersion::V1_1_0),
-            (1, 1, _) | (1, 0, _) => Err(anyhow::format_err!(
+            (1, 1, _) | (1, 0, _) => Err(format_err!(
                 "Could not parse API Version from string (patch)"
             )),
-            (1, _, _) => Err(anyhow::format_err!(
+            (1, _, _) => Err(format_err!(
                 "Could not parse API Version from string (minor)"
             )),
-            _ => Err(anyhow::format_err!(
+            _ => Err(format_err!(
                 "Could not parse API Version from string (major)"
             )),
         }

--- a/storage-proofs-core/src/cache_key.rs
+++ b/storage-proofs-core/src/cache_key.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use std::fmt::{self, Display, Formatter};
 
 #[derive(Debug, Copy, Clone)]
 pub enum CacheKey {
@@ -9,8 +9,8 @@ pub enum CacheKey {
     CommRLastTree,
 }
 
-impl fmt::Display for CacheKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for CacheKey {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             CacheKey::PAux => write!(f, "p_aux"),
             CacheKey::TAux => write!(f, "t_aux"),

--- a/storage-proofs-core/src/crypto/aes.rs
+++ b/storage-proofs-core/src/crypto/aes.rs
@@ -1,7 +1,6 @@
 use aes::Aes256;
 use anyhow::{ensure, Context};
-use block_modes::block_padding::ZeroPadding;
-use block_modes::{BlockMode, Cbc};
+use block_modes::{block_padding::ZeroPadding, BlockMode, Cbc};
 
 use crate::error::Result;
 
@@ -27,12 +26,15 @@ pub fn decode(key: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
+    use crate::TEST_SEED;
+
     #[test]
     fn test_aes() {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for i in 0..10 {
             let key: Vec<u8> = (0..32).map(|_| rng.gen()).collect();

--- a/storage-proofs-core/src/crypto/feistel.rs
+++ b/storage-proofs-core/src/crypto/feistel.rs
@@ -1,5 +1,6 @@
+use std::mem::size_of;
+
 use blake2b_simd::blake2b;
-use std::mem;
 
 pub const FEISTEL_ROUNDS: usize = 3;
 // 3 rounds is an acceptable value for a pseudo-random permutation,
@@ -101,7 +102,7 @@ fn decode(index: Index, keys: &[Index], precomputed: FeistelPrecomputed) -> Inde
     (left << half_bits) | right
 }
 
-const HALF_FEISTEL_BYTES: usize = mem::size_of::<Index>();
+const HALF_FEISTEL_BYTES: usize = size_of::<Index>();
 const FEISTEL_BYTES: usize = 2 * HALF_FEISTEL_BYTES;
 
 // Round function of the Feistel network: `F(Ri, Ki)`. Joins the `right`
@@ -167,7 +168,8 @@ fn feistel(right: Index, key: Index, right_mask: Index) -> Index {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rayon::prelude::*;
+
+    use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 
     // Some sample n-values which are not powers of four and also don't coincidentally happen to
     // encode/decode correctly.

--- a/storage-proofs-core/src/crypto/mod.rs
+++ b/storage-proofs-core/src/crypto/mod.rs
@@ -1,4 +1,5 @@
 use sha2::{Digest, Sha256};
+
 pub mod aes;
 pub mod feistel;
 pub mod sloth;

--- a/storage-proofs-core/src/crypto/sloth.rs
+++ b/storage-proofs-core/src/crypto/sloth.rs
@@ -23,7 +23,8 @@ pub fn decode(key: &Fr, ciphertext: &Fr) -> Fr {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bellperson::bls::{Fr, FrRepr};
+
+    use bellperson::bls::FrRepr;
     use ff::PrimeField;
     use proptest::{prop_compose, proptest};
 

--- a/storage-proofs-core/src/crypto/xor.rs
+++ b/storage-proofs-core/src/crypto/xor.rs
@@ -1,5 +1,6 @@
-use crate::error::Result;
 use anyhow::ensure;
+
+use crate::error::Result;
 
 /// Encodes plaintext by elementwise xoring with the passed in key.
 pub fn encode(key: &[u8], plaintext: &[u8]) -> Result<Vec<u8>> {
@@ -25,12 +26,15 @@ fn xor(key: &[u8], input: &[u8]) -> Result<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
+    use crate::TEST_SEED;
+
     #[test]
     fn test_xor() {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for i in 0..10 {
             let key: Vec<u8> = (0..32).map(|_| rng.gen()).collect();

--- a/storage-proofs-core/src/error.rs
+++ b/storage-proofs-core/src/error.rs
@@ -1,9 +1,10 @@
 use std::any::Any;
 
-use crate::sector::SectorId;
+pub use anyhow::Result;
+
 use bellperson::SynthesisError;
 
-pub use anyhow::Result;
+use crate::sector::SectorId;
 
 /// Custom error types
 #[derive(Debug, thiserror::Error)]
@@ -17,7 +18,7 @@ pub enum Error {
     #[error("{}", _0)]
     Synthesis(#[from] SynthesisError),
     #[error("{}", _0)]
-    Io(#[from] ::std::io::Error),
+    Io(#[from] std::io::Error),
     #[error("tree root and commitment do not match")]
     InvalidCommitment,
     #[error("malformed input")]
@@ -31,7 +32,7 @@ pub enum Error {
     #[error("Cannot (yet) generate inclusion proof for unaligned piece.")]
     UnalignedPiece,
     #[error("{}", _0)]
-    Serde(#[from] serde_json::error::Error),
+    Serde(#[from] serde_json::Error),
     #[error("unclassified error: {}", _0)]
     Unclassified(String),
     #[error("Missing Private Input {0} for sector {1}")]

--- a/storage-proofs-core/src/gadgets/constraint.rs
+++ b/storage-proofs-core/src/gadgets/constraint.rs
@@ -1,4 +1,4 @@
-use bellperson::{bls::Engine, gadgets::num, ConstraintSystem, SynthesisError};
+use bellperson::{bls::Engine, gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
 use ff::Field;
 
 /// Adds a constraint to CS, enforcing an equality relationship between the allocated numbers a and b.
@@ -7,8 +7,8 @@ use ff::Field;
 pub fn equal<E: Engine, A, AR, CS: ConstraintSystem<E>>(
     cs: &mut CS,
     annotation: A,
-    a: &num::AllocatedNum<E>,
-    b: &num::AllocatedNum<E>,
+    a: &AllocatedNum<E>,
+    b: &AllocatedNum<E>,
 ) where
     A: FnOnce() -> AR,
     AR: Into<String>,
@@ -28,9 +28,9 @@ pub fn equal<E: Engine, A, AR, CS: ConstraintSystem<E>>(
 pub fn sum<E: Engine, A, AR, CS: ConstraintSystem<E>>(
     cs: &mut CS,
     annotation: A,
-    a: &num::AllocatedNum<E>,
-    b: &num::AllocatedNum<E>,
-    sum: &num::AllocatedNum<E>,
+    a: &AllocatedNum<E>,
+    b: &AllocatedNum<E>,
+    sum: &AllocatedNum<E>,
 ) where
     A: FnOnce() -> AR,
     AR: Into<String>,
@@ -46,10 +46,10 @@ pub fn sum<E: Engine, A, AR, CS: ConstraintSystem<E>>(
 
 pub fn add<E: Engine, CS: ConstraintSystem<E>>(
     mut cs: CS,
-    a: &num::AllocatedNum<E>,
-    b: &num::AllocatedNum<E>,
-) -> Result<num::AllocatedNum<E>, SynthesisError> {
-    let res = num::AllocatedNum::alloc(cs.namespace(|| "add_num"), || {
+    a: &AllocatedNum<E>,
+    b: &AllocatedNum<E>,
+) -> Result<AllocatedNum<E>, SynthesisError> {
+    let res = AllocatedNum::alloc(cs.namespace(|| "add_num"), || {
         let mut tmp = a
             .get_value()
             .ok_or_else(|| SynthesisError::AssignmentMissing)?;
@@ -69,10 +69,10 @@ pub fn add<E: Engine, CS: ConstraintSystem<E>>(
 
 pub fn sub<E: Engine, CS: ConstraintSystem<E>>(
     mut cs: CS,
-    a: &num::AllocatedNum<E>,
-    b: &num::AllocatedNum<E>,
-) -> Result<num::AllocatedNum<E>, SynthesisError> {
-    let res = num::AllocatedNum::alloc(cs.namespace(|| "sub_num"), || {
+    a: &AllocatedNum<E>,
+    b: &AllocatedNum<E>,
+) -> Result<AllocatedNum<E>, SynthesisError> {
+    let res = AllocatedNum::alloc(cs.namespace(|| "sub_num"), || {
         let mut tmp = a
             .get_value()
             .ok_or_else(|| SynthesisError::AssignmentMissing)?;
@@ -96,9 +96,9 @@ pub fn sub<E: Engine, CS: ConstraintSystem<E>>(
 pub fn difference<E: Engine, A, AR, CS: ConstraintSystem<E>>(
     cs: &mut CS,
     annotation: A,
-    a: &num::AllocatedNum<E>,
-    b: &num::AllocatedNum<E>,
-    difference: &num::AllocatedNum<E>,
+    a: &AllocatedNum<E>,
+    b: &AllocatedNum<E>,
+    difference: &AllocatedNum<E>,
 ) where
     A: FnOnce() -> AR,
     AR: Into<String>,
@@ -118,20 +118,24 @@ pub fn difference<E: Engine, A, AR, CS: ConstraintSystem<E>>(
 mod tests {
     use super::*;
 
-    use bellperson::bls::{Bls12, Fr};
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
+    use bellperson::{
+        bls::{Bls12, Fr},
+        util_cs::test_cs::TestConstraintSystem,
+    };
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
+    use crate::TEST_SEED;
+
     #[test]
     fn add_constraint() {
-        let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
+        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a = num::AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(rng))).unwrap();
-            let b = num::AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(rng))).unwrap();
+            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(rng))).unwrap();
+            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(rng))).unwrap();
 
             let res = add(cs.namespace(|| "a+b"), &a, &b).expect("add failed");
 
@@ -145,13 +149,13 @@ mod tests {
 
     #[test]
     fn sub_constraint() {
-        let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
+        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a = num::AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(rng))).unwrap();
-            let b = num::AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(rng))).unwrap();
+            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(rng))).unwrap();
+            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(rng))).unwrap();
 
             let res = sub(cs.namespace(|| "a-b"), &a, &b).expect("subtraction failed");
 

--- a/storage-proofs-core/src/gadgets/encode.rs
+++ b/storage-proofs-core/src/gadgets/encode.rs
@@ -1,13 +1,12 @@
-use bellperson::gadgets::num;
-use bellperson::{bls::Engine, ConstraintSystem, SynthesisError};
+use bellperson::{bls::Engine, gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
 
 use crate::gadgets::constraint;
 
 pub fn encode<E, CS>(
     mut cs: CS,
-    key: &num::AllocatedNum<E>,
-    value: &num::AllocatedNum<E>,
-) -> Result<num::AllocatedNum<E>, SynthesisError>
+    key: &AllocatedNum<E>,
+    value: &AllocatedNum<E>,
+) -> Result<AllocatedNum<E>, SynthesisError>
 where
     E: Engine,
     CS: ConstraintSystem<E>,
@@ -17,9 +16,9 @@ where
 
 pub fn decode<E, CS>(
     mut cs: CS,
-    key: &num::AllocatedNum<E>,
-    value: &num::AllocatedNum<E>,
-) -> Result<num::AllocatedNum<E>, SynthesisError>
+    key: &AllocatedNum<E>,
+    value: &AllocatedNum<E>,
+) -> Result<AllocatedNum<E>, SynthesisError>
 where
     E: Engine,
     CS: ConstraintSystem<E>,

--- a/storage-proofs-core/src/gadgets/insertion.rs
+++ b/storage-proofs-core/src/gadgets/insertion.rs
@@ -3,9 +3,14 @@
 //! Insert an `AllocatedNum` into a sequence of `AllocatedNums` at an arbitrary position.
 //! This can be thought of as a generalization of `AllocatedNum::conditionally_reverse` and reduces to it in the binary case.
 
-use bellperson::gadgets::boolean::{AllocatedBit, Boolean};
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::{bls::Engine, ConstraintSystem, SynthesisError};
+use bellperson::{
+    bls::Engine,
+    gadgets::{
+        boolean::{AllocatedBit, Boolean},
+        num::AllocatedNum,
+    },
+    ConstraintSystem, SynthesisError,
+};
 use ff::Field;
 
 /// Insert `element` after the nth 1-indexed element of `elements`, where `path_bits` represents n, least-significant bit first.
@@ -348,12 +353,14 @@ where
 mod tests {
     use super::*;
 
-    use bellperson::bls::{Bls12, Fr};
-    use bellperson::gadgets::boolean::AllocatedBit;
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
-    use ff::Field;
+    use bellperson::{
+        bls::{Bls12, Fr},
+        util_cs::test_cs::TestConstraintSystem,
+    };
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
+
+    use crate::TEST_SEED;
 
     #[test]
     fn test_select() {
@@ -361,7 +368,7 @@ mod tests {
             let size = 1 << log_size;
             for index in 0..size {
                 // Initialize rng in loop to simplify debugging with consistent elements.
-                let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
+                let rng = &mut XorShiftRng::from_seed(TEST_SEED);
                 let mut cs = TestConstraintSystem::new();
 
                 let elements: Vec<_> = (0..size)
@@ -379,7 +386,7 @@ mod tests {
 
                 let path_bits = (0..log_size)
                     .map(|i| {
-                        <Boolean as std::convert::From<AllocatedBit>>::from(
+                        <Boolean as From<AllocatedBit>>::from(
                             AllocatedBit::alloc(cs.namespace(|| format!("index bit {}", i)), {
                                 let bit = ((index >> i) & 1) == 1;
                                 Some(bit)
@@ -412,7 +419,7 @@ mod tests {
             let size = 1 << log_size;
             for index in 0..size {
                 // Initialize rng in loop to simplify debugging with consistent elements.
-                let rng = &mut XorShiftRng::from_seed(crate::TEST_SEED);
+                let rng = &mut XorShiftRng::from_seed(TEST_SEED);
                 let mut cs = TestConstraintSystem::new();
 
                 let elements: Vec<_> = (0..size - 1)
@@ -437,7 +444,7 @@ mod tests {
 
                 let index_bits = (0..log_size)
                     .map(|i| {
-                        <Boolean as std::convert::From<AllocatedBit>>::from(
+                        <Boolean as From<AllocatedBit>>::from(
                             AllocatedBit::alloc(cs.namespace(|| format!("index bit {}", i)), {
                                 let bit = ((index >> i) & 1) == 1;
                                 Some(bit)

--- a/storage-proofs-core/src/gadgets/multipack.rs
+++ b/storage-proofs-core/src/gadgets/multipack.rs
@@ -1,8 +1,8 @@
 use bellperson::gadgets::{
     boolean::Boolean,
     num::{AllocatedNum, Num},
+    ConstraintSystem, SynthesisError,
 };
-use bellperson::{ConstraintSystem, SynthesisError};
 use ff::{Field, PrimeField, ScalarEngine};
 
 /// Takes a sequence of booleans and exposes them as a single compact Num.

--- a/storage-proofs-core/src/gadgets/uint64.rs
+++ b/storage-proofs-core/src/gadgets/uint64.rs
@@ -1,6 +1,11 @@
-use bellperson::gadgets::boolean::{AllocatedBit, Boolean};
-use bellperson::gadgets::multipack::pack_into_inputs;
-use bellperson::{bls::Engine, ConstraintSystem, SynthesisError};
+use bellperson::{
+    bls::Engine,
+    gadgets::{
+        boolean::{AllocatedBit, Boolean},
+        multipack::pack_into_inputs,
+    },
+    ConstraintSystem, SynthesisError,
+};
 
 /// Represents an interpretation of 64 `Boolean` objects as an unsigned integer.
 #[derive(Clone)]
@@ -171,9 +176,11 @@ mod test {
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
+    use crate::TEST_SEED;
+
     #[test]
     fn test_uint64_from_bits_be() {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..1000 {
             let v = (0..64)
@@ -205,7 +212,7 @@ mod test {
 
     #[test]
     fn test_uint64_from_bits() {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..1000 {
             let v = (0..64)

--- a/storage-proofs-core/src/gadgets/variables.rs
+++ b/storage-proofs-core/src/gadgets/variables.rs
@@ -1,9 +1,8 @@
-use std::fmt;
+use std::fmt::{self, Debug, Formatter};
 
-use anyhow::Result;
+use bellperson::{bls::Engine, gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
 
-use bellperson::gadgets::num::AllocatedNum;
-use bellperson::{bls::Engine, ConstraintSystem, SynthesisError};
+use crate::error::Result;
 
 /// Root represents a root commitment which may be either a raw value or an already-allocated number.
 /// This allows subcomponents to depend on roots which may optionally be shared with their parent
@@ -14,8 +13,8 @@ pub enum Root<E: Engine> {
     Val(Option<E::Fr>),
 }
 
-impl<E: Engine> fmt::Debug for Root<E> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl<E: Engine> Debug for Root<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
             Root::Var(num) => write!(f, "Root::Var({:?})", num.get_value()),
             Root::Val(val) => write!(f, "Root::Val({:?})", val),

--- a/storage-proofs-core/src/gadgets/xor.rs
+++ b/storage-proofs-core/src/gadgets/xor.rs
@@ -1,5 +1,4 @@
-use bellperson::gadgets::boolean::Boolean;
-use bellperson::{bls::Engine, ConstraintSystem, SynthesisError};
+use bellperson::{bls::Engine, gadgets::boolean::Boolean, ConstraintSystem, SynthesisError};
 
 pub fn xor<E, CS>(
     cs: &mut CS,
@@ -30,17 +29,19 @@ where
 mod tests {
     use super::*;
 
-    use crate::crypto;
-    use crate::util::{bits_to_bytes, bytes_into_boolean_vec};
-    use bellperson::gadgets::boolean::Boolean;
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
-    use bellperson::{bls::Bls12, ConstraintSystem};
+    use bellperson::{bls::Bls12, util_cs::test_cs::TestConstraintSystem};
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 
+    use crate::{
+        crypto::xor,
+        util::{bits_to_bytes, bytes_into_boolean_vec},
+        TEST_SEED,
+    };
+
     #[test]
     fn test_xor_input_circuit() {
-        let mut rng = XorShiftRng::from_seed(crate::TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for i in 0..10 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
@@ -73,7 +74,7 @@ mod tests {
                     .as_slice(),
             );
 
-            let expected = crypto::xor::encode(key.as_slice(), data.as_slice()).unwrap();
+            let expected = xor::encode(key.as_slice(), data.as_slice()).unwrap();
 
             assert_eq!(expected, actual, "circuit and non circuit do not match");
 

--- a/storage-proofs-core/src/lib.rs
+++ b/storage-proofs-core/src/lib.rs
@@ -4,8 +4,7 @@
 #![allow(clippy::type_repetition_in_bounds)]
 #![warn(clippy::unwrap_used)]
 
-#[macro_use]
-pub mod test_helper;
+use std::convert::TryInto;
 
 pub mod api_version;
 pub mod cache_key;
@@ -25,9 +24,10 @@ pub mod por;
 pub mod proof;
 pub mod sector;
 pub mod settings;
+pub mod test_helper;
 pub mod util;
 
-pub use self::data::Data;
+pub use data::Data;
 
 pub const TEST_SEED: [u8; 16] = [
     0x59, 0x62, 0xbe, 0x5d, 0x76, 0x3d, 0x31, 0x8d, 0x17, 0xdb, 0x37, 0x32, 0x54, 0x06, 0xbc, 0xe5,
@@ -38,8 +38,6 @@ pub const MAX_LEGACY_POREP_REGISTERED_PROOF_ID: u64 = 4;
 pub type PoRepID = [u8; 32];
 
 pub fn is_legacy_porep_id(porep_id: PoRepID) -> bool {
-    use std::convert::TryInto;
-
     // NOTE: Because we take only the first 8 bytes, we are actually examining the registered proof type id,
     // not the porep_id. The latter requires the full 32 bytes and includes the nonce.
     // We are, to some extent depending explictly on the strucuture of the `porep_id`.

--- a/storage-proofs-core/src/measurements.rs
+++ b/storage-proofs-core/src/measurements.rs
@@ -1,19 +1,13 @@
 #[cfg(feature = "measurements")]
-use std::sync::mpsc::{channel, Receiver, Sender};
-#[cfg(feature = "measurements")]
-use std::sync::Mutex;
-#[cfg(not(feature = "measurements"))]
+use std::sync::{
+    mpsc::{channel, Receiver, Sender},
+    Mutex,
+};
 use std::time::Duration;
-#[cfg(feature = "measurements")]
-use std::time::{Duration, Instant};
-
-#[cfg(feature = "measurements")]
-use cpu_time::ProcessTime;
-
-use serde::Serialize;
 
 #[cfg(feature = "measurements")]
 use lazy_static::lazy_static;
+use serde::Serialize;
 
 #[cfg(feature = "measurements")]
 lazy_static! {
@@ -57,7 +51,9 @@ pub fn measure_op<T, F>(op: Operation, f: F) -> T
 where
     F: FnOnce() -> T,
 {
-    let cpu_time_start = ProcessTime::now();
+    use std::time::Instant;
+
+    let cpu_time_start = cpu_time::ProcessTime::now();
     let wall_start_time = Instant::now();
 
     #[cfg(feature = "profile")]

--- a/storage-proofs-core/src/merkle/mod.rs
+++ b/storage-proofs-core/src/merkle/mod.rs
@@ -1,7 +1,12 @@
 #![allow(clippy::len_without_is_empty)]
 
+use std::fs::File;
+
+pub use merkletree::store::{DiskStore, ExternalReader, Store};
+
 use filecoin_hashers::Hasher;
 use generic_array::typenum::{U0, U2, U4, U8};
+use merkletree::store::LevelCacheStore;
 
 mod builders;
 mod proof;
@@ -11,11 +16,7 @@ pub use builders::*;
 pub use proof::*;
 pub use tree::*;
 
-// Reexport here, so we don't depend on merkletree directly in other places.
-pub use merkletree::store::{ExternalReader, Store};
-
-pub type DiskStore<E> = merkletree::store::DiskStore<E>;
-pub type LCStore<E> = merkletree::store::LevelCacheStore<E, std::fs::File>;
+pub type LCStore<E> = LevelCacheStore<E, File>;
 
 pub type MerkleStore<T> = DiskStore<T>;
 

--- a/storage-proofs-core/src/multi_proof.rs
+++ b/storage-proofs-core/src/multi_proof.rs
@@ -1,13 +1,16 @@
-use bellperson::groth16;
+use std::io::{Read, Write};
+
+use anyhow::{ensure, Context};
+use bellperson::{
+    bls::Bls12,
+    groth16::{self, PreparedVerifyingKey},
+};
 
 use crate::error::Result;
-use anyhow::{ensure, Context};
-use bellperson::bls::Bls12;
-use std::io::{Read, Write};
 
 pub struct MultiProof<'a> {
     pub circuit_proofs: Vec<groth16::Proof<Bls12>>,
-    pub verifying_key: &'a groth16::PreparedVerifyingKey<Bls12>,
+    pub verifying_key: &'a PreparedVerifyingKey<Bls12>,
 }
 
 const GROTH_PROOF_SIZE: usize = 192;
@@ -15,7 +18,7 @@ const GROTH_PROOF_SIZE: usize = 192;
 impl<'a> MultiProof<'a> {
     pub fn new(
         groth_proofs: Vec<groth16::Proof<Bls12>>,
-        verifying_key: &'a groth16::PreparedVerifyingKey<Bls12>,
+        verifying_key: &'a PreparedVerifyingKey<Bls12>,
     ) -> Self {
         MultiProof {
             circuit_proofs: groth_proofs,
@@ -26,7 +29,7 @@ impl<'a> MultiProof<'a> {
     pub fn new_from_reader<R: Read>(
         partitions: Option<usize>,
         mut reader: R,
-        verifying_key: &'a groth16::PreparedVerifyingKey<Bls12>,
+        verifying_key: &'a PreparedVerifyingKey<Bls12>,
     ) -> Result<Self> {
         let num_proofs = partitions.unwrap_or(1);
 
@@ -40,7 +43,7 @@ impl<'a> MultiProof<'a> {
     pub fn new_from_bytes(
         partitions: Option<usize>,
         proof_bytes: &[u8],
-        verifying_key: &'a groth16::PreparedVerifyingKey<Bls12>,
+        verifying_key: &'a PreparedVerifyingKey<Bls12>,
     ) -> Result<Self> {
         let num_proofs = partitions.unwrap_or(1);
 

--- a/storage-proofs-core/src/pieces.rs
+++ b/storage-proofs-core/src/pieces.rs
@@ -5,9 +5,11 @@ use filecoin_hashers::{Domain, Hasher};
 use fr32::Fr32Ary;
 use merkletree::merkle::next_pow2;
 
-use crate::error::*;
-use crate::merkle::BinaryMerkleTree;
-use crate::util::NODE_SIZE;
+use crate::{
+    error::{Error, Result},
+    merkle::BinaryMerkleTree,
+    util::NODE_SIZE,
+};
 
 /// `position`, `length` are in H::Domain units
 #[derive(Clone, Debug)]
@@ -103,6 +105,7 @@ fn subtree_capacity(pos: usize, total: usize) -> Result<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
     use filecoin_hashers::poseidon::PoseidonHasher;
 
     #[test]

--- a/storage-proofs-core/src/por.rs
+++ b/storage-proofs-core/src/por.rs
@@ -1,12 +1,15 @@
+use std::marker::PhantomData;
+
 use anyhow::ensure;
 use filecoin_hashers::{Domain, Hasher};
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
 
-use crate::error::*;
-use crate::merkle::{MerkleProofTrait, MerkleTreeTrait};
-use crate::parameter_cache::ParameterSetMetadata;
-use crate::proof::{NoRequirements, ProofScheme};
+use crate::{
+    error::{Error, Result},
+    merkle::{MerkleProofTrait, MerkleTreeTrait},
+    parameter_cache::ParameterSetMetadata,
+    proof::{NoRequirements, ProofScheme},
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DataProof<Proof: MerkleProofTrait> {

--- a/storage-proofs-core/src/proof.rs
+++ b/storage-proofs-core/src/proof.rs
@@ -1,8 +1,7 @@
 use std::time::Instant;
 
 use log::info;
-use serde::de::DeserializeOwned;
-use serde::ser::Serialize;
+use serde::{de::DeserializeOwned, Serialize};
 
 use crate::error::Result;
 

--- a/storage-proofs-core/src/sector.rs
+++ b/storage-proofs-core/src/sector.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeSet;
-use std::fmt;
+use std::fmt::{self, Display, Formatter};
 
 use bellperson::bls::{Fr, FrRepr};
-use byteorder::ByteOrder;
+use byteorder::{ByteOrder, LittleEndian};
 use ff::PrimeField;
 use serde::{Deserialize, Serialize};
 
@@ -33,8 +33,8 @@ impl From<SectorId> for Fr {
     }
 }
 
-impl fmt::Display for SectorId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl Display for SectorId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "SectorId({})", self.0)
     }
 }
@@ -42,7 +42,7 @@ impl fmt::Display for SectorId {
 impl SectorId {
     pub fn as_fr_safe(self) -> [u8; 32] {
         let mut buf: [u8; 32] = [0; 32];
-        byteorder::LittleEndian::write_u64(&mut buf[0..8], self.0);
+        LittleEndian::write_u64(&mut buf[0..8], self.0);
         buf
     }
 }

--- a/storage-proofs-core/src/test_helper.rs
+++ b/storage-proofs-core/src/test_helper.rs
@@ -1,8 +1,8 @@
-use memmap::MmapMut;
-use memmap::MmapOptions;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
+
+use memmap::{MmapMut, MmapOptions};
 
 pub fn setup_replica(data: &[u8], replica_path: &Path) -> MmapMut {
     let mut f = OpenOptions::new()

--- a/storage-proofs-porep/benches/encode.rs
+++ b/storage-proofs-porep/benches/encode.rs
@@ -1,10 +1,7 @@
 use bellperson::bls::Fr;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use ff::Field;
-use filecoin_hashers::{
-    sha256::Sha256Hasher,
-    {Domain, Hasher},
-};
+use filecoin_hashers::{sha256::Sha256Hasher, Domain, Hasher};
 use fr32::fr_into_bytes;
 use rand::thread_rng;
 use storage_proofs_core::api_version::ApiVersion;

--- a/storage-proofs-porep/benches/parents.rs
+++ b/storage-proofs-porep/benches/parents.rs
@@ -1,13 +1,17 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, ParameterizedBenchmark};
 use filecoin_hashers::{blake2s::Blake2sHasher, sha256::Sha256Hasher, Hasher};
-use storage_proofs_core::api_version::ApiVersion;
-use storage_proofs_core::drgraph::{Graph, BASE_DEGREE};
+#[cfg(feature = "cpu-profile")]
+use gperftools::profiler::PROFILER;
+use storage_proofs_core::{
+    api_version::ApiVersion,
+    drgraph::{Graph, BASE_DEGREE},
+};
 use storage_proofs_porep::stacked::{StackedBucketGraph, EXP_DEGREE};
 
 #[cfg(feature = "cpu-profile")]
 #[inline(always)]
 fn start_profile(stage: &str) {
-    gperftools::profiler::PROFILER
+    PROFILER
         .lock()
         .unwrap()
         .start(format!("./{}.profile", stage))
@@ -21,11 +25,7 @@ fn start_profile(_stage: &str) {}
 #[cfg(feature = "cpu-profile")]
 #[inline(always)]
 fn stop_profile() {
-    gperftools::profiler::PROFILER
-        .lock()
-        .unwrap()
-        .stop()
-        .unwrap();
+    PROFILER.lock().unwrap().stop().unwrap();
 }
 
 #[cfg(not(feature = "cpu-profile"))]

--- a/storage-proofs-porep/src/drg/compound.rs
+++ b/storage-proofs-porep/src/drg/compound.rs
@@ -5,7 +5,6 @@ use bellperson::bls::{Bls12, Fr};
 use bellperson::Circuit;
 use filecoin_hashers::Hasher;
 use generic_array::typenum;
-
 use storage_proofs_core::{
     compound_proof::{CircuitComponent, CompoundProof},
     drgraph::Graph,
@@ -17,9 +16,9 @@ use storage_proofs_core::{
     por,
     proof::ProofScheme,
 };
+use typenum::U2;
 
-use super::circuit::DrgPoRepCircuit;
-use super::DrgPoRep;
+use crate::drg::{DrgPoRep, DrgPoRepCircuit};
 
 /// DRG based Proof of Replication.
 ///
@@ -242,7 +241,7 @@ where
     fn blank_circuit(
         public_params: &<DrgPoRep<'a, H, G> as ProofScheme<'a>>::PublicParams,
     ) -> DrgPoRepCircuit<'a, H> {
-        let depth = public_params.graph.merkle_tree_depth::<typenum::U2>() as usize;
+        let depth = public_params.graph.merkle_tree_depth::<U2>() as usize;
         let degree = public_params.graph.degree();
         let arity = 2;
 

--- a/storage-proofs-porep/src/drg/mod.rs
+++ b/storage-proofs-porep/src/drg/mod.rs
@@ -2,6 +2,6 @@ mod circuit;
 mod compound;
 mod vanilla;
 
-pub use self::circuit::*;
-pub use self::compound::*;
-pub use self::vanilla::*;
+pub use circuit::*;
+pub use compound::*;
+pub use vanilla::*;

--- a/storage-proofs-porep/src/lib.rs
+++ b/storage-proofs-porep/src/lib.rs
@@ -2,16 +2,18 @@
 #![warn(clippy::unwrap_used)]
 #![cfg_attr(target_arch = "aarch64", feature(stdsimd))]
 
-pub mod drg;
-pub mod stacked;
-
-mod encode;
-
 use std::path::PathBuf;
 
 use filecoin_hashers::Hasher;
 use merkletree::store::StoreConfig;
 use storage_proofs_core::{error::Result, merkle::BinaryMerkleTree, proof::ProofScheme, Data};
+
+pub mod drg;
+pub mod stacked;
+
+mod encode;
+
+pub const MAX_LEGACY_POREP_REGISTERED_PROOF_ID: u64 = 4;
 
 pub trait PoRep<'a, H: Hasher, G: Hasher>: ProofScheme<'a> {
     type Tau;
@@ -41,5 +43,3 @@ pub trait PoRep<'a, H: Hasher, G: Hasher>: ProofScheme<'a> {
         config: Option<StoreConfig>,
     ) -> Result<Vec<u8>>;
 }
-
-pub const MAX_LEGACY_POREP_REGISTERED_PROOF_ID: u64 = 4;

--- a/storage-proofs-porep/src/stacked/circuit/column_proof.rs
+++ b/storage-proofs-porep/src/stacked/circuit/column_proof.rs
@@ -1,5 +1,4 @@
-use bellperson::bls::Bls12;
-use bellperson::{ConstraintSystem, SynthesisError};
+use bellperson::{bls::Bls12, ConstraintSystem, SynthesisError};
 use filecoin_hashers::{Hasher, PoseidonArity};
 use storage_proofs_core::{
     drgraph::Graph,
@@ -7,8 +6,10 @@ use storage_proofs_core::{
     merkle::{MerkleProofTrait, MerkleTreeTrait, Store},
 };
 
-use super::column::{AllocatedColumn, Column};
-use crate::stacked::{ColumnProof as VanillaColumnProof, PublicParams};
+use crate::stacked::{
+    circuit::column::{AllocatedColumn, Column},
+    vanilla::{ColumnProof as VanillaColumnProof, PublicParams},
+};
 
 #[derive(Debug, Clone)]
 pub struct ColumnProof<

--- a/storage-proofs-porep/src/stacked/circuit/create_label.rs
+++ b/storage-proofs-porep/src/stacked/circuit/create_label.rs
@@ -1,9 +1,13 @@
-use bellperson::gadgets::{
-    boolean::Boolean, multipack, num, sha256::sha256 as sha256_circuit, uint32,
+use bellperson::{
+    bls::Engine,
+    gadgets::{
+        boolean::Boolean, multipack, num::AllocatedNum, sha256::sha256 as sha256_circuit,
+        uint32::UInt32,
+    },
+    ConstraintSystem, SynthesisError,
 };
-use bellperson::{bls::Engine, ConstraintSystem, SynthesisError};
 use ff::PrimeField;
-use storage_proofs_core::{gadgets::uint64, util::reverse_bit_numbering};
+use storage_proofs_core::{gadgets::uint64::UInt64, util::reverse_bit_numbering};
 
 use crate::stacked::vanilla::TOTAL_PARENTS;
 
@@ -12,9 +16,9 @@ pub fn create_label_circuit<E, CS>(
     mut cs: CS,
     replica_id: &[Boolean],
     parents: Vec<Vec<Boolean>>,
-    layer_index: uint32::UInt32,
-    node: uint64::UInt64,
-) -> Result<num::AllocatedNum<E>, SynthesisError>
+    layer_index: UInt32,
+    node: UInt64,
+) -> Result<AllocatedNum<E>, SynthesisError>
 where
     E: Engine,
     CS: ConstraintSystem<E>,
@@ -69,9 +73,10 @@ where
 mod tests {
     use super::*;
 
-    use bellperson::bls::{Bls12, Fr};
-    use bellperson::gadgets::boolean::Boolean;
-    use bellperson::util_cs::test_cs::TestConstraintSystem;
+    use bellperson::{
+        bls::{Bls12, Fr},
+        util_cs::test_cs::TestConstraintSystem,
+    };
     use ff::Field;
     use filecoin_hashers::sha256::Sha256Hasher;
     use fr32::{bytes_into_fr, fr_into_bytes};
@@ -84,7 +89,7 @@ mod tests {
         TEST_SEED,
     };
 
-    use crate::stacked::vanilla::{create_label, StackedBucketGraph, EXP_DEGREE, TOTAL_PARENTS};
+    use crate::stacked::vanilla::{create_label, StackedBucketGraph, EXP_DEGREE};
 
     #[test]
     fn test_create_label() {
@@ -152,8 +157,8 @@ mod tests {
             bytes_into_boolean_vec_be(&mut cs, Some(id.as_slice()), id.len()).unwrap()
         };
 
-        let layer_alloc = uint32::UInt32::constant(layer as u32);
-        let node_alloc = uint64::UInt64::constant(node as u64);
+        let layer_alloc = UInt32::constant(layer as u32);
+        let node_alloc = UInt64::constant(node as u64);
 
         let out = create_label_circuit(
             cs.namespace(|| "create_label"),

--- a/storage-proofs-porep/src/stacked/circuit/mod.rs
+++ b/storage-proofs-porep/src/stacked/circuit/mod.rs
@@ -5,5 +5,5 @@ mod hash;
 mod params;
 mod proof;
 
-pub use self::create_label::*;
-pub use self::proof::{StackedCircuit, StackedCompound};
+pub use create_label::*;
+pub use proof::{StackedCircuit, StackedCompound};

--- a/storage-proofs-porep/src/stacked/mod.rs
+++ b/storage-proofs-porep/src/stacked/mod.rs
@@ -1,5 +1,5 @@
 mod circuit;
 mod vanilla;
 
-pub use self::circuit::*;
-pub use self::vanilla::*;
+pub use circuit::*;
+pub use vanilla::*;

--- a/storage-proofs-porep/src/stacked/vanilla/challenges.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/challenges.rs
@@ -1,9 +1,8 @@
+use filecoin_hashers::Domain;
 use num_bigint::BigUint;
 use num_traits::cast::ToPrimitive;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-
-use filecoin_hashers::Domain;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LayerChallenges {
@@ -80,9 +79,10 @@ pub struct ChallengeRequirements {
 mod test {
     use super::*;
 
+    use std::collections::HashMap;
+
     use filecoin_hashers::sha256::Sha256Domain;
     use rand::{thread_rng, Rng};
-    use std::collections::HashMap;
 
     #[test]
     fn test_calculate_fixed_challenges() {

--- a/storage-proofs-porep/src/stacked/vanilla/column.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/column.rs
@@ -3,13 +3,12 @@ use std::marker::PhantomData;
 use bellperson::bls::Fr;
 use filecoin_hashers::Hasher;
 use serde::{Deserialize, Serialize};
-
 use storage_proofs_core::{
     error::Result,
     merkle::{MerkleTreeTrait, Store},
 };
 
-use super::{column_proof::ColumnProof, hash::hash_single_column};
+use crate::stacked::vanilla::{column_proof::ColumnProof, hash::hash_single_column};
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Column<H: Hasher> {

--- a/storage-proofs-porep/src/stacked/vanilla/column_proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/column_proof.rs
@@ -1,10 +1,10 @@
 use bellperson::bls::Fr;
 use filecoin_hashers::Hasher;
 use log::trace;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use storage_proofs_core::{error::Result, merkle::MerkleProofTrait};
 
-use super::column::Column;
+use crate::stacked::vanilla::Column;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ColumnProof<Proof: MerkleProofTrait> {
@@ -15,7 +15,7 @@ pub struct ColumnProof<Proof: MerkleProofTrait> {
     pub(crate) column: Column<Proof::Hasher>,
     #[serde(bound(
         serialize = "Proof: Serialize",
-        deserialize = "Proof: serde::de::DeserializeOwned"
+        deserialize = "Proof: DeserializeOwned"
     ))]
     pub(crate) inclusion_proof: Proof,
 }

--- a/storage-proofs-porep/src/stacked/vanilla/cores.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/cores.rs
@@ -1,18 +1,16 @@
-use log::*;
 use std::sync::{Mutex, MutexGuard};
 
-use anyhow::Result;
-use hwloc::{ObjectType, Topology, TopologyObject, CPUBIND_THREAD};
+use anyhow::{format_err, Result};
+use hwloc::{Bitmap, ObjectType, Topology, TopologyObject, CPUBIND_THREAD};
 use lazy_static::lazy_static;
-
-use storage_proofs_core::settings;
+use log::{debug, info, warn};
+use storage_proofs_core::settings::SETTINGS;
 
 type CoreGroup = Vec<CoreIndex>;
 lazy_static! {
     pub static ref TOPOLOGY: Mutex<Topology> = Mutex::new(Topology::new());
     pub static ref CORE_GROUPS: Option<Vec<Mutex<CoreGroup>>> = {
-        let settings = &settings::SETTINGS;
-        let num_producers = settings.multicore_sdr_producers;
+        let num_producers = &SETTINGS.multicore_sdr_producers;
         let cores_per_unit = num_producers + 1;
 
         core_groups(cores_per_unit)
@@ -62,7 +60,7 @@ fn get_thread_id() -> ThreadId {
 
 pub struct Cleanup {
     tid: ThreadId,
-    prior_state: Option<hwloc::Bitmap>,
+    prior_state: Option<Bitmap>,
 }
 
 impl Drop for Cleanup {
@@ -79,13 +77,12 @@ pub fn bind_core(core_index: CoreIndex) -> Result<Cleanup> {
     let child_topo = &TOPOLOGY;
     let tid = get_thread_id();
     let mut locked_topo = child_topo.lock().expect("poisoned lock");
-    let core = get_core_by_index(&locked_topo, core_index).map_err(|err| {
-        anyhow::format_err!("failed to get core at index {}: {:?}", core_index.0, err)
-    })?;
+    let core = get_core_by_index(&locked_topo, core_index)
+        .map_err(|err| format_err!("failed to get core at index {}: {:?}", core_index.0, err))?;
 
-    let cpuset = core.allowed_cpuset().ok_or_else(|| {
-        anyhow::format_err!("no allowed cpuset for core at index {}", core_index.0,)
-    })?;
+    let cpuset = core
+        .allowed_cpuset()
+        .ok_or_else(|| format_err!("no allowed cpuset for core at index {}", core_index.0,))?;
     debug!("allowed cpuset: {:?}", cpuset);
     let mut bind_to = cpuset;
 
@@ -99,7 +96,7 @@ pub fn bind_core(core_index: CoreIndex) -> Result<Cleanup> {
     // Set the binding.
     let result = locked_topo
         .set_cpubind_for_thread(tid, bind_to, CPUBIND_THREAD)
-        .map_err(|err| anyhow::format_err!("failed to bind CPU: {:?}", err));
+        .map_err(|err| format_err!("failed to bind CPU: {:?}", err));
 
     if result.is_err() {
         warn!("error in bind_core, {:?}", result);
@@ -116,12 +113,12 @@ fn get_core_by_index<'a>(topo: &'a Topology, index: CoreIndex) -> Result<&'a Top
 
     match topo.objects_with_type(&ObjectType::Core) {
         Ok(all_cores) if idx < all_cores.len() => Ok(all_cores[idx]),
-        Ok(all_cores) => Err(anyhow::format_err!(
+        Ok(all_cores) => Err(format_err!(
             "idx ({}) out of range for {} cores",
             idx,
             all_cores.len()
         )),
-        _e => Err(anyhow::format_err!("failed to get core by index {}", idx,)),
+        _e => Err(format_err!("failed to get core by index {}", idx,)),
     }
 }
 

--- a/storage-proofs-porep/src/stacked/vanilla/encoding_proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/encoding_proof.rs
@@ -1,9 +1,9 @@
-use log::trace;
 use std::marker::PhantomData;
 
 use bellperson::bls::Fr;
 use filecoin_hashers::Hasher;
 use fr32::bytes_into_fr_repr_safe;
+use log::trace;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 

--- a/storage-proofs-porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/graph.rs
@@ -1,4 +1,5 @@
 use std::convert::{TryFrom, TryInto};
+use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 
 use anyhow::ensure;
@@ -12,16 +13,15 @@ use storage_proofs_core::{
         feistel::{self, FeistelPrecomputed},
         FEISTEL_DST,
     },
-    drgraph::BASE_DEGREE,
-    drgraph::{BucketGraph, Graph},
+    drgraph::{BucketGraph, Graph, BASE_DEGREE},
     error::Result,
     parameter_cache::ParameterSetMetadata,
-    settings,
+    settings::SETTINGS,
     util::NODE_SIZE,
     PoRepID,
 };
 
-use super::cache::ParentCache;
+use crate::stacked::vanilla::cache::ParentCache;
 
 /// The expansion degree used for Stacked Graphs.
 pub const EXP_DEGREE: usize = 8;
@@ -43,12 +43,12 @@ where
     _h: PhantomData<H>,
 }
 
-impl<H, G> std::fmt::Debug for StackedGraph<H, G>
+impl<H, G> Debug for StackedGraph<H, G>
 where
     H: Hasher,
     G: Graph<H> + 'static,
 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("StackedGraph")
             .field("expansion_degree", &self.expansion_degree)
             .field("base_graph", &self.base_graph)
@@ -105,7 +105,7 @@ where
     ) -> Result<Self> {
         assert_eq!(base_degree, BASE_DEGREE);
         assert_eq!(expansion_degree, EXP_DEGREE);
-        ensure!(nodes <= std::u32::MAX as usize, "too many nodes");
+        ensure!(nodes <= u32::MAX as usize, "too many nodes");
 
         let base_graph = match base_graph {
             Some(graph) => graph,
@@ -135,7 +135,7 @@ where
     /// Returns a reference to the parent cache.
     pub fn parent_cache(&self) -> Result<ParentCache> {
         // Number of nodes to be cached in memory
-        let default_cache_size = settings::SETTINGS.sdr_parents_cache_size;
+        let default_cache_size = SETTINGS.sdr_parents_cache_size;
         let cache_entries = self.size() as u32;
         let cache_size = cache_entries.min(default_cache_size);
 

--- a/storage-proofs-porep/src/stacked/vanilla/macros.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/macros.rs
@@ -49,21 +49,20 @@ macro_rules! prefetch {
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         unsafe {
             #[cfg(target_arch = "x86")]
-            use std::arch::x86::*;
+            use std::arch::x86;
             #[cfg(target_arch = "x86_64")]
-            use std::arch::x86_64::*;
+            use std::arch::x86_64 as x86;
 
-            _mm_prefetch($val, _MM_HINT_T0);
+            x86::_mm_prefetch($val, x86::_MM_HINT_T0);
         }
-        #[cfg(all(target_arch = "aarch64"))]
+        #[cfg(target_arch = "aarch64")]
         unsafe {
-            use std::arch::aarch64::*;
+            use std::arch::aarch64::{_prefetch, _PREFETCH_LOCALITY3, _PREFETCH_READ};
             _prefetch($val, _PREFETCH_READ, _PREFETCH_LOCALITY3);
         }
     };
 }
 
-#[macro_export]
 macro_rules! compress256 {
     ($state:expr, $buf:expr, 1) => {
         let blocks = [*GenericArray::<u8, U64>::from_slice(&$buf[..64])];

--- a/storage-proofs-porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/mod.rs
@@ -1,15 +1,16 @@
 #[macro_use]
 mod macros;
 
+pub mod create_label;
+pub(crate) mod hash;
+
 mod cache;
 mod challenges;
 mod column;
 mod column_proof;
 mod cores;
-pub mod create_label;
 mod encoding_proof;
 mod graph;
-pub(crate) mod hash;
 mod labeling_proof;
 mod memory_handling;
 mod params;
@@ -18,11 +19,11 @@ mod proof;
 mod proof_scheme;
 mod utils;
 
-pub use self::challenges::{ChallengeRequirements, LayerChallenges};
-pub use self::column::Column;
-pub use self::column_proof::ColumnProof;
-pub use self::encoding_proof::EncodingProof;
-pub use self::graph::{StackedBucketGraph, StackedGraph, EXP_DEGREE};
-pub use self::labeling_proof::LabelingProof;
-pub use self::params::*;
-pub use self::proof::{StackedDrg, TOTAL_PARENTS};
+pub use challenges::{ChallengeRequirements, LayerChallenges};
+pub use column::Column;
+pub use column_proof::ColumnProof;
+pub use encoding_proof::EncodingProof;
+pub use graph::{StackedBucketGraph, StackedGraph, EXP_DEGREE};
+pub use labeling_proof::LabelingProof;
+pub use params::*;
+pub use proof::{StackedDrg, TOTAL_PARENTS};

--- a/storage-proofs-porep/src/stacked/vanilla/porep.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/porep.rs
@@ -8,11 +8,13 @@ use storage_proofs_core::{
     Data,
 };
 
-use super::{
-    params::{PersistentAux, PublicParams, Tau, TemporaryAux},
-    proof::StackedDrg,
+use crate::{
+    stacked::vanilla::{
+        params::{PersistentAux, PublicParams, Tau, TemporaryAux},
+        proof::StackedDrg,
+    },
+    PoRep,
 };
-use crate::PoRep;
 
 impl<'a, 'c, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> PoRep<'a, Tree::Hasher, G>
     for StackedDrg<'a, Tree, G>

--- a/storage-proofs-porep/src/stacked/vanilla/proof_scheme.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof_scheme.rs
@@ -1,12 +1,12 @@
 use anyhow::ensure;
 use filecoin_hashers::{HashFunction, Hasher};
 use log::trace;
-use rayon::prelude::*;
+use rayon::prelude::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use storage_proofs_core::{
     drgraph::Graph, error::Result, merkle::MerkleTreeTrait, proof::ProofScheme,
 };
 
-use super::{
+use crate::stacked::vanilla::{
     challenges::ChallengeRequirements,
     graph::StackedBucketGraph,
     params::{PrivateInputs, Proof, PublicInputs, PublicParams, SetupParams},
@@ -136,7 +136,7 @@ impl<'a, 'c, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> ProofScheme<'
     }
 
     fn with_partition(pub_in: Self::PublicInputs, k: Option<usize>) -> Self::PublicInputs {
-        self::PublicInputs {
+        PublicInputs {
             replica_id: pub_in.replica_id,
             seed: pub_in.seed,
             tau: pub_in.tau,

--- a/storage-proofs-porep/src/stacked/vanilla/utils.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/utils.rs
@@ -1,4 +1,5 @@
 use std::cell::UnsafeCell;
+use std::slice::{self, ChunksExactMut};
 
 /// A slice type which can be shared between threads, but must be fully managed by the caller.
 /// Any synchronization must be ensured by the caller, which is why all access is `unsafe`.
@@ -26,12 +27,12 @@ impl<'a, T> UnsafeSlice<'a, T> {
     /// Safety: The caller must ensure that there are no unsynchronized parallel access to the same regions.
     #[inline]
     pub unsafe fn as_mut_slice(&self) -> &'a mut [T] {
-        std::slice::from_raw_parts_mut(self.ptr, self.len)
+        slice::from_raw_parts_mut(self.ptr, self.len)
     }
     /// Safety: The caller must ensure that there are no unsynchronized parallel access to the same regions.
     #[inline]
     pub unsafe fn as_slice(&self) -> &'a [T] {
-        std::slice::from_raw_parts(self.ptr, self.len)
+        slice::from_raw_parts(self.ptr, self.len)
     }
 
     #[inline]
@@ -108,7 +109,7 @@ impl RingBuf {
 
     #[allow(clippy::mut_from_ref)]
     unsafe fn slice_mut(&self) -> &mut [u8] {
-        std::slice::from_raw_parts_mut((*self.data.get()).as_mut_ptr(), self.len())
+        slice::from_raw_parts_mut((*self.data.get()).as_mut_ptr(), self.len())
     }
 
     fn len(&self) -> usize {
@@ -123,7 +124,7 @@ impl RingBuf {
         &mut self.slice_mut()[start..end]
     }
 
-    pub fn iter_slot_mut(&mut self) -> std::slice::ChunksExactMut<'_, u8> {
+    pub fn iter_slot_mut(&mut self) -> ChunksExactMut<'_, u8> {
         // Safety: safe because we are holding &mut self
         unsafe { self.slice_mut().chunks_exact_mut(self.slot_size) }
     }

--- a/storage-proofs-porep/tests/drg_circuit.rs
+++ b/storage-proofs-porep/tests/drg_circuit.rs
@@ -28,6 +28,7 @@ use storage_proofs_porep::{
     stacked::BINARY_ARITY,
     PoRep,
 };
+use tempfile::tempdir;
 
 #[test]
 fn test_drg_porep_circuit() {
@@ -45,7 +46,7 @@ fn test_drg_porep_circuit() {
 
     // MT for original data is always named tree-d, and it will be
     // referenced later in the process as such.
-    let cache_dir = tempfile::tempdir().unwrap();
+    let cache_dir = tempdir().unwrap();
     let config = StoreConfig::new(
         cache_dir.path(),
         CacheKey::CommDTree.to_string(),

--- a/storage-proofs-porep/tests/drg_compound.rs
+++ b/storage-proofs-porep/tests/drg_compound.rs
@@ -26,6 +26,7 @@ use storage_proofs_porep::{
     stacked::BINARY_ARITY,
     PoRep,
 };
+use tempfile::tempdir;
 
 #[test]
 #[ignore]
@@ -51,7 +52,7 @@ fn drg_porep_compound<Tree: 'static + MerkleTreeTrait>() {
 
     // MT for original data is always named tree-d, and it will be
     // referenced later in the process as such.
-    let cache_dir = tempfile::tempdir().unwrap();
+    let cache_dir = tempdir().unwrap();
     let config = StoreConfig::new(
         cache_dir.path(),
         CacheKey::CommDTree.to_string(),

--- a/storage-proofs-porep/tests/drg_vanilla.rs
+++ b/storage-proofs-porep/tests/drg_vanilla.rs
@@ -22,6 +22,7 @@ use storage_proofs_porep::{
     stacked::BINARY_ARITY,
     PoRep,
 };
+use tempfile::tempdir;
 
 #[test]
 fn text_drg_porep_extract_all_sha256() {
@@ -43,7 +44,7 @@ fn test_extract_all<Tree: MerkleTreeTrait>() {
 
     // MT for original data is always named tree-d, and it will be
     // referenced later in the process as such.
-    let cache_dir = tempfile::tempdir().expect("tempdir failure");
+    let cache_dir = tempdir().expect("tempdir failure");
     let config = StoreConfig::new(
         cache_dir.path(),
         CacheKey::CommDTree.to_string(),
@@ -118,7 +119,7 @@ fn test_extract<Tree: MerkleTreeTrait>() {
 
     // MT for original data is always named tree-d, and it will be
     // referenced later in the process as such.
-    let cache_dir = tempfile::tempdir().expect("tempdir failure");
+    let cache_dir = tempdir().expect("tempdir failure");
     let config = StoreConfig::new(
         cache_dir.path(),
         CacheKey::CommDTree.to_string(),
@@ -212,7 +213,7 @@ fn test_prove_verify_aux<Tree: MerkleTreeTrait>(
 
         // MT for original data is always named tree-d, and it will be
         // referenced later in the process as such.
-        let cache_dir = tempfile::tempdir().expect("tempdir failure");
+        let cache_dir = tempdir().expect("tempdir failure");
         let config = StoreConfig::new(
             cache_dir.path(),
             CacheKey::CommDTree.to_string(),

--- a/storage-proofs-porep/tests/stacked_circuit.rs
+++ b/storage-proofs-porep/tests/stacked_circuit.rs
@@ -28,6 +28,7 @@ use storage_proofs_porep::{
     },
     PoRep,
 };
+use tempfile::tempdir;
 
 #[test]
 fn test_stacked_porep_circuit_poseidon_base_2() {
@@ -68,7 +69,7 @@ fn test_stacked_porep_circuit<Tree: MerkleTreeTrait + 'static>(
 
     // MT for original data is always named tree-d, and it will be
     // referenced later in the process as such.
-    let cache_dir = tempfile::tempdir().unwrap();
+    let cache_dir = tempdir().unwrap();
     let config = StoreConfig::new(
         cache_dir.path(),
         CacheKey::CommDTree.to_string(),

--- a/storage-proofs-porep/tests/stacked_compound.rs
+++ b/storage-proofs-porep/tests/stacked_compound.rs
@@ -27,6 +27,7 @@ use storage_proofs_porep::{
     },
     PoRep,
 };
+use tempfile::tempdir;
 
 #[test]
 #[ignore]
@@ -78,7 +79,7 @@ fn test_stacked_compound<Tree: 'static + MerkleTreeTrait>() {
 
     // MT for original data is always named tree-d, and it will be
     // referenced later in the process as such.
-    let cache_dir = tempfile::tempdir().unwrap();
+    let cache_dir = tempdir().unwrap();
     let config = StoreConfig::new(
         cache_dir.path(),
         CacheKey::CommDTree.to_string(),

--- a/storage-proofs-post/src/election/compound.rs
+++ b/storage-proofs-post/src/election/compound.rs
@@ -1,11 +1,13 @@
 use std::marker::PhantomData;
 
-use bellperson::bls::{Bls12, Fr};
-use bellperson::Circuit;
+use bellperson::{
+    bls::{Bls12, Fr},
+    Circuit,
+};
 use generic_array::typenum::Unsigned;
 use storage_proofs_core::{
     compound_proof::{CircuitComponent, CompoundProof},
-    drgraph,
+    drgraph::graph_height,
     error::Result,
     gadgets::por::PoRCompound,
     merkle::MerkleTreeTrait,
@@ -15,7 +17,7 @@ use storage_proofs_core::{
     util::NODE_SIZE,
 };
 
-use crate::election::{self, ElectionPoSt, ElectionPoStCircuit};
+use crate::election::{generate_leaf_challenge, ElectionPoSt, ElectionPoStCircuit};
 
 pub struct ElectionPoStCompound<Tree>
 where
@@ -56,7 +58,7 @@ where
         // 2. Inputs for verifying inclusion paths
 
         for n in 0..pub_params.challenge_count {
-            let challenged_leaf_start = election::generate_leaf_challenge(
+            let challenged_leaf_start = generate_leaf_challenge(
                 &pub_params,
                 pub_inputs.randomness,
                 pub_inputs.sector_challenge_index,
@@ -133,8 +135,7 @@ where
         pub_params: &<ElectionPoSt<'a, Tree> as ProofScheme<'a>>::PublicParams,
     ) -> ElectionPoStCircuit<Tree> {
         let challenges_count = pub_params.challenged_nodes * pub_params.challenge_count;
-        let height =
-            drgraph::graph_height::<Tree::Arity>(pub_params.sector_size as usize / NODE_SIZE);
+        let height = graph_height::<Tree::Arity>(pub_params.sector_size as usize / NODE_SIZE);
 
         let leafs = vec![None; challenges_count];
         let paths = vec![

--- a/storage-proofs-post/src/fallback/compound.rs
+++ b/storage-proofs-post/src/fallback/compound.rs
@@ -1,8 +1,10 @@
 use std::marker::PhantomData;
 
 use anyhow::{anyhow, ensure};
-use bellperson::bls::{Bls12, Fr};
-use bellperson::Circuit;
+use bellperson::{
+    bls::{Bls12, Fr},
+    Circuit,
+};
 use filecoin_hashers::Hasher;
 use sha2::{Digest, Sha256};
 use storage_proofs_core::{
@@ -16,8 +18,7 @@ use storage_proofs_core::{
     util::NODE_SIZE,
 };
 
-use super::circuit::Sector;
-use crate::fallback::{generate_leaf_challenge_inner, FallbackPoSt, FallbackPoStCircuit};
+use crate::fallback::{generate_leaf_challenge_inner, FallbackPoSt, FallbackPoStCircuit, Sector};
 
 pub struct FallbackPoStCompound<Tree>
 where

--- a/storage-proofs-post/src/fallback/vanilla.rs
+++ b/storage-proofs-post/src/fallback/vanilla.rs
@@ -7,8 +7,10 @@ use byteorder::{ByteOrder, LittleEndian};
 use filecoin_hashers::{Domain, HashFunction, Hasher};
 use generic_array::typenum::Unsigned;
 use log::{error, trace};
-use rayon::prelude::*;
-use serde::{Deserialize, Serialize};
+use rayon::prelude::{
+    IndexedParallelIterator, IntoParallelIterator, IntoParallelRefIterator, ParallelIterator,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use storage_proofs_core::{
     api_version::ApiVersion,
@@ -16,7 +18,7 @@ use storage_proofs_core::{
     merkle::{MerkleProof, MerkleProofTrait, MerkleTreeTrait, MerkleTreeWrapper},
     parameter_cache::ParameterSetMetadata,
     proof::ProofScheme,
-    sector::*,
+    sector::SectorId,
     util::{default_rows_to_discard, NODE_SIZE},
 };
 
@@ -109,7 +111,7 @@ pub struct Proof<P: MerkleProofTrait> {
 pub struct SectorProof<Proof: MerkleProofTrait> {
     #[serde(bound(
         serialize = "MerkleProof<Proof::Hasher, Proof::Arity, Proof::SubTreeArity, Proof::TopTreeArity>: Serialize",
-        deserialize = "MerkleProof<Proof::Hasher, Proof::Arity, Proof::SubTreeArity, Proof::TopTreeArity>: serde::de::DeserializeOwned"
+        deserialize = "MerkleProof<Proof::Hasher, Proof::Arity, Proof::SubTreeArity, Proof::TopTreeArity>: DeserializeOwned"
     ))]
     pub inclusion_proofs:
         Vec<MerkleProof<Proof::Hasher, Proof::Arity, Proof::SubTreeArity, Proof::TopTreeArity>>,

--- a/storage-proofs-post/src/rational/circuit.rs
+++ b/storage-proofs-post/src/rational/circuit.rs
@@ -1,8 +1,10 @@
 use std::marker::PhantomData;
 
-use bellperson::bls::{Bls12, Fr};
-use bellperson::gadgets::num;
-use bellperson::{Circuit, ConstraintSystem, SynthesisError};
+use bellperson::{
+    bls::{Bls12, Fr},
+    gadgets::num::AllocatedNum,
+    Circuit, ConstraintSystem, SynthesisError,
+};
 use filecoin_hashers::{HashFunction, Hasher};
 use storage_proofs_core::{
     compound_proof::CircuitComponent, error::Result, gadgets::constraint, gadgets::por::PoRCircuit,
@@ -48,25 +50,23 @@ impl<'a, Tree: 'static + MerkleTreeTrait> Circuit<Bls12> for RationalPoStCircuit
             .zip(comm_rs.iter())
         {
             let comm_r_last_num =
-                num::AllocatedNum::alloc(cs.namespace(|| format!("comm_r_last_{}", i)), || {
+                AllocatedNum::alloc(cs.namespace(|| format!("comm_r_last_{}", i)), || {
                     comm_r_last
                         .map(Into::into)
                         .ok_or_else(|| SynthesisError::AssignmentMissing)
                 })?;
 
-            let comm_c_num =
-                num::AllocatedNum::alloc(cs.namespace(|| format!("comm_c_{}", i)), || {
-                    comm_c
-                        .map(Into::into)
-                        .ok_or_else(|| SynthesisError::AssignmentMissing)
-                })?;
+            let comm_c_num = AllocatedNum::alloc(cs.namespace(|| format!("comm_c_{}", i)), || {
+                comm_c
+                    .map(Into::into)
+                    .ok_or_else(|| SynthesisError::AssignmentMissing)
+            })?;
 
-            let comm_r_num =
-                num::AllocatedNum::alloc(cs.namespace(|| format!("comm_r_{}", i)), || {
-                    comm_r
-                        .map(Into::into)
-                        .ok_or_else(|| SynthesisError::AssignmentMissing)
-                })?;
+            let comm_r_num = AllocatedNum::alloc(cs.namespace(|| format!("comm_r_{}", i)), || {
+                comm_r
+                    .map(Into::into)
+                    .ok_or_else(|| SynthesisError::AssignmentMissing)
+            })?;
 
             comm_r_num.inputize(cs.namespace(|| format!("comm_r_{}_input", i)))?;
 

--- a/storage-proofs-post/src/rational/compound.rs
+++ b/storage-proofs-post/src/rational/compound.rs
@@ -3,10 +3,10 @@ use std::marker::PhantomData;
 use anyhow::ensure;
 use bellperson::bls::{Bls12, Fr};
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
-use generic_array::typenum;
+use generic_array::typenum::U2;
 use storage_proofs_core::{
     compound_proof::{CircuitComponent, CompoundProof},
-    drgraph,
+    drgraph::graph_height,
     error::Result,
     gadgets::por::PoRCompound,
     merkle::MerkleTreeTrait,
@@ -16,7 +16,7 @@ use storage_proofs_core::{
     util::NODE_SIZE,
 };
 
-use super::{RationalPoSt, RationalPoStCircuit};
+use crate::rational::{RationalPoSt, RationalPoStCircuit};
 
 pub struct RationalPoStCompound<Tree>
 where
@@ -130,8 +130,7 @@ where
         pub_params: &<RationalPoSt<'a, Tree> as ProofScheme<'a>>::PublicParams,
     ) -> RationalPoStCircuit<Tree> {
         let challenges_count = pub_params.challenges_count;
-        let height =
-            drgraph::graph_height::<typenum::U2>(pub_params.sector_size as usize / NODE_SIZE);
+        let height = graph_height::<U2>(pub_params.sector_size as usize / NODE_SIZE);
 
         let comm_rs = vec![None; challenges_count];
         let comm_cs = vec![None; challenges_count];

--- a/storage-proofs-post/src/rational/mod.rs
+++ b/storage-proofs-post/src/rational/mod.rs
@@ -2,6 +2,6 @@ mod circuit;
 mod compound;
 mod vanilla;
 
-pub use self::circuit::*;
-pub use self::compound::*;
-pub use self::vanilla::*;
+pub use circuit::*;
+pub use compound::*;
+pub use vanilla::*;

--- a/storage-proofs-post/tests/election_circuit.rs
+++ b/storage-proofs-post/tests/election_circuit.rs
@@ -22,6 +22,7 @@ use storage_proofs_core::{
 use storage_proofs_post::election::{
     self, generate_candidates, ElectionPoSt, ElectionPoStCircuit, ElectionPoStCompound,
 };
+use tempfile::tempdir;
 
 #[test]
 fn test_election_post_circuit_poseidon() {
@@ -46,7 +47,7 @@ fn test_election_post_circuit<Tree: 'static + MerkleTreeTrait>(expected_constrai
     let mut sectors: Vec<SectorId> = Vec::new();
     let mut trees = BTreeMap::new();
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     for i in 0..5 {

--- a/storage-proofs-post/tests/election_compound.rs
+++ b/storage-proofs-post/tests/election_compound.rs
@@ -19,6 +19,7 @@ use storage_proofs_core::{
 use storage_proofs_post::election::{
     generate_candidates, ElectionPoStCompound, PrivateInputs, PublicInputs, SetupParams,
 };
+use tempfile::tempdir;
 
 #[ignore]
 #[test]
@@ -47,7 +48,7 @@ fn test_election_post_compound<Tree: 'static + MerkleTreeTrait>() {
     let mut sectors: Vec<SectorId> = Vec::new();
     let mut trees = BTreeMap::new();
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     for i in 0..5 {

--- a/storage-proofs-post/tests/election_vanilla.rs
+++ b/storage-proofs-post/tests/election_vanilla.rs
@@ -14,6 +14,7 @@ use storage_proofs_core::{
 use storage_proofs_post::election::{
     generate_candidates, ElectionPoSt, PrivateInputs, PublicInputs, PublicParams,
 };
+use tempfile::tempdir;
 
 #[test]
 fn test_election_post_poseidon_base_8() {
@@ -48,7 +49,7 @@ fn test_election_post<Tree: 'static + MerkleTreeTrait>() {
     let mut sectors: Vec<SectorId> = Vec::new();
     let mut trees = BTreeMap::new();
 
-    let temp_dir = tempfile::tempdir().expect("tempdir failure");
+    let temp_dir = tempdir().expect("tempdir failure");
     let temp_path = temp_dir.path();
 
     for i in 0..5 {

--- a/storage-proofs-post/tests/fallback_circuit.rs
+++ b/storage-proofs-post/tests/fallback_circuit.rs
@@ -21,6 +21,7 @@ use storage_proofs_post::fallback::{
     self, FallbackPoSt, FallbackPoStCircuit, FallbackPoStCompound, PrivateSector, PublicSector,
     Sector,
 };
+use tempfile::tempdir;
 
 #[test]
 fn test_fallback_post_circuit_poseidon_single_partition_base_8() {
@@ -75,7 +76,7 @@ fn test_fallback_post<Tree: 'static + MerkleTreeTrait>(
         api_version: ApiVersion::V1_1_0,
     };
 
-    let temp_dir = tempfile::tempdir().expect("tempdir failure");
+    let temp_dir = tempdir().expect("tempdir failure");
     let temp_path = temp_dir.path();
 
     let mut pub_sectors = Vec::new();

--- a/storage-proofs-post/tests/fallback_compound.rs
+++ b/storage-proofs-post/tests/fallback_compound.rs
@@ -18,6 +18,7 @@ use storage_proofs_post::fallback::{
     ChallengeRequirements, FallbackPoStCompound, PrivateInputs, PrivateSector, PublicInputs,
     PublicSector, SetupParams,
 };
+use tempfile::tempdir;
 
 #[ignore]
 #[test]
@@ -88,7 +89,7 @@ fn fallback_post<Tree: 'static + MerkleTreeTrait>(
         priority: false,
     };
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     let mut pub_sectors = Vec::new();

--- a/storage-proofs-post/tests/fallback_vanilla.rs
+++ b/storage-proofs-post/tests/fallback_vanilla.rs
@@ -12,6 +12,7 @@ use storage_proofs_core::{
     TEST_SEED,
 };
 use storage_proofs_post::fallback::{self, FallbackPoSt, PrivateSector, PublicSector};
+use tempfile::tempdir;
 
 #[test]
 fn test_fallback_post_poseidon_single_partition_base_8() {
@@ -132,7 +133,7 @@ fn test_fallback_post<Tree: MerkleTreeTrait>(
     let randomness = <Tree::Hasher as Hasher>::Domain::random(rng);
     let prover_id = <Tree::Hasher as Hasher>::Domain::random(rng);
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     let mut pub_sectors = Vec::new();
@@ -303,7 +304,7 @@ fn test_invalid_fallback_post<Tree: MerkleTreeTrait>(
     let randomness = <Tree::Hasher as Hasher>::Domain::random(rng);
     let prover_id = <Tree::Hasher as Hasher>::Domain::random(rng);
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     let mut pub_sectors = Vec::new();

--- a/storage-proofs-post/tests/rational_circuit.rs
+++ b/storage-proofs-post/tests/rational_circuit.rs
@@ -21,6 +21,7 @@ use storage_proofs_core::{
 use storage_proofs_post::rational::{
     self, derive_challenges, RationalPoSt, RationalPoStCircuit, RationalPoStCompound,
 };
+use tempfile::tempdir;
 
 #[test]
 fn test_rational_post_circuit_poseidon() {
@@ -39,7 +40,7 @@ fn test_rational_post_circuit<Tree: 'static + MerkleTreeTrait>(expected_constrai
         challenges_count,
     };
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     let (_data1, tree1) = generate_tree::<Tree, _>(rng, leaves, Some(temp_path.to_path_buf()));

--- a/storage-proofs-post/tests/rational_compound.rs
+++ b/storage-proofs-post/tests/rational_compound.rs
@@ -12,8 +12,8 @@ use storage_proofs_core::{
     util::NODE_SIZE,
     TEST_SEED,
 };
-
 use storage_proofs_post::rational::{self, derive_challenges, RationalPoStCompound};
+use tempfile::tempdir;
 
 #[ignore]
 #[test]
@@ -39,7 +39,7 @@ fn test_rational_post_compound<Tree: 'static + MerkleTreeTrait>() {
 
     let pub_params = RationalPoStCompound::<Tree>::setup(&setup_params).expect("setup failed");
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     let (_data1, tree1) = generate_tree::<Tree, _>(rng, leaves, Some(temp_path.to_path_buf()));

--- a/storage-proofs-post/tests/rational_vanilla.rs
+++ b/storage-proofs-post/tests/rational_vanilla.rs
@@ -14,6 +14,7 @@ use storage_proofs_core::{
     TEST_SEED,
 };
 use storage_proofs_post::rational::{self, derive_challenges, RationalPoSt};
+use tempfile::tempdir;
 
 #[test]
 fn test_rational_post_sha256_base_8() {
@@ -55,7 +56,7 @@ where
         challenges_count,
     };
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     let (_data1, tree1) = generate_tree::<Tree, _>(rng, leaves, Some(temp_path.to_path_buf()));
@@ -161,7 +162,7 @@ fn test_rational_post_validates_challenge<Tree: 'static + MerkleTreeTrait>() {
         challenges_count,
     };
 
-    let temp_dir = tempfile::tempdir().unwrap();
+    let temp_dir = tempdir().unwrap();
     let temp_path = temp_dir.path();
 
     let (_data, tree) = generate_tree::<Tree, _>(rng, leaves, Some(temp_path.to_path_buf()));


### PR DESCRIPTION
1. Removes glob imports everywhere except in two cases:

when re-exporting in `lib.rs`/`mod.rs` files:
```rust
mod mod_1;
mod mod_2;

pub use mod_1::*;
pub use mod_2::*;
```

in unit test submodules:
```rust
#[cfg(test)]
mod tests {
    use super::*;
}
```

2. Enforces the import order:

```rust
// Only in lib.rs/mod.rs files
#[macro_use]
pub mod public_module_containing_macros;

// Only in lib.rs/mod.rs files
#[macro_use]
mod private_module_containing_macros;

// Only as the first line of an inner-file submodule e.g. `mod tests`
use super::*;

use std::something;

pub use external_crate::something_to_export;

use external_crate::something_to_use;

pub use crate::something_to_export;

use crate::something_to_use;

pub mod public_module;

mod private_module;

pub use some_module::something_to_export;

use some_module::something_to_use;
```

3. Removes unnecessary/repeated namespace operators:
```rust
// Changed code like this:
let x = std::io::copy(...);
let y = std::io::copy(...);
let z = std::io::copy(...);

// To this:
use std::io;

let x = io::copy(...);
let y = io::copy(...);
let z = io::copy(...);
``` 

4. Uses nested imports (except in std library imports):
```rust
use std::io;
use std::fs;

use crate::{mod_1::thing, mod_2::other_thing};
```

5. Removes duplicate imports, for example in code like:
```rust
use something;

#[cfg(test)]
mod tests {
    use something;
}
```

6. Replaces hard to read imports like:
```rust
use super::super::something;
```

7. Removes `enum` variant imports:
```rust
// Changes something like this:
use some_crate::SomeEnum::SomeVariant;

let x = SomeVariant;

// To this:
use some_crate::SomeEnum;

let x = SomeEnum::SomeVariant;
```