### PR TITLE
chore: improve Clippy on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,6 @@ jobs:
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
       - run: rustup install << pipeline.parameters.nightly-toolchain >>
-      - run: rustup component add rustfmt-preview
-      - run: rustup component add clippy
       - run: cargo update
       - run: cargo fetch
       - run: rustc +$(cat rust-toolchain) --version
@@ -327,7 +325,7 @@ jobs:
       - restore_rustup_cache
       - run:
           name: Run cargo clippy
-          command: cargo +$(cat rust-toolchain) clippy --workspace
+          command: cargo +$(cat rust-toolchain) clippy --all-targets --workspace -- -D warnings
   test_darwin:
     macos:
       xcode: "10.0.0"


### PR DESCRIPTION
Clippy is run on CI, but even if there are warnings, the CI doesn't
fail. With this commit the CI fails when there are Clippy warnings.
It also runs Clippy on all the code (also tests, benchmarks and
examples) now.