### PR TITLE
feat: use feature [compress, asm] of sha2 for aarch64

### DIFF
--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -19,7 +19,6 @@ merkletree = "0.21.0"
 mapr = "0.8.0"
 num-bigint = "0.2"
 num-traits = "0.2"
-sha2 = { version = "0.9.1", features = ["compress"] }
 rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
@@ -40,6 +39,11 @@ hwloc = "0.3.0"
 libc = "0.2"
 fdlimit = "0.2.0"
 fr32 = { path = "../fr32", default-features = false }
+
+[target."cfg(target_arch = \"aarch64\")".dependencies]
+sha2 = { version = "0.9.3", features = ["compress", "asm"] }
+[target."cfg(not(target_arch = \"aarch64\"))".dependencies]
+sha2 = { version = "0.9.3", features = ["compress"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
Hi,

As of now, if `FIL_PROOFS_USE_MULTICORE_SDR == 1`, `sha2::compress256` is used to hash the data in `Phase 1`.
The function `sha2::compress256` is provided with feature `compress` of sha2.
But for aarch64, only with feature `compress`, the `sha2::compress256` does not use the aarch64 accelerators, e.g. `sha256su0`, but degradats to `soft_compress`.
According to our tests, that ~x6 slower than the ASM one.
We should add feature `asm` to enable those aarch64 accelerators as the code [1] in `sha2` shows.

Due to the compile BUG of `sha2` fixed by PR `https://github.com/RustCrypto/hashes/pull/207`, commited as `78f00c5f6d218`, we need a git dependency here.

In addition, to keep `x86` use only `compress` of sha2 as before, we need add `-Zfeatures=itarget` to support conditional compilation of dependency feature based on target.
I've raise a separate PR (https://github.com/filecoin-project/filecoin-ffi/pull/163) in `filecoin-ffi` for this.

Regards.

[1] https://github.com/RustCrypto/hashes/blob/a18e0bdaac45ad97419292b24fb1e3d470336d11/sha2/src/sha256.rs#L145
