### PR TITLE
fix: update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,8 @@ members = [
   "sha2raw",
   "filecoin-hashers",
 ]
+
+[patch.crates-io]
+rust-gpu-tools = { git = "https://github.com/filecoin-project/rust-gpu-tools", branch = "master" }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "opencl3" }
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "opencl3" }


### PR DESCRIPTION
Update to the latest versions of rust-gpu-tools, which is now using
`opencl3` instead of `ocl`. Also update to the latest version of
neptune, which got its API a bit cleaned up and doesn't need the
`BatcherType` anymore, but used that batchers directly.