### PR TITLE
fix: use latest version of dialoguer

### DIFF
--- a/fil-proofs-param/Cargo.toml
+++ b/fil-proofs-param/Cargo.toml
@@ -46,7 +46,7 @@ structopt = "0.3.12"
 humansize = "1.1.0"
 indicatif = "0.15.0"
 groupy = "0.3.0"
-dialoguer = "0.7.1"
+dialoguer = "0.8.0"
 clap = "2.33.3"
 
 [dependencies.reqwest]

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -48,7 +48,7 @@ typenum = "1.11.2"
 generic-array = "0.14.4"
 byte-unit = "4.0.9"
 fdlimit = "0.2.0"
-dialoguer = "0.7.1"
+dialoguer = "0.8.0"
 structopt = "0.3.12"
 humansize = "1.1.0"
 


### PR DESCRIPTION
The older version of dialoguer had a dependency on zerioize that
was yanked, hence making builds fail.

I've tried out some of the tools using `dialoguer` locally.

 - `circuitinfo`: seems to do the correct thing interface wise, but it didn't print any information for me. I can't tell if it worked before or not
 - `paramcache`: the output isn't as smooth I remembered it (but I can't tell if it was the same prior to this change, but i suspect it was), but it seems to work properly
 - `paramfetch`: seems to work as expected

So I think this PR is OK to be merged.