### PR TITLE
feat: use OnceCell for srs key caches to avoid duplicate generation

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -40,6 +40,7 @@ generic-array = "0.14.4"
 groupy = "0.4.1"
 byte-slice-cast = "1.0.0"
 fr32 = { path = "../fr32", version = "^1.0.0", default-features = false }
+once_cell = "1.8.0"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -29,6 +29,10 @@ type Cache<G> = HashMap<String, Arc<G>>;
 type GrothMemCache = Cache<Bls12GrothParams>;
 type VerifyingKeyMemCache = Cache<Bls12PreparedVerifyingKey>;
 
+const FIP0013_MIN_SNARKS: usize = 64;
+const FIP0013_MAX_SNARKS: usize = 8192;
+const PROOFS_TESTS_MIN_SNARKS: usize = FIP0013_MIN_SNARKS >> 5;
+
 const SRS_IDENTIFIER: &str = "srs-key";
 const SRS_VERIFIER_IDENTIFIER: &str = "srs-verifying-key";
 
@@ -52,7 +56,7 @@ pub struct SRSCache<G> {
 impl<G> SRSCache<G> {
     pub fn with_defaults(identifier: &str) -> Self {
         let mut data = HashMap::new();
-        let mut num_proofs_to_aggregate = 2;
+        let mut num_proofs_to_aggregate = PROOFS_TESTS_MIN_SNARKS;
 
         loop {
             for sector_size in &PUBLISHED_SECTOR_SIZES {
@@ -65,7 +69,7 @@ impl<G> SRSCache<G> {
             }
 
             num_proofs_to_aggregate <<= 1;
-            if num_proofs_to_aggregate > 8192 {
+            if num_proofs_to_aggregate > FIP0013_MAX_SNARKS {
                 break;
             }
         }

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -7,14 +7,15 @@ use bellperson::{
     groth16::{self, prepare_verifying_key},
 };
 use lazy_static::lazy_static;
-use log::info;
+use log::{info, trace};
+use once_cell::sync::OnceCell;
 use rand::rngs::OsRng;
 use storage_proofs_core::{compound_proof::CompoundProof, merkle::MerkleTreeTrait};
 use storage_proofs_porep::stacked::{StackedCompound, StackedDrg};
 use storage_proofs_post::fallback::{FallbackPoSt, FallbackPoStCircuit, FallbackPoStCompound};
 
 use crate::{
-    constants::DefaultPieceHasher,
+    constants::{DefaultPieceHasher, PUBLISHED_SECTOR_SIZES},
     parameters::{public_params, window_post_public_params, winning_post_public_params},
     types::{PaddedBytesAmount, PoRepConfig, PoRepProofPartitions, PoStConfig, PoStType},
 };
@@ -27,14 +28,65 @@ type Bls12VerifierSRSKey = groth16::aggregate::VerifierSRS<Bls12>;
 type Cache<G> = HashMap<String, Arc<G>>;
 type GrothMemCache = Cache<Bls12GrothParams>;
 type VerifyingKeyMemCache = Cache<Bls12PreparedVerifyingKey>;
-type SRSKeyMemCache = Cache<Bls12ProverSRSKey>;
-type SRSVerifierKeyMemCache = Cache<Bls12VerifierSRSKey>;
+
+const SRS_IDENTIFIER: &str = "srs-key";
+const SRS_VERIFIER_IDENTIFIER: &str = "srs-verifying-key";
 
 lazy_static! {
     static ref GROTH_PARAM_MEMORY_CACHE: Mutex<GrothMemCache> = Default::default();
     static ref VERIFYING_KEY_MEMORY_CACHE: Mutex<VerifyingKeyMemCache> = Default::default();
-    static ref SRS_KEY_MEMORY_CACHE: Mutex<SRSKeyMemCache> = Default::default();
-    static ref SRS_VERIFIER_KEY_MEMORY_CACHE: Mutex<SRSVerifierKeyMemCache> = Default::default();
+    static ref SRS_KEY_MEMORY_CACHE: SRSCache<Bls12ProverSRSKey> =
+        SRSCache::with_defaults(SRS_IDENTIFIER);
+    static ref SRS_VERIFIER_KEY_MEMORY_CACHE: SRSCache<Bls12VerifierSRSKey> =
+        SRSCache::with_defaults(SRS_VERIFIER_IDENTIFIER);
+}
+
+// We have a separate SRSCache type for srs keys since they are cached
+// differently (as a hashmap per type, keyed by identifier consisting
+// of sector size and pow2 num proofs to aggregate)
+#[derive(Debug, Default)]
+pub struct SRSCache<G> {
+    data: HashMap<String, OnceCell<Arc<G>>>,
+}
+
+impl<G> SRSCache<G> {
+    pub fn with_defaults(identifier: &str) -> Self {
+        let mut data = HashMap::new();
+        let mut num_proofs_to_aggregate = 2;
+
+        loop {
+            for sector_size in &PUBLISHED_SECTOR_SIZES {
+                let key = format!(
+                    "STACKED[{}-{}]-{}",
+                    sector_size, num_proofs_to_aggregate, identifier,
+                );
+                trace!("inserting placeholder srs key with hash key {}", key);
+                data.insert(key.to_string(), OnceCell::new());
+            }
+
+            num_proofs_to_aggregate <<= 1;
+            if num_proofs_to_aggregate > 8192 {
+                break;
+            }
+        }
+
+        Self { data }
+    }
+
+    /// Returns `None` for non existent entries, `Some(v)` for existing ones, where `v` is either
+    /// the result of running `generator` or already existing one.
+    pub fn get_or_init<F>(&self, key: &str, generator: F) -> Option<&Arc<G>>
+    where
+        F: FnOnce() -> Result<G>,
+    {
+        if let Some(cell) = self.data.get(key) {
+            return Some(
+                cell.get_or_init(|| Arc::new(generator().expect("SRS specialize failed"))),
+            );
+        }
+
+        None
+    }
 }
 
 pub fn cache_lookup<F, G>(
@@ -68,6 +120,23 @@ where
     Ok(res)
 }
 
+pub fn srs_cache_lookup<F, G>(
+    cache_ref: &SRSCache<G>,
+    identifier: String,
+    generator: F,
+) -> Result<Arc<G>>
+where
+    F: FnOnce() -> Result<G>,
+    G: Send + Sync,
+{
+    trace!("srs_cache_lookup looking up {}", identifier);
+    if let Some(entry) = cache_ref.get_or_init(&identifier, generator) {
+        return Ok(entry.clone());
+    }
+
+    panic!("unknown identifier {}", identifier);
+}
+
 #[inline]
 pub fn lookup_groth_params<F>(identifier: String, generator: F) -> Result<Arc<Bls12GrothParams>>
 where
@@ -93,8 +162,8 @@ pub fn lookup_srs_key<F>(identifier: String, generator: F) -> Result<Arc<Bls12Pr
 where
     F: FnOnce() -> Result<Bls12ProverSRSKey>,
 {
-    let srs_identifier = format!("{}-srs-key", &identifier);
-    cache_lookup(&*SRS_KEY_MEMORY_CACHE, srs_identifier, generator)
+    let srs_identifier = format!("{}-{}", &identifier, SRS_IDENTIFIER);
+    srs_cache_lookup::<_, Bls12ProverSRSKey>(&*SRS_KEY_MEMORY_CACHE, srs_identifier, generator)
 }
 
 #[inline]
@@ -105,8 +174,12 @@ pub fn lookup_srs_verifier_key<F>(
 where
     F: FnOnce() -> Result<Bls12VerifierSRSKey>,
 {
-    let srs_identifier = format!("{}-srs-key", &identifier);
-    cache_lookup(&*SRS_VERIFIER_KEY_MEMORY_CACHE, srs_identifier, generator)
+    let srs_identifier = format!("{}-{}", &identifier, SRS_VERIFIER_IDENTIFIER);
+    srs_cache_lookup::<_, Bls12VerifierSRSKey>(
+        &*SRS_VERIFIER_KEY_MEMORY_CACHE,
+        srs_identifier,
+        generator,
+    )
 }
 
 pub fn get_stacked_params<Tree: 'static + MerkleTreeTrait>(
@@ -265,6 +338,11 @@ pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
     )?;
 
     let srs_generator = || {
+        trace!(
+            "get_stacked_srs_key specializing STACKED[{}-{}]",
+            usize::from(PaddedBytesAmount::from(porep_config)),
+            num_proofs_to_aggregate,
+        );
         <StackedCompound<Tree, DefaultPieceHasher> as CompoundProof<
             StackedDrg<'_, Tree, DefaultPieceHasher>,
             _,


### PR DESCRIPTION
Resolves #1479 