### PR TITLE
fix: remove build conditional (not needed; not clear it was used)

### DIFF
--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -39,11 +39,7 @@ hwloc = "0.3.0"
 libc = "0.2"
 fdlimit = "0.2.0"
 fr32 = { path = "../fr32", version = "^1.0.0", default-features = false }
-
-[target."cfg(target_arch = \"aarch64\")".dependencies]
 sha2 = { version = "0.9.3", features = ["compress", "asm"] }
-[target."cfg(not(target_arch = \"aarch64\"))".dependencies]
-sha2 = { version = "0.9.3", features = ["compress"] }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
I recall an error with this kind of conditional not actually working (but silently):

https://github.com/filecoin-project/rust-fil-proofs/blame/master/storage-proofs-porep/Cargo.toml#L43

I believe it's no longer needed in any case with asm support for all supported platforms in sha2 now available.