### PR TITLE
fix(fil-proofs-tooling): fix circuitinfo's binary name

### DIFF
--- a/fil-proofs-tooling/src/bin/circuitinfo/main.rs
+++ b/fil-proofs-tooling/src/bin/circuitinfo/main.rs
@@ -83,7 +83,7 @@ fn get_window_post_info<Tree: 'static + MerkleTreeTrait>(post_config: &PoStConfi
 }
 
 #[derive(Debug, StructOpt)]
-#[structopt(name = "paramcache")]
+#[structopt(name = "circuitinfo")]
 struct Opt {
     #[structopt(long)]
     winning: bool,


### PR DESCRIPTION
The `circuitinfo` binary is incorrectly named `paramcache` in its cli.