### PR TITLE
feat: use upstream group, ff and pairing dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,9 +100,6 @@ jobs:
     parameters:
       crate:
         type: string
-      features:
-        type: string
-        default: ""
     steps:
       - checkout
       - attach_workspace:
@@ -116,7 +113,7 @@ jobs:
               ulimit -u 20000
               ulimit -n 20000
               cd << parameters.crate >>
-              cargo test --release << parameters.features >> -- --ignored --nocapture
+              cargo test --release -- --ignored --nocapture
           environment:
             RUST_TEST_THREADS: 1
           no_output_timeout: 30m
@@ -134,7 +131,7 @@ jobs:
       - restore_rustup_cache
       - restore_parameter_cache
       - run:
-          name: Test with use_multicore_sdr pairing enabled
+          name: Test with use_multicore_sdr
           command: |
             ulimit -n 20000
             ulimit -u 20000
@@ -143,18 +140,6 @@ jobs:
             cargo +<< pipeline.parameters.nightly-toolchain >> test -p storage-proofs-porep --features isolated-testing --release checkout_cores -- --test-threads=1
             cargo +<< pipeline.parameters.nightly-toolchain >> test -p storage-proofs-porep --features isolated-testing --release test_parallel_generation_and_read_partial_range_v1_0
             cargo +<< pipeline.parameters.nightly-toolchain >> test -p storage-proofs-porep --features isolated-testing --release test_parallel_generation_and_read_partial_range_v1_1
-          no_output_timeout: 30m
-          environment:
-            RUST_TEST_THREADS: 1
-            FIL_PROOFS_USE_MULTICORE_SDR: true
-
-      - run:
-          name: Test with use_multicore_sdr and blst enabled
-          command: |
-            ulimit -n 20000
-            ulimit -u 20000
-            ulimit -n 20000
-            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --no-default-features --features gpu,blst --verbose --release  lifecycle -- --ignored --nocapture
           no_output_timeout: 30m
           environment:
             RUST_TEST_THREADS: 1
@@ -185,7 +170,7 @@ jobs:
             ulimit -n 20000
             ulimit -u 20000
             ulimit -n 20000
-            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --no-default-features --features gpu,blst --verbose --release lifecycle -- --ignored --nocapture
+            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --verbose --release lifecycle -- --ignored --nocapture
           no_output_timeout: 30m
           environment:
             RUST_TEST_THREADS: 1
@@ -195,9 +180,6 @@ jobs:
   test_no_gpu:
     executor: default
     environment: *setup-env
-    parameters:
-      features:
-        type: string
     steps:
       - checkout
       - attach_workspace:
@@ -205,17 +187,14 @@ jobs:
       - restore_rustup_cache
       - restore_parameter_cache
       - run:
-          name: Test with no gpu (<< parameters.features >>)
+          name: Test with no gpu
           command: |
-            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --verbose --no-default-features --features << parameters.features >>
+            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --verbose --no-default-features
           no_output_timeout: 30m
 
   test_arm_no_gpu:
     executor: arm
     environment: *setup-env
-    parameters:
-      features:
-        type: string
     steps:
       - checkout
       - attach_workspace:
@@ -237,59 +216,10 @@ jobs:
             sudo apt-get update -y
             sudo apt install -y libhwloc-dev
       - run:
-          name: Test arm with no gpu (<< parameters.features >>)
+          name: Test arm with no gpu
           command: |
-            cargo +<< pipeline.parameters.nightly-toolchain >> -Zpackage-features test --release --all --verbose --no-default-features --features << parameters.features >>
+            cargo +<< pipeline.parameters.nightly-toolchain >> -Zpackage-features test --release --all --verbose --no-default-features
           no_output_timeout: 90m
-
-  test_blst:
-    executor: default
-    environment: *setup-env
-    parameters:
-      crate:
-        type: string
-      features:
-        type: string
-        default: "gpu,blst"
-    steps:
-      - checkout
-      - attach_workspace:
-          at: "."
-      - restore_rustup_cache
-      - restore_parameter_cache
-      - run:
-          name: Test ignored with blst enabled (<< parameters.crate >>)
-          command: |
-            ulimit -n 20000
-            ulimit -u 20000
-            ulimit -n 20000
-            RUST_LOG=trace cargo +<< pipeline.parameters.nightly-toolchain >> test --no-default-features --features << parameters.features >> --verbose --release --package << parameters.crate >> -- --nocapture
-          no_output_timeout: 30m
-          environment:
-            RUST_TEST_THREADS: 1
-
-  test_blst_ignored:
-    executor: default
-    environment: *setup-env
-    parameters:
-      crate:
-        type: string
-    steps:
-      - checkout
-      - attach_workspace:
-          at: "."
-      - restore_rustup_cache
-      - restore_parameter_cache
-
-      - run:
-          name: Test with blst enabled (<< parameters.crate >>)
-          command: |
-            ulimit -n 20000
-            ulimit -u 20000
-            ulimit -n 20000
-            cargo +<< pipeline.parameters.nightly-toolchain >> test --no-default-features --features gpu,blst --verbose --package << parameters.crate >> --release -- --ignored --nocapture
-          no_output_timeout: 30m
-
 
   bench:
     executor: default
@@ -472,37 +402,9 @@ workflows:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
 
-      - test_blst:
-          name: test_blst_filecoin_proofs
-          crate: "filecoin-proofs"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
-      - test_blst_ignored:
-          name: test_blst_ignored_filecoin_proofs
-          crate: "filecoin-proofs"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
       - test:
           name: test_filecoin_proofs
           crate: "filecoin-proofs"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
-      - test_blst:
-          name: test_blst_storage_proofs_core
-          crate: "storage-proofs-core"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
-      - test_blst_ignored:
-          name: test_blst_ignored_storage_proofs_core
-          crate: "storage-proofs-core"
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
@@ -514,20 +416,6 @@ workflows:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
 
-      - test_blst:
-          name: test_blst_storage_proofs_post
-          crate: "storage-proofs-post"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
-      - test_blst_ignored:
-          name: test_blst_ignored_storage_proofs_post
-          crate: "storage-proofs-post"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
       - test:
           name: test_storage_proofs_post
           crate: "storage-proofs-post"
@@ -535,32 +423,9 @@ workflows:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
 
-
-      - test_blst:
-          name: test_blst_storage_proofs_porep
-          crate: "storage-proofs-porep"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
-      - test_blst_ignored:
-          name: test_blst_ignored_storage_proofs_porep
-          crate: "storage-proofs-porep"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
       - test:
           name: test_storage_proofs_porep
           crate: "storage-proofs-porep"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
-
-      - test_blst:
-          name: test_blst_fil_proofs_tooling
-          crate: "fil-proofs-tooling"
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
@@ -579,15 +444,6 @@ workflows:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
 
-            
-      - test_blst:
-          name: test_blst_filecoin_hashers
-          crate: "filecoin-hashers"
-          features: "blst,gpu,poseidon,sha256,blake2s"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
       - test:
           name: test_filecoin_hashers
           crate: "filecoin-hashers"
@@ -595,13 +451,6 @@ workflows:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
 
-
-      - test_blst:
-          name: test_blst_fil_proofs_param
-          crate: "fil-proofs-param"
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
 
       - test:
           name: test_fil_proofs_param
@@ -611,29 +460,13 @@ workflows:
             - ensure_groth_parameters_and_keys_linux
 
       - test_no_gpu:
-          name: test_no_gpu_pairing
-          features: 'pairing'
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
-      - test_no_gpu:
-          name: test_no_gpu_blst
-          features: 'blst'
+          name: test_no_gpu
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
 
       - test_arm_no_gpu:
-          name: test_arm_no_gpu_pairing
-          features: 'pairing'
-          requires:
-            - cargo_fetch
-            - ensure_groth_parameters_and_keys_linux
-
-      - test_arm_no_gpu:
-          name: test_arm_no_gpu_blst
-          features: 'blst'
+          name: test_arm_no_gpu
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
@@ -646,12 +479,6 @@ workflows:
 
       - test:
           name: test_fr32
-          crate: "fr32"
-          requires:
-            - cargo_fetch
-
-      - test_blst:
-          name: test_blst_fr32
           crate: "fr32"
           requires:
             - cargo_fetch

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `hwloc` dependency is optional and may be disabled.  Disabling it will not a
 To disable `multicore sdr` so that `hwloc` is not required, you can build proofs like this:
 
 ```
-> cargo build --release --all --no-default-features --features pairing,gpu
+> cargo build --release --all --no-default-features --features gpu
 ```
 
 Note that the `multicore-sdr` feature is omitted from the specified feature list, which removes it from being used by default.

--- a/fil-proofs-param/Cargo.toml
+++ b/fil-proofs-param/Cargo.toml
@@ -15,7 +15,7 @@ storage-proofs-post = { path = "../storage-proofs-post", version = "^9.0.0", def
 filecoin-hashers = { version = "^4.0.0", path = "../filecoin-hashers", default-features = false, features = ["poseidon", "sha256"] }
 filecoin-proofs = { version = "^9.0.0", path = "../filecoin-proofs", default-features = false }
 bitvec = "0.17"
-rand = "0.7"
+rand = "0.8"
 lazy_static = "1.2"
 memmap = "0.7"
 pbr = "1.0"
@@ -23,9 +23,9 @@ byteorder = "1"
 itertools = "0.9"
 serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
-ff = { version = "0.3.1", package = "fff" }
+ff = "0.11.0"
 blake2b_simd = "0.5"
-bellperson = { version = "0.16", default-features = false }
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
 log = "0.4.7"
 fil_logger = "0.1"
 env_proxy = "0.4"
@@ -37,7 +37,7 @@ hex = "0.4.0"
 merkletree = "0.21.0"
 bincode = "1.1.2"
 anyhow = "1.0.23"
-rand_xorshift = "0.2.0"
+rand_xorshift = "0.3.0"
 sha2 = "0.9.1"
 typenum = "1.11.2"
 gperftools = { version = "0.2", optional = true }
@@ -45,7 +45,7 @@ generic-array = "0.14.4"
 structopt = "0.3.12"
 humansize = "1.1.0"
 indicatif = "0.15.0"
-groupy = "0.4.1"
+group = "0.11.0"
 dialoguer = "0.8.0"
 clap = "2.33.3"
 
@@ -62,11 +62,9 @@ failure = "0.1.7"
 tempfile = "3"
 
 [features]
-default = ["gpu", "blst"]
+default = ["gpu"]
 cpu-profile = ["gperftools"]
 heap-profile = ["gperftools/heap"]
 simd = ["storage-proofs-core/simd"]
 asm = ["storage-proofs-core/asm"]
 gpu = ["storage-proofs-core/gpu", "storage-proofs-porep/gpu", "storage-proofs-post/gpu", "bellperson/gpu"]
-pairing = ["storage-proofs-core/pairing", "storage-proofs-porep/pairing", "storage-proofs-post/pairing", "bellperson/pairing"]
-blst = ["storage-proofs-core/blst", "storage-proofs-porep/blst", "storage-proofs-post/blst", "bellperson/blst"]

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -25,8 +25,8 @@ regex = "1.3.7"
 commandspec = "0.12.2"
 chrono = { version = "0.4.7", features = ["serde"] }
 memmap = "0.7.0"
-bellperson = { version = "0.16", default-features = false }
-rand = "0.7"
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
+rand = "0.8"
 tempfile = "3.0.8"
 cpu-time = "1.0.0"
 git2 = "0.13.6"
@@ -39,8 +39,8 @@ uom = "0.30"
 merkletree = "0.21.0"
 bincode = "1.1.2"
 anyhow = "1.0.23"
-ff = { version = "0.3.1", package = "fff" }
-rand_xorshift = "0.2.0"
+ff = "0.11.0"
+rand_xorshift = "0.3.0"
 bytefmt = "0.1.7"
 rayon = "1.3.0"
 flexi_logger = "0.16.1"
@@ -51,9 +51,10 @@ fdlimit = "0.2.0"
 dialoguer = "0.8.0"
 structopt = "0.3.12"
 humansize = "1.1.0"
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
 
 [features]
-default = ["gpu", "measurements", "blst"]
+default = ["gpu", "measurements"]
 gpu = [
     "storage-proofs-core/gpu",
     "storage-proofs-porep/gpu",
@@ -64,22 +65,6 @@ gpu = [
 ]
 measurements = ["storage-proofs-core/measurements"]
 profile = ["storage-proofs-core/profile", "measurements"]
-pairing = [
-    "storage-proofs-core/pairing",
-    "storage-proofs-porep/pairing",
-    "storage-proofs-post/pairing",
-    "filecoin-proofs/pairing",
-    "bellperson/pairing",
-    "filecoin-hashers/pairing",
-]
-blst = [
-    "storage-proofs-core/blst",
-    "storage-proofs-porep/blst",
-    "storage-proofs-post/blst",
-    "filecoin-proofs/blst",
-    "bellperson/blst",
-    "filecoin-hashers/blst",
-]
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 raw-cpuid = "8.1.2"

--- a/fil-proofs-tooling/src/bin/benchy/hash_fns.rs
+++ b/fil-proofs-tooling/src/bin/benchy/hash_fns.rs
@@ -1,7 +1,7 @@
-use bellperson::bls::Bls12;
 use bellperson::gadgets::boolean::Boolean;
 use bellperson::util_cs::test_cs::TestConstraintSystem;
 use bellperson::ConstraintSystem;
+use blstrs::Bls12;
 use fil_proofs_tooling::metadata::Metadata;
 use rand::RngCore;
 use serde::Serialize;

--- a/fil-proofs-tooling/src/bin/benchy/merkleproofs.rs
+++ b/fil-proofs-tooling/src/bin/benchy/merkleproofs.rs
@@ -50,7 +50,7 @@ fn generate_proofs<R: Rng, Tree: MerkleTreeTrait>(
         let challenge = if proofs_count == nodes {
             i
         } else {
-            rng.gen_range(0, nodes)
+            rng.gen_range(0..nodes)
         };
         debug!("challenge[{}] = {}", i, challenge);
         let proof = tree

--- a/fil-proofs-tooling/src/bin/benchy/prodbench.rs
+++ b/fil-proofs-tooling/src/bin/benchy/prodbench.rs
@@ -1,7 +1,8 @@
 use std::fs::remove_file;
 use std::str::FromStr;
 
-use bellperson::{bls::Bls12, util_cs::bench_cs::BenchCS, Circuit};
+use bellperson::{util_cs::bench_cs::BenchCS, Circuit};
+use blstrs::Bls12;
 use fil_proofs_tooling::{
     measure,
     shared::{create_replicas, PROVER_ID, RANDOMNESS, TICKET_BYTES},

--- a/fil-proofs-tooling/src/bin/check_parameters/main.rs
+++ b/fil-proofs-tooling/src/bin/check_parameters/main.rs
@@ -1,8 +1,8 @@
 use std::path::Path;
 
 use anyhow::Result;
-use bellperson::bls::Bls12;
 use bellperson::groth16::MappedParameters;
+use blstrs::Bls12;
 use clap::{value_t, App, Arg, SubCommand};
 
 use storage_proofs_core::parameter_cache::read_cached_params;

--- a/fil-proofs-tooling/src/bin/circuitinfo/main.rs
+++ b/fil-proofs-tooling/src/bin/circuitinfo/main.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
-use bellperson::{bls::Bls12, util_cs::bench_cs::BenchCS, Circuit};
+use bellperson::{util_cs::bench_cs::BenchCS, Circuit};
+use blstrs::Bls12;
 use dialoguer::{theme::ColorfulTheme, MultiSelect};
 use filecoin_proofs::{
     parameters::{public_params, window_post_public_params, winning_post_public_params},

--- a/filecoin-hashers/Cargo.toml
+++ b/filecoin-hashers/Cargo.toml
@@ -9,27 +9,25 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-bellperson = { version = "0.16", default-features = false }
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
 generic-array = "0.14.4"
 merkletree = "0.21.0"
-ff = { version = "0.3.1", package = "fff" }
+ff = "0.11.0"
 anyhow = "1.0.34"
 serde = "1.0.117"
-rand = "0.7.3"
+rand = "0.8.0"
 
-neptune = { version = "^4.0", default-features = false, optional = true }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
 blake2s_simd = { version = "0.5.11", optional = true }
 sha2 = { version = "0.9.2", optional = true }
 hex = "0.4.2"
 
 [features]
-default = ["gpu", "blst", "blake2s", "poseidon", "sha256"]
+default = ["gpu", "blake2s", "poseidon", "sha256"]
 
 gpu = ["bellperson/gpu", "neptune/opencl"]
-
-pairing = ["bellperson/pairing", "neptune/pairing"]
-blst = ["bellperson/blst", "neptune/blst"]
 
 # available hashers
 blake2s = ["blake2s_simd"]
@@ -37,5 +35,5 @@ poseidon = ["neptune", "lazy_static"]
 sha256 = ["sha2"]
 
 [dev-dependencies]
-rand_xorshift = "0.2.0"
+rand_xorshift = "0.3.0"
 serde_json = "1.0.59"

--- a/filecoin-hashers/src/blake2s.rs
+++ b/filecoin-hashers/src/blake2s.rs
@@ -4,14 +4,14 @@ use std::panic::panic_any;
 
 use anyhow::ensure;
 use bellperson::{
-    bls::{Bls12, Fr, FrRepr},
     gadgets::{
         blake2s::blake2s as blake2s_circuit, boolean::Boolean, multipack, num::AllocatedNum,
     },
     ConstraintSystem, SynthesisError,
 };
 use blake2s_simd::{Hash as Blake2sHash, Params as Blake2s, State};
-use ff::{Field, PrimeField, PrimeFieldRepr};
+use blstrs::{Bls12, Scalar as Fr};
+use ff::{Field, PrimeField};
 use merkletree::{
     hash::{Algorithm, Hashable},
     merkle::Element,
@@ -100,21 +100,7 @@ impl Hashable<Blake2sFunction> for Blake2sDomain {
 
 impl From<Fr> for Blake2sDomain {
     fn from(val: Fr) -> Self {
-        let mut res = Self::default();
-        val.into_repr()
-            .write_le(&mut res.0[0..32])
-            .expect("write_le failure");
-
-        res
-    }
-}
-
-impl From<FrRepr> for Blake2sDomain {
-    fn from(val: FrRepr) -> Self {
-        let mut res = Self::default();
-        val.write_le(&mut res.0[0..32]).expect("write_le failure");
-
-        res
+        Blake2sDomain(val.to_repr())
     }
 }
 
@@ -137,10 +123,7 @@ impl Element for Blake2sDomain {
 
 impl From<Blake2sDomain> for Fr {
     fn from(val: Blake2sDomain) -> Self {
-        let mut res = FrRepr::default();
-        res.read_le(&val.0[0..32]).expect("read_le failure");
-
-        Fr::from_repr(res).expect("from_repr failure")
+        Fr::from_repr_vartime(val.0).expect("from_repr failure")
     }
 }
 

--- a/filecoin-hashers/src/poseidon.rs
+++ b/filecoin-hashers/src/poseidon.rs
@@ -1,16 +1,14 @@
 use std::cmp::Ordering;
 use std::hash::{Hash as StdHash, Hasher as StdHasher};
-use std::mem::size_of;
 use std::panic::panic_any;
-use std::slice;
 
 use anyhow::ensure;
 use bellperson::{
-    bls::{Bls12, Fr, FrRepr},
     gadgets::{boolean::Boolean, num::AllocatedNum},
     ConstraintSystem, SynthesisError,
 };
-use ff::{Field, PrimeField, PrimeFieldRepr, ScalarEngine};
+use blstrs::{Bls12, Scalar as Fr};
+use ff::{Field, PrimeField};
 use generic_array::typenum::{marker_traits::Unsigned, U2};
 use merkletree::{
     hash::{Algorithm as LightAlgorithm, Hashable},
@@ -42,32 +40,24 @@ pub struct PoseidonFunction(Fr);
 
 impl Default for PoseidonFunction {
     fn default() -> PoseidonFunction {
-        PoseidonFunction(Fr::from_repr(FrRepr::default()).expect("failed default"))
+        PoseidonFunction(Fr::zero())
     }
 }
 
 impl Hashable<PoseidonFunction> for Fr {
     fn hash(&self, state: &mut PoseidonFunction) {
-        let mut bytes = Vec::with_capacity(32);
-        self.into_repr()
-            .write_le(&mut bytes)
-            .expect("write_le failure");
-        state.write(&bytes);
+        state.write(&self.to_repr());
     }
 }
 
 impl Hashable<PoseidonFunction> for PoseidonDomain {
     fn hash(&self, state: &mut PoseidonFunction) {
-        let mut bytes = Vec::with_capacity(32);
-        self.0
-            .write_le(&mut bytes)
-            .expect("Failed to write `FrRepr`");
-        state.write(&bytes);
+        state.write(&self.0);
     }
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
-pub struct PoseidonDomain(pub FrRepr);
+pub struct PoseidonDomain(pub <Fr as PrimeField>::Repr);
 
 impl AsRef<PoseidonDomain> for PoseidonDomain {
     fn as_ref(&self) -> &PoseidonDomain {
@@ -77,14 +67,13 @@ impl AsRef<PoseidonDomain> for PoseidonDomain {
 
 impl StdHash for PoseidonDomain {
     fn hash<H: StdHasher>(&self, state: &mut H) {
-        let raw: &[u64] = self.0.as_ref();
-        StdHash::hash(raw, state);
+        StdHash::hash(&self.0, state);
     }
 }
 
 impl PartialEq for PoseidonDomain {
     fn eq(&self, other: &Self) -> bool {
-        self.0.as_ref() == other.0.as_ref()
+        self.0 == other.0
     }
 }
 
@@ -92,7 +81,7 @@ impl Eq for PoseidonDomain {}
 
 impl Default for PoseidonDomain {
     fn default() -> PoseidonDomain {
-        PoseidonDomain(FrRepr::default())
+        PoseidonDomain(<Fr as PrimeField>::Repr::default())
     }
 }
 
@@ -113,25 +102,13 @@ impl PartialOrd for PoseidonDomain {
 impl AsRef<[u8]> for PoseidonDomain {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        as_ref(&(self.0).0)
+        &self.0
     }
-}
-
-// This is unsafe, and I wish it wasn't here, but I really need AsRef<[u8]> to work, without allocating.
-// https://internals.rust-lang.org/t/safe-trasnsmute-for-slices-e-g-u64-u32-particularly-simd-types/2871
-// https://github.com/briansmith/ring/blob/abb3fdfc08562f3f02e95fb551604a871fd4195e/src/polyfill.rs#L93-L110
-#[inline(always)]
-#[allow(clippy::needless_lifetimes)]
-fn as_ref<'a>(src: &'a [u64; 4]) -> &'a [u8] {
-    unsafe { slice::from_raw_parts(src.as_ptr() as *const u8, src.len() * size_of::<u64>()) }
 }
 
 impl Domain for PoseidonDomain {
     fn into_bytes(&self) -> Vec<u8> {
-        let mut out = Vec::with_capacity(PoseidonDomain::byte_len());
-        self.0.write_le(&mut out).expect("write_le failure");
-
-        out
+        self.0.to_vec()
     }
 
     fn try_from_bytes(raw: &[u8]) -> anyhow::Result<Self> {
@@ -139,14 +116,17 @@ impl Domain for PoseidonDomain {
             raw.len() == PoseidonDomain::byte_len(),
             "invalid amount of bytes"
         );
-        let mut res: FrRepr = Default::default();
-        res.read_le(raw)?;
-
-        Ok(PoseidonDomain(res))
+        let mut repr = <Fr as PrimeField>::Repr::default();
+        repr.copy_from_slice(&raw);
+        Ok(PoseidonDomain(repr))
     }
 
     fn write_bytes(&self, dest: &mut [u8]) -> anyhow::Result<()> {
-        self.0.write_le(dest)?;
+        ensure!(
+            dest.len() == PoseidonDomain::byte_len(),
+            "invalid amount of bytes"
+        );
+        dest.copy_from_slice(&self.0);
         Ok(())
     }
 
@@ -169,14 +149,14 @@ impl Element for PoseidonDomain {
     }
 
     fn copy_to_slice(&self, bytes: &mut [u8]) {
-        bytes.copy_from_slice(&self.into_bytes());
+        bytes.copy_from_slice(&self.0);
     }
 }
 
 impl StdHasher for PoseidonFunction {
     #[inline]
     fn write(&mut self, msg: &[u8]) {
-        self.0 = Fr::from_repr(shared_hash(msg).0).expect("from_repr failure");
+        self.0 = Fr::from_repr_vartime(shared_hash(msg).0).expect("from_repr failure");
     }
 
     #[inline]
@@ -191,15 +171,14 @@ fn shared_hash(data: &[u8]) -> PoseidonDomain {
     let preimage = data
         .chunks(32)
         .map(|ref chunk| {
-            <Bls12 as ScalarEngine>::Fr::from_repr(PoseidonDomain::from_slice(chunk).0)
-                .expect("from_repr failure")
+            Fr::from_repr_vartime(PoseidonDomain::from_slice(chunk).0).expect("from_repr failure")
         })
         .collect::<Vec<_>>();
 
     shared_hash_frs(&preimage).into()
 }
 
-fn shared_hash_frs(preimage: &[<Bls12 as ScalarEngine>::Fr]) -> <Bls12 as ScalarEngine>::Fr {
+fn shared_hash_frs(preimage: &[Fr]) -> Fr {
     match preimage.len() {
         2 => {
             let mut p = Poseidon::new_with_preimage(&preimage, &POSEIDON_CONSTANTS_2);
@@ -233,7 +212,7 @@ impl HashFunction<PoseidonDomain> for PoseidonFunction {
     fn hash2(a: &PoseidonDomain, b: &PoseidonDomain) -> PoseidonDomain {
         let mut p =
             Poseidon::new_with_preimage(&[(*a).into(), (*b).into()][..], &*POSEIDON_CONSTANTS_2);
-        let fr: <Bls12 as ScalarEngine>::Fr = p.hash();
+        let fr: Fr = p.hash();
         fr.into()
     }
 
@@ -245,7 +224,7 @@ impl HashFunction<PoseidonDomain> for PoseidonFunction {
 
         let fr_input = input
             .iter()
-            .map(|x| <Bls12 as ScalarEngine>::Fr::from_repr(x.0).expect("from_repr failure"))
+            .map(|x| Fr::from_repr_vartime(x.0).expect("from_repr failure"))
             .collect::<Vec<_>>();
 
         fr_input[1..]
@@ -340,7 +319,7 @@ impl LightAlgorithm<PoseidonDomain> for PoseidonFunction {
 
     #[inline]
     fn reset(&mut self) {
-        self.0 = Fr::from_repr(FrRepr::from(0)).expect("failed 0");
+        self.0 = Fr::zero();
     }
 
     fn leaf(&mut self, leaf: PoseidonDomain) -> PoseidonDomain {
@@ -354,8 +333,8 @@ impl LightAlgorithm<PoseidonDomain> for PoseidonFunction {
         _height: usize,
     ) -> PoseidonDomain {
         shared_hash_frs(&[
-            <Bls12 as ScalarEngine>::Fr::from_repr(left.0).expect("from_repr failure"),
-            <Bls12 as ScalarEngine>::Fr::from_repr(right.0).expect("from_repr failure"),
+            Fr::from_repr_vartime(left.0).expect("from_repr failure"),
+            Fr::from_repr_vartime(right.0).expect("from_repr failure"),
         ])
         .into()
     }
@@ -367,8 +346,11 @@ impl LightAlgorithm<PoseidonDomain> for PoseidonFunction {
                     .iter()
                     .enumerate()
                     .map(|(i, x)| {
-                        <Bls12 as ScalarEngine>::Fr::from_repr(x.0)
-                            .unwrap_or_else(|_| panic_any(format!("from_repr failure at {}", i)))
+                        if let Some(fr) = Fr::from_repr_vartime(x.0) {
+                            fr
+                        } else {
+                            panic_any(format!("from_repr failure at {}", i));
+                        }
                     })
                     .collect::<Vec<_>>(),
             )
@@ -381,13 +363,13 @@ impl LightAlgorithm<PoseidonDomain> for PoseidonFunction {
 impl From<Fr> for PoseidonDomain {
     #[inline]
     fn from(val: Fr) -> Self {
-        PoseidonDomain(val.into_repr())
+        PoseidonDomain(val.to_repr())
     }
 }
 
-impl From<FrRepr> for PoseidonDomain {
+impl From<[u8; 32]> for PoseidonDomain {
     #[inline]
-    fn from(val: FrRepr) -> Self {
+    fn from(val: [u8; 32]) -> Self {
         PoseidonDomain(val)
     }
 }
@@ -395,7 +377,7 @@ impl From<FrRepr> for PoseidonDomain {
 impl From<PoseidonDomain> for Fr {
     #[inline]
     fn from(val: PoseidonDomain) -> Self {
-        Fr::from_repr(val.0).expect("from_repr failure")
+        Fr::from_repr_vartime(val.0).expect("from_repr failure")
     }
 }
 
@@ -403,18 +385,25 @@ impl From<PoseidonDomain> for Fr {
 mod tests {
     use super::*;
 
-    use std::mem;
-
     use bellperson::util_cs::test_cs::TestConstraintSystem;
     use merkletree::{merkle::MerkleTree, store::VecStore};
+
+    fn u64s_to_u8s(u64s: [u64; 4]) -> [u8; 32] {
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&u64s[0].to_le_bytes());
+        bytes[8..16].copy_from_slice(&u64s[1].to_le_bytes());
+        bytes[16..24].copy_from_slice(&u64s[2].to_le_bytes());
+        bytes[24..].copy_from_slice(&u64s[3].to_le_bytes());
+        bytes
+    }
 
     #[test]
     fn test_path() {
         let values = [
-            PoseidonDomain(Fr::one().into_repr()),
-            PoseidonDomain(Fr::one().into_repr()),
-            PoseidonDomain(Fr::one().into_repr()),
-            PoseidonDomain(Fr::one().into_repr()),
+            PoseidonDomain(Fr::one().to_repr()),
+            PoseidonDomain(Fr::one().to_repr()),
+            PoseidonDomain(Fr::one().to_repr()),
+            PoseidonDomain(Fr::one().to_repr()),
         ];
 
         let t = MerkleTree::<PoseidonDomain, PoseidonFunction, VecStore<_>, U2>::new(
@@ -436,16 +425,16 @@ mod tests {
     // fn test_poseidon_quad() {
     //     let leaves = [Fr::one(), Fr::zero(), Fr::zero(), Fr::one()];
 
-    //     assert_eq!(Fr::zero().into_repr(), shared_hash_frs(&leaves[..]).0);
+    //     assert_eq!(Fr::zero().to_repr(), shared_hash_frs(&leaves[..]).0);
     // }
 
     #[test]
     fn test_poseidon_hasher() {
         let leaves = [
-            PoseidonDomain(Fr::one().into_repr()),
-            PoseidonDomain(Fr::zero().into_repr()),
-            PoseidonDomain(Fr::zero().into_repr()),
-            PoseidonDomain(Fr::one().into_repr()),
+            PoseidonDomain(Fr::one().to_repr()),
+            PoseidonDomain(Fr::zero().to_repr()),
+            PoseidonDomain(Fr::zero().to_repr()),
+            PoseidonDomain(Fr::one().to_repr()),
         ];
 
         let t = MerkleTree::<PoseidonDomain, PoseidonFunction, VecStore<_>, U2>::new(
@@ -475,15 +464,15 @@ mod tests {
 
         assert_eq!(
             t.read_at(4).expect("read_at failure").0,
-            FrRepr([
+            u64s_to_u8s([
                 0xb339ff6079800b5e,
                 0xec5907b3dc3094af,
                 0x93c003cc74a24f26,
                 0x042f94ffbe786bc3,
-            ])
+            ]),
         );
 
-        let expected = FrRepr([
+        let expected = u64s_to_u8s([
             0xefbb8be3e291e671,
             0x77cc72b8cb2b5ad2,
             0x30eb6385ae6b74ae,
@@ -508,8 +497,7 @@ mod tests {
         ];
 
         for case in cases.into_iter() {
-            let repr = FrRepr(case);
-            let val = PoseidonDomain(repr);
+            let val = PoseidonDomain(u64s_to_u8s(case));
 
             for _ in 0..100 {
                 assert_eq!(val.into_bytes(), val.into_bytes());
@@ -517,20 +505,15 @@ mod tests {
 
             let raw: &[u8] = val.as_ref();
 
-            for i in 0..4 {
-                assert_eq!(case[i], unsafe {
-                    let mut val = [0u8; 8];
-                    val.clone_from_slice(&raw[i * 8..(i + 1) * 8]);
-                    mem::transmute::<[u8; 8], u64>(val)
-                });
+            for (limb, bytes) in case.iter().zip(raw.chunks(8)) {
+                assert_eq!(&limb.to_le_bytes(), bytes);
             }
         }
     }
 
     #[test]
     fn test_serialize() {
-        let repr = FrRepr([1, 2, 3, 4]);
-        let val = PoseidonDomain(repr);
+        let val = PoseidonDomain(u64s_to_u8s([1, 2, 3, 4]));
 
         let ser = serde_json::to_string(&val)
             .expect("Failed to serialize `PoseidonDomain` element to JSON string");
@@ -544,12 +527,12 @@ mod tests {
     fn test_hash_md() {
         // let arity = PoseidonMDArity::to_usize();
         let n = 71;
-        let data = vec![PoseidonDomain(Fr::one().into_repr()); n];
+        let data = vec![PoseidonDomain(Fr::one().to_repr()); n];
         let hashed = PoseidonFunction::hash_md(&data);
 
         assert_eq!(
             hashed,
-            PoseidonDomain(FrRepr([
+            PoseidonDomain(u64s_to_u8s([
                 0x351c54133b332c90,
                 0xc26f6d625f4e8195,
                 0x5fd9623643ed9622,
@@ -561,7 +544,7 @@ mod tests {
     fn test_hash_md_circuit() {
         // let arity = PoseidonMDArity::to_usize();
         let n = 71;
-        let data = vec![PoseidonDomain(Fr::one().into_repr()); n];
+        let data = vec![PoseidonDomain(Fr::one().to_repr()); n];
 
         let mut cs = TestConstraintSystem::<Bls12>::new();
         let circuit_data = (0..n)
@@ -572,7 +555,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let hashed = PoseidonFunction::hash_md(&data);
-        let hashed_fr = Fr::from_repr(hashed.0).expect("from_repr failure");
+        let hashed_fr = Fr::from_repr_vartime(hashed.0).expect("from_repr failure");
 
         let circuit_hashed = PoseidonFunction::hash_md_circuit(&mut cs, circuit_data.as_slice())
             .expect("hash_md_circuit failure");

--- a/filecoin-hashers/src/poseidon_types.rs
+++ b/filecoin-hashers/src/poseidon_types.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use bellperson::bls::{Bls12, Fr};
+use blstrs::Scalar as Fr;
 use generic_array::typenum::{U0, U11, U16, U2, U24, U36, U4, U8};
 use lazy_static::lazy_static;
 use neptune::{poseidon::PoseidonConstants, Arity};
@@ -17,68 +17,64 @@ pub type PoseidonMDArity = U36;
 pub const MERKLE_TREE_ARITY: usize = 2;
 
 lazy_static! {
-    pub static ref POSEIDON_CONSTANTS_2: PoseidonConstants::<Bls12, U2> = PoseidonConstants::new();
-    pub static ref POSEIDON_CONSTANTS_4: PoseidonConstants::<Bls12, U4> = PoseidonConstants::new();
-    pub static ref POSEIDON_CONSTANTS_8: PoseidonConstants::<Bls12, U8> = PoseidonConstants::new();
-    pub static ref POSEIDON_CONSTANTS_16: PoseidonConstants::<Bls12, U16> =
-        PoseidonConstants::new();
-    pub static ref POSEIDON_CONSTANTS_24: PoseidonConstants::<Bls12, U24> =
-        PoseidonConstants::new();
-    pub static ref POSEIDON_CONSTANTS_36: PoseidonConstants::<Bls12, U36> =
-        PoseidonConstants::new();
-    pub static ref POSEIDON_CONSTANTS_11: PoseidonConstants::<Bls12, U11> =
-        PoseidonConstants::new();
-    pub static ref POSEIDON_MD_CONSTANTS: PoseidonConstants::<Bls12, PoseidonMDArity> =
+    pub static ref POSEIDON_CONSTANTS_2: PoseidonConstants::<Fr, U2> = PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_4: PoseidonConstants::<Fr, U4> = PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_8: PoseidonConstants::<Fr, U8> = PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_16: PoseidonConstants::<Fr, U16> = PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_24: PoseidonConstants::<Fr, U24> = PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_36: PoseidonConstants::<Fr, U36> = PoseidonConstants::new();
+    pub static ref POSEIDON_CONSTANTS_11: PoseidonConstants::<Fr, U11> = PoseidonConstants::new();
+    pub static ref POSEIDON_MD_CONSTANTS: PoseidonConstants::<Fr, PoseidonMDArity> =
         PoseidonConstants::new();
 }
 
 pub trait PoseidonArity: Arity<Fr> + Send + Sync + Clone + Debug {
     #[allow(non_snake_case)]
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self>;
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self>;
 }
 
 impl PoseidonArity for U0 {
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self> {
         unreachable!("dummy implementation, do not ever call me")
     }
 }
 
 impl PoseidonArity for U2 {
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self> {
         &*POSEIDON_CONSTANTS_2
     }
 }
 
 impl PoseidonArity for U4 {
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self> {
         &*POSEIDON_CONSTANTS_4
     }
 }
 
 impl PoseidonArity for U8 {
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self> {
         &*POSEIDON_CONSTANTS_8
     }
 }
 
 impl PoseidonArity for U11 {
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self> {
         &*POSEIDON_CONSTANTS_11
     }
 }
 
 impl PoseidonArity for U16 {
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self> {
         &*POSEIDON_CONSTANTS_16
     }
 }
 impl PoseidonArity for U24 {
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self> {
         &*POSEIDON_CONSTANTS_24
     }
 }
 impl PoseidonArity for U36 {
-    fn PARAMETERS() -> &'static PoseidonConstants<Bls12, Self> {
+    fn PARAMETERS() -> &'static PoseidonConstants<Fr, Self> {
         &*POSEIDON_CONSTANTS_36
     }
 }

--- a/filecoin-hashers/src/sha256.rs
+++ b/filecoin-hashers/src/sha256.rs
@@ -4,11 +4,11 @@ use std::panic::panic_any;
 
 use anyhow::ensure;
 use bellperson::{
-    bls::{Bls12, Fr, FrRepr},
     gadgets::{boolean::Boolean, multipack, num::AllocatedNum, sha256::sha256 as sha256_circuit},
     ConstraintSystem, SynthesisError,
 };
-use ff::{Field, PrimeField, PrimeFieldRepr};
+use blstrs::{Bls12, Scalar as Fr};
+use ff::{Field, PrimeField};
 use merkletree::{
     hash::{Algorithm, Hashable},
     merkle::Element,
@@ -82,30 +82,13 @@ impl Hashable<Sha256Function> for Sha256Domain {
 
 impl From<Fr> for Sha256Domain {
     fn from(val: Fr) -> Self {
-        let mut res = Self::default();
-        val.into_repr()
-            .write_le(&mut res.0[0..32])
-            .expect("write_le failure");
-
-        res
-    }
-}
-
-impl From<FrRepr> for Sha256Domain {
-    fn from(val: FrRepr) -> Self {
-        let mut res = Self::default();
-        val.write_le(&mut res.0[0..32]).expect("write_le failure");
-
-        res
+        Sha256Domain(val.to_repr())
     }
 }
 
 impl From<Sha256Domain> for Fr {
     fn from(val: Sha256Domain) -> Self {
-        let mut res = FrRepr::default();
-        res.read_le(&val.0[0..32]).expect("read_le failure");
-
-        Fr::from_repr(res).expect("from_repr failure")
+        Fr::from_repr_vartime(val.0).expect("from_repr failure")
     }
 }
 

--- a/filecoin-hashers/src/types.rs
+++ b/filecoin-hashers/src/types.rs
@@ -5,10 +5,11 @@ use std::hash::Hash as StdHash;
 pub use crate::poseidon_types::*;
 
 use bellperson::{
-    bls::{Bls12, Fr, FrRepr},
     gadgets::{boolean::Boolean, num::AllocatedNum},
     ConstraintSystem, SynthesisError,
 };
+use blstrs::{Bls12, Scalar as Fr};
+use ff::PrimeField;
 use merkletree::{
     hash::{Algorithm as LightAlgorithm, Hashable as LightHashable},
     merkle::Element,
@@ -27,7 +28,7 @@ pub trait Domain:
     + Send
     + Sync
     + From<Fr>
-    + From<FrRepr>
+    + From<<Fr as PrimeField>::Repr>
     + Into<Fr>
     + Serialize
     + DeserializeOwned

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -14,16 +14,16 @@ storage-proofs-porep = { path = "../storage-proofs-porep", version = "^9.0.0", d
 storage-proofs-post = { path = "../storage-proofs-post", version = "^9.0.0", default-features = false }
 filecoin-hashers = { version = "^4.0.0", path = "../filecoin-hashers", default-features = false, features = ["poseidon", "sha256"] }
 bitvec = "0.17"
-rand = "0.7"
+rand = "0.8"
 lazy_static = "1.2"
 memmap = "0.7"
 byteorder = "1"
 itertools = "0.9"
 serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
-ff = { version = "0.3.1", package = "fff" }
+ff = "0.11.0"
 blake2b_simd = "0.5"
-bellperson = { version = "0.16", default-features = false }
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
 log = "0.4.7"
 fil_logger = "0.1"
 rayon = "1.1.0"
@@ -32,15 +32,16 @@ hex = "0.4.0"
 merkletree = "0.21.0"
 bincode = "1.1.2"
 anyhow = "1.0.23"
-rand_xorshift = "0.2.0"
+rand_xorshift = "0.3.0"
 sha2 = "0.9.1"
 typenum = "1.11.2"
 gperftools = { version = "0.2", optional = true }
 generic-array = "0.14.4"
-groupy = "0.4.1"
+group = "0.11.0"
 byte-slice-cast = "1.0.0"
 fr32 = { path = "../fr32", version = "^2.0.0", default-features = false }
 once_cell = "1.8.0"
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -50,7 +51,7 @@ failure = "0.1.7"
 tempfile = "3"
 
 [features]
-default = ["gpu", "blst"]
+default = ["gpu"]
 cpu-profile = ["gperftools"]
 heap-profile = ["gperftools/heap"]
 simd = ["storage-proofs-core/simd"]
@@ -62,22 +63,6 @@ gpu = [
     "bellperson/gpu",
     "filecoin-hashers/gpu",
     "fr32/gpu",
-]
-pairing = [
-    "storage-proofs-core/pairing",
-    "storage-proofs-porep/pairing",
-    "storage-proofs-post/pairing",
-    "bellperson/pairing",
-    "filecoin-hashers/pairing",
-    "fr32/pairing",
-]
-blst = [
-    "storage-proofs-core/blst",
-    "storage-proofs-porep/blst",
-    "storage-proofs-post/blst",
-    "bellperson/blst",
-    "filecoin-hashers/blst",
-    "fr32/blst",
 ]
 
 [[bench]]

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -3,9 +3,9 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use anyhow::{ensure, Context, Result};
-use bellperson::bls::{Bls12, Fr};
 use bellperson::groth16;
 use bincode::{deserialize, serialize};
+use blstrs::{Bls12, Scalar as Fr};
 use filecoin_hashers::{Domain, Hasher};
 use log::{info, trace};
 use memmap::MmapOptions;

--- a/filecoin-proofs/src/api/util.rs
+++ b/filecoin-proofs/src/api/util.rs
@@ -1,7 +1,7 @@
 use std::mem::size_of;
 
 use anyhow::{Context, Result};
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use filecoin_hashers::{Domain, Hasher};
 use fr32::{bytes_into_fr, fr_into_bytes};
 use merkletree::merkle::{get_merkle_tree_leafs, get_merkle_tree_len};

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -2,10 +2,8 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
-use bellperson::{
-    bls::Bls12,
-    groth16::{self, prepare_verifying_key},
-};
+use bellperson::groth16::{self, prepare_verifying_key};
+use blstrs::Bls12;
 use lazy_static::lazy_static;
 use log::{info, trace};
 use once_cell::sync::OnceCell;

--- a/filecoin-proofs/tests/mod.rs
+++ b/filecoin-proofs/tests/mod.rs
@@ -1,6 +1,6 @@
 use std::panic::panic_any;
 
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use ff::Field;
 use filecoin_proofs::{
     as_safe_commitment, verify_seal, DefaultOctLCTree, DefaultTreeDomain, PoRepConfig,
@@ -147,10 +147,10 @@ fn test_verify_seal_fr32_validation() {
 
 #[test]
 fn test_random_domain_element() {
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     for _ in 0..100 {
-        let random_el: DefaultTreeDomain = Fr::random(rng).into();
+        let random_el: DefaultTreeDomain = Fr::random(&mut rng).into();
         let mut randomness = [0u8; 32];
         randomness.copy_from_slice(AsRef::<[u8]>::as_ref(&random_el));
         let back: DefaultTreeDomain =

--- a/filecoin-proofs/tests/pieces.rs
+++ b/filecoin-proofs/tests/pieces.rs
@@ -2,7 +2,7 @@ use std::io::{Cursor, Read};
 use std::iter::Iterator;
 
 use anyhow::Result;
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use filecoin_proofs::{
     add_piece, commitment_from_fr,
     pieces::{
@@ -325,10 +325,8 @@ fn test_verify_random_pieces() -> Result<()> {
                     let max_exp = (left_power_of_two as f64).log2() as u32;
 
                     let padded_exp = if max_exp > 7 {
-                        rng.gen_range(
-                            7, // 2**7 == 128,
-                            max_exp,
-                        )
+                        // 2**7 == 128
+                        rng.gen_range(7..max_exp)
                     } else {
                         7
                     };

--- a/fr32/Cargo.toml
+++ b/fr32/Cargo.toml
@@ -9,25 +9,24 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 
 [dependencies]
 anyhow = "1.0.23"
-bellperson = { version = "0.16", default-features = false }
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
 byte-slice-cast = "1.0.0"
 byteorder = "1"
-ff = { version = "0.3.1", package = "fff" }
+ff = "0.11.0"
 thiserror = "1.0.6"
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
 
 [dev-dependencies]
 bitvec = "0.17"
 criterion = "0.3"
 itertools = "0.9"
 pretty_assertions = "0.6.1"
-rand = "0.7"
-rand_xorshift = "0.2.0"
+rand = "0.8"
+rand_xorshift = "0.3"
 
 [features]
-default = ["blst"]
-blst = ["bellperson/blst"]
+default = []
 gpu = ["bellperson/gpu"]
-pairing = ["bellperson/pairing"]
 
 [[bench]]
 name = "fr"

--- a/fr32/benches/fr.rs
+++ b/fr32/benches/fr.rs
@@ -1,4 +1,4 @@
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use ff::Field;
 use fr32::{bytes_into_fr, fr_into_bytes};

--- a/fr32/src/padding.rs
+++ b/fr32/src/padding.rs
@@ -789,9 +789,9 @@ mod tests {
         // TODO: Evaluate designing a scattered pattered of `pos` and `num_bits`
         // instead of repeating too many iterations with any number.
         for _ in 0..100 {
-            let pos = rng.gen_range(0, data.len() / 2);
-            let num_bits = rng.gen_range(1, data.len() * 8 - pos);
-            let new_offset = rng.gen_range(0, 8);
+            let pos = rng.gen_range(0..data.len() / 2);
+            let num_bits = rng.gen_range(1..data.len() * 8 - pos);
+            let new_offset = rng.gen_range(0..8);
 
             let mut bv = BitVec::<LittleEndian, u8>::new();
             bv.extend(

--- a/storage-proofs-core/Cargo.toml
+++ b/storage-proofs-core/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 
 [dependencies]
 filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-features = false, features = ["sha256", "poseidon"] }
-rand = "0.7"
+rand = "0.8"
 merkletree = "0.21.0"
 byteorder = "1"
 config = { version = "0.10.1", default-features = false, features = ["toml"] }
@@ -30,33 +30,35 @@ serde = { version = "1.0", features = ["derive"]}
 blake2b_simd = "0.5"
 blake2s_simd = "0.5"
 toml = "0.5"
-ff = { version = "0.3.1", package = "fff" }
-bellperson = { version = "0.16", default-features = false }
+ff = "0.11.0"
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
 serde_json = "1.0"
 log = "0.4.7"
-rand_chacha = "0.2.1"
+rand_chacha = "0.3"
 hex = "0.4.0"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
-neptune = { version = "^4.0", default-features = false }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master" }
 cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"
 semver = "0.11.0"
-fr32 = { path = "../fr32", version = "^2.0.0", default-features = false }
+fr32 = { path = "../fr32", version = "^2.0.0" }
+pairing = "0.21"
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
 
 [dev-dependencies]
 proptest = "0.10"
 criterion = "0.3"
 bitvec = "0.17"
-rand_xorshift = "0.2.0"
+rand_xorshift = "0.3.0"
 pretty_assertions = "0.6.1"
 sha2raw = { path = "../sha2raw", version = "^4.0.0"}
 filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-features = false, features = ["blake2s", "sha256", "poseidon"] }
 
 [features]
-default = ["gpu", "blst"]
+default = ["gpu"]
 simd = []
 asm = ["sha2/sha2-asm"]
 big-sector-sizes-bench = []
@@ -64,8 +66,6 @@ measurements = ["cpu-time", "gperftools"]
 profile = ["measurements"]
 
 gpu = ["bellperson/gpu", "neptune/opencl", "filecoin-hashers/gpu", "fr32/gpu"]
-pairing = ["bellperson/pairing", "neptune/pairing", "bellperson/pairing", "filecoin-hashers/pairing", "fr32/pairing"]
-blst = ["bellperson/blst", "neptune/blst", "bellperson/blst", "filecoin-hashers/blst", "fr32/blst"]
 
 [[bench]]
 name = "sha256"

--- a/storage-proofs-core/benches/blake2s.rs
+++ b/storage-proofs-core/benches/blake2s.rs
@@ -1,5 +1,4 @@
 use bellperson::{
-    bls::Bls12,
     gadgets::{
         blake2s::blake2s as blake2s_circuit,
         boolean::{AllocatedBit, Boolean},
@@ -9,6 +8,7 @@ use bellperson::{
     Circuit, ConstraintSystem, SynthesisError,
 };
 use blake2s_simd::blake2s;
+use blstrs::Bls12;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
 

--- a/storage-proofs-core/benches/sha256.rs
+++ b/storage-proofs-core/benches/sha256.rs
@@ -1,5 +1,4 @@
 use bellperson::{
-    bls::Bls12,
     gadgets::{
         boolean::{AllocatedBit, Boolean},
         sha256::sha256 as sha256_circuit,
@@ -8,6 +7,7 @@ use bellperson::{
     util_cs::bench_cs::BenchCS,
     Circuit, ConstraintSystem, SynthesisError,
 };
+use blstrs::Bls12;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use rand::{thread_rng, Rng};
 use sha2::Digest;

--- a/storage-proofs-core/benches/xor.rs
+++ b/storage-proofs-core/benches/xor.rs
@@ -1,10 +1,10 @@
 use bellperson::{
-    bls::Bls12,
     gadgets::boolean::{AllocatedBit, Boolean},
     groth16::{create_random_proof, generate_random_parameters},
     util_cs::bench_cs::BenchCS,
     Circuit, ConstraintSystem, SynthesisError,
 };
+use blstrs::Bls12;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use rand::{thread_rng, Rng};
 use storage_proofs_core::{crypto::xor, gadgets::xor::xor as xor_circuit};

--- a/storage-proofs-core/src/compound_proof.rs
+++ b/storage-proofs-core/src/compound_proof.rs
@@ -1,6 +1,5 @@
 use anyhow::{ensure, Context};
 use bellperson::{
-    bls::{Bls12, Fr},
     groth16::{
         self,
         aggregate::{
@@ -11,6 +10,7 @@ use bellperson::{
     },
     Circuit,
 };
+use blstrs::{Bls12, Scalar as Fr};
 use log::info;
 use rand::{rngs::OsRng, RngCore};
 use rayon::prelude::{

--- a/storage-proofs-core/src/crypto/sloth.rs
+++ b/storage-proofs-core/src/crypto/sloth.rs
@@ -1,35 +1,26 @@
-use bellperson::bls::Fr;
-use ff::Field;
+use blstrs::Scalar as Fr;
 
 /// Sloth based encoding.
 #[inline]
 pub fn encode(key: &Fr, plaintext: &Fr) -> Fr {
-    let mut ciphertext = *plaintext;
-
-    ciphertext.add_assign(key); // c + k
-    ciphertext
+    plaintext + key
 }
 
 /// Sloth based decoding.
 #[inline]
 pub fn decode(key: &Fr, ciphertext: &Fr) -> Fr {
-    let mut plaintext = *ciphertext;
-
-    plaintext.sub_assign(key); // c - k
-
-    plaintext
+    ciphertext - key
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use bellperson::bls::FrRepr;
     use ff::PrimeField;
     use proptest::{prop_compose, proptest};
 
     // the modulus from `bls12_381::Fr`
-    // The definition of MODULUS and comment defining r come from paired/src/bls_12_381/fr.rs.
+    // The definition of MODULUS and comment defining r come from blstrs/src/scalar.rs.
     // r = 52435875175126190479447740508185965837690552500527637822603658699938581184513
     const MODULUS: [u64; 4] = [
         0xffffffff00000001,
@@ -40,8 +31,8 @@ mod tests {
 
     #[test]
     fn sloth_bls_12() {
-        let key = Fr::from_str("11111111").expect("from_str failed");
-        let plaintext = Fr::from_str("123456789").expect("from_str failed");
+        let key = Fr::from_str_vartime("11111111").expect("from_str failed");
+        let plaintext = Fr::from_str_vartime("123456789").expect("from_str failed");
         let ciphertext = encode(&key, &plaintext);
         let decrypted = decode(&key, &ciphertext);
         assert_eq!(plaintext, decrypted);
@@ -50,9 +41,9 @@ mod tests {
 
     #[test]
     fn sloth_bls_12_fake() {
-        let key = Fr::from_str("11111111").expect("from_str failed");
-        let key_fake = Fr::from_str("11111112").expect("from_str failed");
-        let plaintext = Fr::from_str("123456789").expect("from_str failed");
+        let key = Fr::from_str_vartime("11111111").expect("from_str failed");
+        let key_fake = Fr::from_str_vartime("11111112").expect("from_str failed");
+        let plaintext = Fr::from_str_vartime("123456789").expect("from_str failed");
         let ciphertext = encode(&key, &plaintext);
         let decrypted = decode(&key_fake, &ciphertext);
         assert_ne!(plaintext, decrypted);
@@ -60,7 +51,12 @@ mod tests {
 
     prop_compose! {
         fn arb_fr()(a in 0..MODULUS[0], b in 0..MODULUS[1], c in 0..MODULUS[2], d in 0..MODULUS[3]) -> Fr {
-            Fr::from_repr(FrRepr([a, b, c, d])).expect("from_repr failed")
+            let mut le_bytes = [0u8; 32];
+            le_bytes[0..8].copy_from_slice(&a.to_le_bytes());
+            le_bytes[8..16].copy_from_slice(&b.to_le_bytes());
+            le_bytes[16..24].copy_from_slice(&c.to_le_bytes());
+            le_bytes[24..32].copy_from_slice(&d.to_le_bytes());
+            Fr::from_repr_vartime(le_bytes).expect("from_repr failed")
         }
     }
     proptest! {

--- a/storage-proofs-core/src/gadgets/constraint.rs
+++ b/storage-proofs-core/src/gadgets/constraint.rs
@@ -1,5 +1,5 @@
-use bellperson::{bls::Engine, gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
-use ff::Field;
+use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use pairing::Engine;
 
 /// Adds a constraint to CS, enforcing an equality relationship between the allocated numbers a and b.
 ///
@@ -51,7 +51,7 @@ pub fn add<E: Engine, CS: ConstraintSystem<E>>(
 ) -> Result<AllocatedNum<E>, SynthesisError> {
     let res = AllocatedNum::alloc(cs.namespace(|| "add_num"), || {
         let mut tmp = a.get_value().ok_or(SynthesisError::AssignmentMissing)?;
-        tmp.add_assign(&b.get_value().ok_or(SynthesisError::AssignmentMissing)?);
+        tmp += &b.get_value().ok_or(SynthesisError::AssignmentMissing)?;
 
         Ok(tmp)
     })?;
@@ -69,7 +69,7 @@ pub fn sub<E: Engine, CS: ConstraintSystem<E>>(
 ) -> Result<AllocatedNum<E>, SynthesisError> {
     let res = AllocatedNum::alloc(cs.namespace(|| "sub_num"), || {
         let mut tmp = a.get_value().ok_or(SynthesisError::AssignmentMissing)?;
-        tmp.sub_assign(&b.get_value().ok_or(SynthesisError::AssignmentMissing)?);
+        tmp -= &b.get_value().ok_or(SynthesisError::AssignmentMissing)?;
 
         Ok(tmp)
     })?;
@@ -108,10 +108,9 @@ pub fn difference<E: Engine, A, AR, CS: ConstraintSystem<E>>(
 mod tests {
     use super::*;
 
-    use bellperson::{
-        bls::{Bls12, Fr},
-        util_cs::test_cs::TestConstraintSystem,
-    };
+    use bellperson::util_cs::test_cs::TestConstraintSystem;
+    use blstrs::{Bls12, Scalar as Fr};
+    use ff::Field;
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
@@ -119,20 +118,20 @@ mod tests {
 
     #[test]
     fn add_constraint() {
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(rng)))
+            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(&mut rng)))
                 .expect("alloc failed");
-            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(rng)))
+            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(&mut rng)))
                 .expect("alloc failed");
 
             let res = add(cs.namespace(|| "a+b"), &a, &b).expect("add failed");
 
             let mut tmp = a.get_value().expect("get_value failed");
-            tmp.add_assign(&b.get_value().expect("get_value failed"));
+            tmp += &b.get_value().expect("get_value failed");
 
             assert_eq!(res.get_value().expect("get_value failed"), tmp);
             assert!(cs.is_satisfied());
@@ -141,20 +140,20 @@ mod tests {
 
     #[test]
     fn sub_constraint() {
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..100 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(rng)))
+            let a = AllocatedNum::alloc(cs.namespace(|| "a"), || Ok(Fr::random(&mut rng)))
                 .expect("alloc failed");
-            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(rng)))
+            let b = AllocatedNum::alloc(cs.namespace(|| "b"), || Ok(Fr::random(&mut rng)))
                 .expect("alloc failed");
 
             let res = sub(cs.namespace(|| "a-b"), &a, &b).expect("subtraction failed");
 
             let mut tmp = a.get_value().expect("get_value failed");
-            tmp.sub_assign(&b.get_value().expect("get_value failed"));
+            tmp -= &b.get_value().expect("get_value failed");
 
             assert_eq!(res.get_value().expect("get_value failed"), tmp);
             assert!(cs.is_satisfied());

--- a/storage-proofs-core/src/gadgets/encode.rs
+++ b/storage-proofs-core/src/gadgets/encode.rs
@@ -1,4 +1,5 @@
-use bellperson::{bls::Engine, gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use pairing::Engine;
 
 use crate::gadgets::constraint;
 

--- a/storage-proofs-core/src/gadgets/insertion.rs
+++ b/storage-proofs-core/src/gadgets/insertion.rs
@@ -4,7 +4,6 @@
 //! This can be thought of as a generalization of `AllocatedNum::conditionally_reverse` and reduces to it in the binary case.
 
 use bellperson::{
-    bls::Engine,
     gadgets::{
         boolean::{AllocatedBit, Boolean},
         num::AllocatedNum,
@@ -12,6 +11,7 @@ use bellperson::{
     ConstraintSystem, SynthesisError,
 };
 use ff::Field;
+use pairing::Engine;
 
 /// Insert `element` after the nth 1-indexed element of `elements`, where `path_bits` represents n, least-significant bit first.
 /// The returned result contains a new vector of `AllocatedNum`s with `element` inserted, and constraints are enforced.
@@ -353,10 +353,8 @@ where
 mod tests {
     use super::*;
 
-    use bellperson::{
-        bls::{Bls12, Fr},
-        util_cs::test_cs::TestConstraintSystem,
-    };
+    use bellperson::util_cs::test_cs::TestConstraintSystem;
+    use blstrs::{Bls12, Scalar as Fr};
     use rand::SeedableRng;
     use rand_xorshift::XorShiftRng;
 
@@ -368,7 +366,7 @@ mod tests {
             let size = 1 << log_size;
             for index in 0..size {
                 // Initialize rng in loop to simplify debugging with consistent elements.
-                let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+                let mut rng = XorShiftRng::from_seed(TEST_SEED);
                 let mut cs = TestConstraintSystem::new();
 
                 let elements: Vec<_> = (0..size)
@@ -376,7 +374,7 @@ mod tests {
                         AllocatedNum::<Bls12>::alloc(
                             &mut cs.namespace(|| format!("element {}", i)),
                             || {
-                                let elt = <Fr as Field>::random(rng);
+                                let elt = <Fr as Field>::random(&mut rng);
                                 Ok(elt)
                             },
                         )
@@ -420,7 +418,7 @@ mod tests {
             let size = 1 << log_size;
             for index in 0..size {
                 // Initialize rng in loop to simplify debugging with consistent elements.
-                let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+                let mut rng = XorShiftRng::from_seed(TEST_SEED);
                 let mut cs = TestConstraintSystem::new();
 
                 let elements: Vec<_> = (0..size - 1)
@@ -428,7 +426,7 @@ mod tests {
                         AllocatedNum::<Bls12>::alloc(
                             &mut cs.namespace(|| format!("element {}", i)),
                             || {
-                                let elt = <Fr as Field>::random(rng);
+                                let elt = <Fr as Field>::random(&mut rng);
                                 Ok(elt)
                             },
                         )
@@ -438,7 +436,7 @@ mod tests {
 
                 let to_insert =
                     AllocatedNum::<Bls12>::alloc(&mut cs.namespace(|| "insert"), || {
-                        let elt_to_insert = <Fr as Field>::random(rng);
+                        let elt_to_insert = <Fr as Field>::random(&mut rng);
                         Ok(elt_to_insert)
                     })
                     .expect("alloc failed");

--- a/storage-proofs-core/src/gadgets/por.rs
+++ b/storage-proofs-core/src/gadgets/por.rs
@@ -3,7 +3,6 @@ use std::marker::PhantomData;
 
 use anyhow::ensure;
 use bellperson::{
-    bls::{Bls12, Fr, FrRepr},
     gadgets::{
         boolean::{AllocatedBit, Boolean},
         multipack,
@@ -11,7 +10,7 @@ use bellperson::{
     },
     Circuit, ConstraintSystem, SynthesisError,
 };
-use ff::PrimeField;
+use blstrs::{Bls12, Scalar as Fr};
 use filecoin_hashers::{HashFunction, Hasher, PoseidonArity};
 use generic_array::typenum::Unsigned;
 
@@ -322,9 +321,8 @@ impl<'a, Tree: 'static + MerkleTreeTrait> CompoundProof<'a, PoR<Tree>, PoRCircui
         // Inputs are (currently, inefficiently) packed with one `Fr` per challenge.
         // Boolean/bit auth paths trivially correspond to the challenged node's index within a sector.
         // Defensively convert the challenge with `try_from` as a reminder that we must not truncate.
-        let input_fr = Fr::from_repr(FrRepr::from(
-            u64::try_from(pub_inputs.challenge).expect("challenge type too wide"),
-        ))?;
+        let input_fr =
+            Fr::from(u64::try_from(pub_inputs.challenge).expect("challenge type too wide"));
         inputs.push(input_fr);
 
         if let Some(commitment) = pub_inputs.commitment {
@@ -552,12 +550,12 @@ mod tests {
     }
 
     fn por_compound<Tree: 'static + MerkleTreeTrait>() {
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         let leaves = 64 * get_base_tree_count::<Tree>();
 
         let data: Vec<u8> = (0..leaves)
-            .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+            .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
             .collect();
         let tree = create_base_merkle_tree::<Tree>(None, leaves, data.as_slice())
             .expect("create_base_merkle_tree failure");
@@ -587,8 +585,9 @@ mod tests {
             &tree,
         );
 
-        let gparams = PoRCompound::<Tree>::groth_params(Some(rng), &public_params.vanilla_params)
-            .expect("failed to generate groth params");
+        let gparams =
+            PoRCompound::<Tree>::groth_params(Some(&mut rng), &public_params.vanilla_params)
+                .expect("failed to generate groth params");
 
         let proof =
             PoRCompound::<Tree>::prove(&public_params, &public_inputs, &private_inputs, &gparams)
@@ -936,14 +935,14 @@ mod tests {
     }
 
     fn test_private_por_input_circuit<Tree: MerkleTreeTrait>(num_constraints: usize) {
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         let leaves = 64 * get_base_tree_count::<Tree>();
         for i in 0..leaves {
             // -- Basic Setup
 
             let data: Vec<u8> = (0..leaves)
-                .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+                .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
                 .collect();
 
             let tree = create_base_merkle_tree::<Tree>(None, leaves, data.as_slice())

--- a/storage-proofs-core/src/gadgets/uint64.rs
+++ b/storage-proofs-core/src/gadgets/uint64.rs
@@ -1,11 +1,11 @@
 use bellperson::{
-    bls::Engine,
     gadgets::{
         boolean::{AllocatedBit, Boolean},
         multipack::pack_into_inputs,
     },
     ConstraintSystem, SynthesisError,
 };
+use pairing::Engine;
 
 /// Represents an interpretation of 64 `Boolean` objects as an unsigned integer.
 #[derive(Clone)]

--- a/storage-proofs-core/src/gadgets/variables.rs
+++ b/storage-proofs-core/src/gadgets/variables.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Debug, Formatter};
 
-use bellperson::{bls::Engine, gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use pairing::Engine;
 
 use crate::error::Result;
 

--- a/storage-proofs-core/src/gadgets/xor.rs
+++ b/storage-proofs-core/src/gadgets/xor.rs
@@ -1,4 +1,5 @@
-use bellperson::{bls::Engine, gadgets::boolean::Boolean, ConstraintSystem, SynthesisError};
+use bellperson::{gadgets::boolean::Boolean, ConstraintSystem, SynthesisError};
+use pairing::Engine;
 
 pub fn xor<E, CS>(
     cs: &mut CS,
@@ -29,7 +30,8 @@ where
 mod tests {
     use super::*;
 
-    use bellperson::{bls::Bls12, util_cs::test_cs::TestConstraintSystem};
+    use bellperson::util_cs::test_cs::TestConstraintSystem;
+    use blstrs::Bls12;
     use rand::{Rng, SeedableRng};
     use rand_xorshift::XorShiftRng;
 

--- a/storage-proofs-core/src/merkle/proof.rs
+++ b/storage-proofs-core/src/merkle/proof.rs
@@ -5,7 +5,7 @@ use std::marker::PhantomData;
 use std::slice::Iter;
 
 use anyhow::{ensure, Result};
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use filecoin_hashers::{Hasher, PoseidonArity};
 use generic_array::typenum::{Unsigned, U0};
 use merkletree::hash::Algorithm;

--- a/storage-proofs-core/src/multi_proof.rs
+++ b/storage-proofs-core/src/multi_proof.rs
@@ -1,10 +1,8 @@
 use std::io::{Read, Write};
 
 use anyhow::{ensure, Context};
-use bellperson::{
-    bls::Bls12,
-    groth16::{self, PreparedVerifyingKey},
-};
+use bellperson::groth16::{self, PreparedVerifyingKey};
+use blstrs::Bls12;
 
 use crate::error::Result;
 

--- a/storage-proofs-core/src/parameter_cache.rs
+++ b/storage-proofs-core/src/parameter_cache.rs
@@ -6,8 +6,9 @@ use std::sync::Mutex;
 use std::time::Instant;
 
 use anyhow::bail;
-use bellperson::{bls::Bls12, groth16, Circuit};
+use bellperson::{groth16, Circuit};
 use blake2b_simd::Params as Blake2bParams;
+use blstrs::Bls12;
 use fs2::FileExt;
 use itertools::Itertools;
 use lazy_static::lazy_static;

--- a/storage-proofs-core/src/sector.rs
+++ b/storage-proofs-core/src/sector.rs
@@ -1,9 +1,8 @@
 use std::collections::BTreeSet;
 use std::fmt::{self, Display, Formatter};
 
-use bellperson::bls::{Fr, FrRepr};
+use blstrs::Scalar as Fr;
 use byteorder::{ByteOrder, LittleEndian};
-use ff::PrimeField;
 use serde::{Deserialize, Serialize};
 
 /// An ordered set of `SectorId`s.
@@ -29,7 +28,7 @@ impl From<SectorId> for u64 {
 
 impl From<SectorId> for Fr {
     fn from(n: SectorId) -> Self {
-        Fr::from_repr(FrRepr::from(n.0)).expect("from repr failure")
+        Fr::from(n.0)
     }
 }
 

--- a/storage-proofs-core/src/util.rs
+++ b/storage-proofs-core/src/util.rs
@@ -2,11 +2,11 @@ use std::cmp::min;
 
 use anyhow::ensure;
 use bellperson::{
-    bls::Engine,
     gadgets::boolean::{AllocatedBit, Boolean},
     ConstraintSystem, SynthesisError,
 };
 use merkletree::merkle::get_merkle_tree_row_count;
+use pairing::Engine;
 
 use crate::{error::Error, settings::SETTINGS};
 
@@ -182,11 +182,8 @@ pub fn default_rows_to_discard(leafs: usize, arity: usize) -> usize {
 mod tests {
     use super::*;
 
-    use bellperson::{
-        bls::{Bls12, Fr},
-        gadgets::num::AllocatedNum,
-        util_cs::test_cs::TestConstraintSystem,
-    };
+    use bellperson::{gadgets::num::AllocatedNum, util_cs::test_cs::TestConstraintSystem};
+    use blstrs::{Bls12, Scalar as Fr};
     use ff::Field;
     use filecoin_hashers::{sha256::Sha256Function, HashFunction};
     use fr32::fr_into_bytes;
@@ -295,10 +292,10 @@ mod tests {
     #[test]
     fn hash_leaf_bits_circuit() {
         let mut cs = TestConstraintSystem::<Bls12>::new();
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
-        let left_fr = Fr::random(rng);
-        let right_fr = Fr::random(rng);
+        let left_fr = Fr::random(&mut rng);
+        let right_fr = Fr::random(&mut rng);
         let left: Vec<u8> = fr_into_bytes(&left_fr);
         let right: Vec<u8> = fr_into_bytes(&right_fr);
         let height = 1;

--- a/storage-proofs-core/tests/por_circuit.rs
+++ b/storage-proofs-core/tests/por_circuit.rs
@@ -1,9 +1,9 @@
 use bellperson::{
-    bls::{Bls12, Fr},
     gadgets::{boolean::AllocatedBit, multipack, num::AllocatedNum},
     util_cs::test_cs::TestConstraintSystem,
     Circuit, ConstraintSystem,
 };
+use blstrs::{Bls12, Scalar as Fr};
 use ff::Field;
 use filecoin_hashers::{
     blake2s::Blake2sHasher, poseidon::PoseidonHasher, sha256::Sha256Hasher, Domain, Hasher,
@@ -107,13 +107,13 @@ fn test_por_circuit_poseidon_top_8_2_4() {
 }
 
 fn test_por_circuit<Tree: 'static + MerkleTreeTrait>(num_inputs: usize, num_constraints: usize) {
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     // Ensure arity will evenly fill tree.
     let leaves = 64 * get_base_tree_count::<Tree>();
 
     // -- Basic Setup
-    let (data, tree) = generate_tree::<Tree, _>(rng, leaves, None);
+    let (data, tree) = generate_tree::<Tree, _>(&mut rng, leaves, None);
 
     for i in 0..leaves {
         //println!("challenge: {}, ({})", i, leaves);
@@ -198,14 +198,14 @@ fn test_por_circuit_poseidon_base_8_private_root() {
 }
 
 fn test_por_circuit_private_root<Tree: MerkleTreeTrait>(num_constraints: usize) {
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     let leaves = 64 * get_base_tree_count::<Tree>();
     for i in 0..leaves {
         // -- Basic Setup
 
         let data: Vec<u8> = (0..leaves)
-            .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+            .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
             .collect();
 
         let tree = create_base_merkle_tree::<Tree>(None, leaves, data.as_slice())
@@ -281,13 +281,13 @@ fn test_por_no_challenge_input() {
     type Tree = TreeBase<PoseidonHasher, Arity>;
 
     // == Setup
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     let height = 3;
     let n_leaves = Arity::to_usize() << height;
 
     let data: Vec<u8> = (0..n_leaves)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
 
     let tree = create_base_merkle_tree::<Tree>(None, n_leaves, &data)

--- a/storage-proofs-core/tests/por_vanilla.rs
+++ b/storage-proofs-core/tests/por_vanilla.rs
@@ -1,6 +1,6 @@
 use std::convert::Into;
 
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use ff::Field;
 use filecoin_hashers::{
     blake2s::Blake2sHasher, poseidon::PoseidonHasher, sha256::Sha256Hasher, Domain, Hasher,
@@ -52,7 +52,7 @@ fn test_por_blake2s_base_4() {
 }
 
 fn test_por<Tree: MerkleTreeTrait>() {
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     let leaves = 16;
     let pub_params = por::PublicParams {
@@ -61,7 +61,7 @@ fn test_por<Tree: MerkleTreeTrait>() {
     };
 
     let data: Vec<u8> = (0..leaves)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
     let porep_id = [3; 32];
     let graph =
@@ -120,7 +120,7 @@ fn test_por_validates_proof_poseidon_base_4() {
 }
 
 fn test_por_validates_proof<Tree: MerkleTreeTrait>() {
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     let leaves = 64;
     let pub_params = por::PublicParams {
@@ -129,7 +129,7 @@ fn test_por_validates_proof<Tree: MerkleTreeTrait>() {
     };
 
     let data: Vec<u8> = (0..leaves)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
 
     let porep_id = [99; 32];
@@ -162,7 +162,7 @@ fn test_por_validates_proof<Tree: MerkleTreeTrait>() {
     let bad_proof = {
         let mut proof = good_proof;
         let mut bad_leaf = Into::<Fr>::into(proof.data);
-        bad_leaf.add_assign(&Fr::one());
+        bad_leaf += Fr::one();
         proof.data = bad_leaf.into();
         proof
     };
@@ -204,7 +204,7 @@ fn test_por_validates_challenge_poseidon_base_4() {
 }
 
 fn test_por_validates_challenge<Tree: MerkleTreeTrait>() {
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     let leaves = 64;
 
@@ -214,7 +214,7 @@ fn test_por_validates_challenge<Tree: MerkleTreeTrait>() {
     };
 
     let data: Vec<u8> = (0..leaves)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
 
     let porep_id = [32; 32];

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -14,7 +14,7 @@ digest = "0.9"
 storage-proofs-core = { path = "../storage-proofs-core", version = "^9.0.0", default-features = false}
 sha2raw = { path = "../sha2raw", version = "^4.0.0"}
 filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-features = false, features = ["poseidon", "sha256"]}
-rand = "0.7"
+rand = "0.8"
 merkletree = "0.21.0"
 mapr = "0.8.0"
 num-bigint = "0.2"
@@ -22,13 +22,13 @@ num-traits = "0.2"
 rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
-ff = { version = "0.3.1", package = "fff" }
-bellperson = { version = "0.16", default-features = false }
+ff = "0.11.0"
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
 log = "0.4.7"
 pretty_assertions = "0.6.1"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { version = "^4.0", default-features = false }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master" }
 num_cpus = "1.10.1"
 hex = "0.4.2"
 bincode = "1.1.2"
@@ -41,6 +41,8 @@ fdlimit = "0.2.0"
 fr32 = { path = "../fr32", version = "^2.0.0", default-features = false }
 yastl = "0.1.2"
 fil_logger = "0.1"
+pairing = "0.21"
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
 
 [target."cfg(target_arch = \"aarch64\")".dependencies]
 sha2 = { version = "0.9.3", features = ["compress", "asm"] }
@@ -49,17 +51,15 @@ sha2 = { version = "0.9.3", features = ["compress"] }
 
 [dev-dependencies]
 tempfile = "3"
-rand_xorshift = "0.2.0"
+rand_xorshift = "0.3.0"
 criterion = "0.3.2"
 glob = "0.3.0"
 pretty_env_logger = "0.4.0"
 filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
 
 [features]
-default = ["blst", "gpu", "multicore-sdr"]
+default = ["gpu", "multicore-sdr"]
 gpu = ["storage-proofs-core/gpu", "filecoin-hashers/gpu", "neptune/opencl", "bellperson/gpu", "fr32/gpu"]
-pairing = ["storage-proofs-core/pairing", "bellperson/pairing", "neptune/pairing", "filecoin-hashers/pairing", "fr32/pairing"]
-blst = ["storage-proofs-core/blst", "bellperson/blst", "neptune/blst", "filecoin-hashers/blst", "fr32/blst"]
 isolated-testing = []
 multicore-sdr = ["hwloc"]
 

--- a/storage-proofs-porep/benches/encode.rs
+++ b/storage-proofs-porep/benches/encode.rs
@@ -1,4 +1,4 @@
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 use ff::Field;
 use filecoin_hashers::{sha256::Sha256Hasher, Domain, Hasher};

--- a/storage-proofs-porep/src/drg/circuit.rs
+++ b/storage-proofs-porep/src/drg/circuit.rs
@@ -1,12 +1,13 @@
 use std::marker::PhantomData;
 
 use bellperson::{
-    bls::{Bls12, Engine, Fr},
     gadgets::{boolean::Boolean, multipack, num::AllocatedNum, sha256::sha256 as sha256_circuit},
     Circuit, ConstraintSystem, SynthesisError,
 };
+use blstrs::{Bls12, Scalar as Fr};
 use ff::PrimeField;
 use filecoin_hashers::Hasher;
+use pairing::Engine;
 use storage_proofs_core::{
     compound_proof::CircuitComponent,
     error::Result,

--- a/storage-proofs-porep/src/drg/compound.rs
+++ b/storage-proofs-porep/src/drg/compound.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
 use anyhow::{ensure, Context};
-use bellperson::bls::{Bls12, Fr};
 use bellperson::Circuit;
+use blstrs::{Bls12, Scalar as Fr};
 use filecoin_hashers::Hasher;
 use generic_array::typenum;
 use storage_proofs_core::{

--- a/storage-proofs-porep/src/encode.rs
+++ b/storage-proofs-porep/src/encode.rs
@@ -1,12 +1,11 @@
-use bellperson::bls::Fr;
-use ff::Field;
+use blstrs::Scalar as Fr;
 use filecoin_hashers::Domain;
 
 pub fn encode<T: Domain>(key: T, value: T) -> T {
     let mut result: Fr = value.into();
     let key: Fr = key.into();
 
-    result.add_assign(&key);
+    result += key;
     result.into()
 }
 
@@ -14,6 +13,6 @@ pub fn decode<T: Domain>(key: T, value: T) -> T {
     let mut result: Fr = value.into();
     let key: Fr = key.into();
 
-    result.sub_assign(&key);
+    result -= key;
     result.into()
 }

--- a/storage-proofs-porep/src/stacked/circuit/column.rs
+++ b/storage-proofs-porep/src/stacked/circuit/column.rs
@@ -1,8 +1,5 @@
-use bellperson::{
-    bls::{Bls12, Fr},
-    gadgets::num::AllocatedNum,
-    ConstraintSystem, SynthesisError,
-};
+use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use blstrs::{Bls12, Scalar as Fr};
 use filecoin_hashers::Hasher;
 use storage_proofs_core::merkle::MerkleTreeTrait;
 

--- a/storage-proofs-porep/src/stacked/circuit/column_proof.rs
+++ b/storage-proofs-porep/src/stacked/circuit/column_proof.rs
@@ -1,4 +1,5 @@
-use bellperson::{bls::Bls12, ConstraintSystem, SynthesisError};
+use bellperson::{ConstraintSystem, SynthesisError};
+use blstrs::Bls12;
 use filecoin_hashers::{Hasher, PoseidonArity};
 use storage_proofs_core::{
     drgraph::Graph,

--- a/storage-proofs-porep/src/stacked/circuit/create_label.rs
+++ b/storage-proofs-porep/src/stacked/circuit/create_label.rs
@@ -1,5 +1,4 @@
 use bellperson::{
-    bls::Engine,
     gadgets::{
         boolean::Boolean, multipack, num::AllocatedNum, sha256::sha256 as sha256_circuit,
         uint32::UInt32,
@@ -7,6 +6,7 @@ use bellperson::{
     ConstraintSystem, SynthesisError,
 };
 use ff::PrimeField;
+use pairing::Engine;
 use storage_proofs_core::{gadgets::uint64::UInt64, util::reverse_bit_numbering};
 
 use crate::stacked::vanilla::TOTAL_PARENTS;
@@ -73,10 +73,8 @@ where
 mod tests {
     use super::*;
 
-    use bellperson::{
-        bls::{Bls12, Fr},
-        util_cs::test_cs::TestConstraintSystem,
-    };
+    use bellperson::util_cs::test_cs::TestConstraintSystem;
+    use blstrs::{Bls12, Scalar as Fr};
     use ff::Field;
     use filecoin_hashers::sha256::Sha256Hasher;
     use fr32::{bytes_into_fr, fr_into_bytes};
@@ -94,7 +92,7 @@ mod tests {
     #[test]
     fn test_create_label() {
         let mut cs = TestConstraintSystem::<Bls12>::new();
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         let size = 64;
         let porep_id = [32; 32];
@@ -108,13 +106,13 @@ mod tests {
         )
         .expect("stacked bucket graph new_stacked failed");
 
-        let id_fr = Fr::random(rng);
+        let id_fr = Fr::random(&mut rng);
         let id: Vec<u8> = fr_into_bytes(&id_fr);
         let layer = 3;
         let node = 22;
 
         let mut data: Vec<u8> = (0..2 * size)
-            .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+            .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
             .collect();
 
         let mut parents = vec![0; BASE_DEGREE + EXP_DEGREE];

--- a/storage-proofs-porep/src/stacked/circuit/hash.rs
+++ b/storage-proofs-porep/src/stacked/circuit/hash.rs
@@ -1,4 +1,5 @@
-use bellperson::{bls::Bls12, gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use blstrs::Bls12;
 use filecoin_hashers::{POSEIDON_CONSTANTS_11, POSEIDON_CONSTANTS_2};
 use generic_array::typenum::{U11, U2};
 use neptune::circuit::poseidon_hash;
@@ -22,7 +23,8 @@ where
 mod tests {
     use super::*;
 
-    use bellperson::{bls::Fr, util_cs::test_cs::TestConstraintSystem};
+    use bellperson::util_cs::test_cs::TestConstraintSystem;
+    use blstrs::Scalar as Fr;
     use ff::Field;
     use filecoin_hashers::{poseidon::PoseidonHasher, HashFunction, Hasher};
     use rand::SeedableRng;
@@ -33,13 +35,13 @@ mod tests {
 
     #[test]
     fn test_hash2_circuit() {
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..10 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let a = Fr::random(rng);
-            let b = Fr::random(rng);
+            let a = Fr::random(&mut rng);
+            let b = Fr::random(&mut rng);
 
             let a_num = {
                 let mut cs = cs.namespace(|| "a");
@@ -74,12 +76,12 @@ mod tests {
 
     #[test]
     fn test_hash_single_column_circuit() {
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
         for _ in 0..1 {
             let mut cs = TestConstraintSystem::<Bls12>::new();
 
-            let vals = vec![Fr::random(rng); 11];
+            let vals = vec![Fr::random(&mut rng); 11];
             let vals_opt = vals
                 .iter()
                 .enumerate()

--- a/storage-proofs-porep/src/stacked/circuit/params.rs
+++ b/storage-proofs-porep/src/stacked/circuit/params.rs
@@ -1,10 +1,10 @@
 use std::marker::PhantomData;
 
 use bellperson::{
-    bls::{Bls12, Fr},
     gadgets::{boolean::Boolean, num::AllocatedNum, uint32::UInt32},
     ConstraintSystem, SynthesisError,
 };
+use blstrs::{Bls12, Scalar as Fr};
 use filecoin_hashers::{Hasher, PoseidonArity};
 use generic_array::typenum::{U0, U2};
 use storage_proofs_core::{

--- a/storage-proofs-porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs-porep/src/stacked/circuit/proof.rs
@@ -1,11 +1,8 @@
 use std::marker::PhantomData;
 
 use anyhow::ensure;
-use bellperson::{
-    bls::{Bls12, Fr},
-    gadgets::num::AllocatedNum,
-    Circuit, ConstraintSystem, SynthesisError,
-};
+use bellperson::{gadgets::num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
+use blstrs::{Bls12, Scalar as Fr};
 use filecoin_hashers::{HashFunction, Hasher};
 use fr32::u64_into_fr;
 use storage_proofs_core::{

--- a/storage-proofs-porep/src/stacked/vanilla/column.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/column.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use filecoin_hashers::Hasher;
 use serde::{Deserialize, Serialize};
 use storage_proofs_core::{

--- a/storage-proofs-porep/src/stacked/vanilla/column_proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/column_proof.rs
@@ -1,4 +1,4 @@
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use filecoin_hashers::Hasher;
 use log::trace;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};

--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -635,7 +635,7 @@ pub fn create_labels_for_decoding<Tree: 'static + MerkleTreeTrait, T: AsRef<[u8]
 mod tests {
     use super::*;
 
-    use bellperson::bls::{Fr, FrRepr};
+    use blstrs::Scalar as Fr;
     use ff::PrimeField;
     use filecoin_hashers::poseidon::PoseidonHasher;
     use generic_array::typenum::{U0, U2, U8};
@@ -659,7 +659,7 @@ mod tests {
             replica_id,
             legacy_porep_id,
             ApiVersion::V1_0_0,
-            Fr::from_repr(FrRepr([
+            Option::from(Fr::from_u64s_le(&[
                 0xd3faa96b9a0fba04,
                 0xea81a283d106485e,
                 0xe3d51b9afa5ac2b3,
@@ -673,7 +673,7 @@ mod tests {
             replica_id,
             legacy_porep_id,
             ApiVersion::V1_0_0,
-            Fr::from_repr(FrRepr([
+            Option::from(Fr::from_u64s_le(&[
                 0x7e191e52c4a8da86,
                 0x5ae8a1c9e6fac148,
                 0xce239f3b88a894b8,
@@ -688,7 +688,7 @@ mod tests {
             replica_id,
             new_porep_id,
             ApiVersion::V1_1_0,
-            Fr::from_repr(FrRepr([
+            Option::from(Fr::from_u64s_le(&[
                 0xabb3f38bb70defcf,
                 0x777a2e4d7769119f,
                 0x3448959d495490bc,
@@ -703,7 +703,7 @@ mod tests {
             replica_id,
             new_porep_id,
             ApiVersion::V1_1_0,
-            Fr::from_repr(FrRepr([
+            Option::from(Fr::from_u64s_le(&[
                 0x22ab81cf68c4676d,
                 0x7a77a82fc7c9c189,
                 0xc6c03d32c1e42d23,
@@ -753,6 +753,6 @@ mod tests {
             .read_at(final_labels.len() - 1)
             .expect("read_at");
         dbg!(&last_label);
-        assert_eq!(expected_last_label.into_repr(), last_label.0);
+        assert_eq!(expected_last_label.to_repr(), last_label.0);
     }
 }

--- a/storage-proofs-porep/src/stacked/vanilla/encoding_proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/encoding_proof.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use filecoin_hashers::Hasher;
 use fr32::bytes_into_fr_repr_safe;
 use log::trace;

--- a/storage-proofs-porep/src/stacked/vanilla/hash.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/hash.rs
@@ -1,4 +1,4 @@
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use filecoin_hashers::{POSEIDON_CONSTANTS_11, POSEIDON_CONSTANTS_2};
 use neptune::poseidon::Poseidon;
 

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -485,7 +485,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         use std::sync::mpsc::sync_channel as channel;
         use std::sync::{Arc, RwLock};
 
-        use bellperson::bls::Fr;
+        use blstrs::Scalar as Fr;
         use fr32::fr_into_bytes;
         use generic_array::GenericArray;
         use merkletree::store::DiskStore;
@@ -866,7 +866,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         use std::io::Write;
         use std::sync::mpsc::sync_channel as channel;
 
-        use bellperson::bls::Fr;
+        use blstrs::Scalar as Fr;
         use fr32::fr_into_bytes;
         use merkletree::merkle::{get_merkle_tree_cache_size, get_merkle_tree_leafs};
         use neptune::{
@@ -1416,7 +1416,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         use std::fs::OpenOptions;
         use std::io::Write;
 
-        use bellperson::bls::Fr;
+        use blstrs::Scalar as Fr;
         use ff::Field;
         use fr32::fr_into_bytes;
         use merkletree::merkle::{get_merkle_tree_cache_size, get_merkle_tree_leafs};

--- a/storage-proofs-porep/tests/drg_circuit.rs
+++ b/storage-proofs-porep/tests/drg_circuit.rs
@@ -1,8 +1,5 @@
-use bellperson::{
-    bls::{Bls12, Fr},
-    util_cs::test_cs::TestConstraintSystem,
-    ConstraintSystem,
-};
+use bellperson::{util_cs::test_cs::TestConstraintSystem, ConstraintSystem};
+use blstrs::{Bls12, Scalar as Fr};
 use ff::Field;
 use filecoin_hashers::poseidon::PoseidonHasher;
 use fr32::{bytes_into_fr, fr_into_bytes};
@@ -32,16 +29,16 @@ use tempfile::tempdir;
 
 #[test]
 fn test_drg_porep_circuit() {
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     let nodes = 16;
     let degree = BASE_DEGREE;
     let challenge = 2;
 
-    let replica_id: Fr = Fr::random(rng);
+    let replica_id: Fr = Fr::random(&mut rng);
 
     let data: Vec<u8> = (0..nodes)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
 
     // MT for original data is always named tree-d, and it will be
@@ -207,7 +204,7 @@ fn test_drg_porep_circuit() {
 
 #[test]
 fn test_drg_porep_circuit_inputs_and_constraints() {
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     // 1 GB
     let n = (1 << 30) / 32;
@@ -217,15 +214,15 @@ fn test_drg_porep_circuit_inputs_and_constraints() {
     let mut cs = TestConstraintSystem::<Bls12>::new();
     DrgPoRepCircuit::<PoseidonHasher>::synthesize(
         cs.namespace(|| "drgporep"),
-        vec![Some(Fr::random(rng)); 1],
-        vec![vec![(vec![Some(Fr::random(rng))], Some(0)); tree_depth]; 1],
-        Root::Val(Some(Fr::random(rng))),
-        vec![vec![Some(Fr::random(rng)); m]; 1],
-        vec![vec![vec![(vec![Some(Fr::random(rng))], Some(0)); tree_depth]; m]; 1],
-        vec![Some(Fr::random(rng)); 1],
-        vec![vec![(vec![Some(Fr::random(rng))], Some(0)); tree_depth]; 1],
-        Root::Val(Some(Fr::random(rng))),
-        Some(Fr::random(rng)),
+        vec![Some(Fr::random(&mut rng)); 1],
+        vec![vec![(vec![Some(Fr::random(&mut rng))], Some(0)); tree_depth]; 1],
+        Root::Val(Some(Fr::random(&mut rng))),
+        vec![vec![Some(Fr::random(&mut rng)); m]; 1],
+        vec![vec![vec![(vec![Some(Fr::random(&mut rng))], Some(0)); tree_depth]; m]; 1],
+        vec![Some(Fr::random(&mut rng)); 1],
+        vec![vec![(vec![Some(Fr::random(&mut rng))], Some(0)); tree_depth]; 1],
+        Root::Val(Some(Fr::random(&mut rng))),
+        Some(Fr::random(&mut rng)),
         false,
     )
     .expect("failed to synthesize circuit");

--- a/storage-proofs-porep/tests/drg_compound.rs
+++ b/storage-proofs-porep/tests/drg_compound.rs
@@ -1,8 +1,8 @@
 use bellperson::{
-    bls::Fr,
     util_cs::{metric_cs::MetricCS, test_cs::TestConstraintSystem},
     Circuit,
 };
+use blstrs::Scalar as Fr;
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, Hasher};
 use fr32::fr_into_bytes;
@@ -39,15 +39,15 @@ fn drg_porep_compound<Tree: 'static + MerkleTreeTrait>() {
     //     .start(log::LevelFilter::Trace)
     //     .ok();
 
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     let nodes = 8;
     let degree = BASE_DEGREE;
     let challenges = vec![1, 3];
 
-    let replica_id: Fr = Fr::random(rng);
+    let replica_id: Fr = Fr::random(&mut rng);
     let data: Vec<u8> = (0..nodes)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
 
     // MT for original data is always named tree-d, and it will be
@@ -161,7 +161,7 @@ fn drg_porep_compound<Tree: 'static + MerkleTreeTrait>() {
 
     {
         let gparams = DrgPoRepCompound::<Tree::Hasher, _>::groth_params(
-            Some(rng),
+            Some(&mut rng),
             &public_params.vanilla_params,
         )
         .expect("failed to get groth params");

--- a/storage-proofs-porep/tests/drg_vanilla.rs
+++ b/storage-proofs-porep/tests/drg_vanilla.rs
@@ -1,4 +1,4 @@
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use ff::Field;
 use filecoin_hashers::{blake2s::Blake2sHasher, sha256::Sha256Hasher, Domain, Hasher};
 use fr32::fr_into_bytes;
@@ -199,14 +199,14 @@ fn test_prove_verify_aux<Tree: MerkleTreeTrait>(
 
     // The loop is here in case we need to retry because of an edge case in the test design.
     loop {
-        let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+        let mut rng = XorShiftRng::from_seed(TEST_SEED);
         let degree = BASE_DEGREE;
         let expansion_degree = 0;
 
         let replica_id: <Tree::Hasher as Hasher>::Domain =
-            <Tree::Hasher as Hasher>::Domain::random(rng);
+            <Tree::Hasher as Hasher>::Domain::random(&mut rng);
         let data: Vec<u8> = (0..nodes)
-            .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+            .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
             .collect();
 
         // MT for original data is always named tree-d, and it will be

--- a/storage-proofs-porep/tests/stacked_circuit.rs
+++ b/storage-proofs-porep/tests/stacked_circuit.rs
@@ -1,8 +1,8 @@
 use bellperson::{
-    bls::{Bls12, Fr},
     util_cs::{metric_cs::MetricCS, test_cs::TestConstraintSystem},
     Circuit, ConstraintSystem,
 };
+use blstrs::{Bls12, Scalar as Fr};
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, sha256::Sha256Hasher, Hasher};
 use fr32::fr_into_bytes;
@@ -60,11 +60,11 @@ fn test_stacked_porep_circuit<Tree: MerkleTreeTrait + 'static>(
     let num_layers = 2;
     let layer_challenges = LayerChallenges::new(num_layers, 1);
 
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
-    let replica_id: Fr = Fr::random(rng);
+    let replica_id: Fr = Fr::random(&mut rng);
     let data: Vec<u8> = (0..nodes)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
 
     // MT for original data is always named tree-d, and it will be

--- a/storage-proofs-porep/tests/stacked_compound.rs
+++ b/storage-proofs-porep/tests/stacked_compound.rs
@@ -1,8 +1,8 @@
 use bellperson::{
-    bls::Fr,
     util_cs::{metric_cs::MetricCS, test_cs::TestConstraintSystem},
     Circuit,
 };
+use blstrs::Scalar as Fr;
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, sha256::Sha256Hasher, Hasher};
 use fr32::fr_into_bytes;
@@ -56,11 +56,11 @@ fn test_stacked_compound<Tree: 'static + MerkleTreeTrait>() {
     let layer_challenges = LayerChallenges::new(num_layers, 1);
     let partition_count = 1;
 
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
-    let replica_id: Fr = Fr::random(rng);
+    let replica_id: Fr = Fr::random(&mut rng);
     let data: Vec<u8> = (0..nodes)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
 
     let arbitrary_porep_id = [55; 32];
@@ -174,7 +174,7 @@ fn test_stacked_compound<Tree: 'static + MerkleTreeTrait>() {
     let blank_groth_params = <StackedCompound<Tree, Sha256Hasher> as CompoundProof<
         StackedDrg<'_, Tree, Sha256Hasher>,
         _,
-    >>::groth_params(Some(rng), &public_params.vanilla_params)
+    >>::groth_params(Some(&mut rng), &public_params.vanilla_params)
     .expect("failed to generate groth params");
 
     // Discard cached MTs that are no longer needed.

--- a/storage-proofs-porep/tests/stacked_vanilla.rs
+++ b/storage-proofs-porep/tests/stacked_vanilla.rs
@@ -1,6 +1,6 @@
 use std::fs::remove_file;
 
-use bellperson::bls::{Fr, FrRepr};
+use blstrs::Scalar as Fr;
 use ff::{Field, PrimeField};
 use filecoin_hashers::{
     blake2s::Blake2sHasher, poseidon::PoseidonHasher, sha256::Sha256Hasher, Domain, Hasher,
@@ -81,14 +81,14 @@ fn test_stacked_porep_extract_all_poseidon_top_8_8_2() {
 fn test_extract_all<Tree: 'static + MerkleTreeTrait>() {
     // pretty_env_logger::try_init();
 
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
     let replica_id: <Tree::Hasher as Hasher>::Domain =
-        <Tree::Hasher as Hasher>::Domain::random(rng);
+        <Tree::Hasher as Hasher>::Domain::random(&mut rng);
     let nodes = 64 * get_base_tree_count::<Tree>();
 
     let data: Vec<u8> = (0..nodes)
         .flat_map(|_| {
-            let v = <Tree::Hasher as Hasher>::Domain::random(rng);
+            let v = <Tree::Hasher as Hasher>::Domain::random(&mut rng);
             v.into_bytes()
         })
         .collect();
@@ -185,13 +185,13 @@ fn test_stacked_porep_resume_seal() {
 
     type Tree = DiskTree<PoseidonHasher, U8, U8, U2>;
 
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
-    let replica_id = <PoseidonHasher as Hasher>::Domain::random(rng);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
+    let replica_id = <PoseidonHasher as Hasher>::Domain::random(&mut rng);
     let nodes = 64 * get_base_tree_count::<Tree>();
 
     let data: Vec<u8> = (0..nodes)
         .flat_map(|_| {
-            let v = <PoseidonHasher as Hasher>::Domain::random(rng);
+            let v = <PoseidonHasher as Hasher>::Domain::random(&mut rng);
             v.into_bytes()
         })
         .collect();
@@ -348,14 +348,14 @@ fn test_prove_verify<Tree: 'static + MerkleTreeTrait>(n: usize, challenges: Laye
     //     .ok();
 
     let nodes = n * get_base_tree_count::<Tree>();
-    let rng = &mut XorShiftRng::from_seed(TEST_SEED);
+    let mut rng = XorShiftRng::from_seed(TEST_SEED);
 
     let degree = BASE_DEGREE;
     let expansion_degree = EXP_DEGREE;
     let replica_id: <Tree::Hasher as Hasher>::Domain =
-        <Tree::Hasher as Hasher>::Domain::random(rng);
+        <Tree::Hasher as Hasher>::Domain::random(&mut rng);
     let data: Vec<u8> = (0..nodes)
-        .flat_map(|_| fr_into_bytes(&Fr::random(rng)))
+        .flat_map(|_| fr_into_bytes(&Fr::random(&mut rng)))
         .collect();
 
     // MT for original data is always named tree-d, and it will be
@@ -477,12 +477,12 @@ fn test_stacked_porep_generate_labels() {
         replica_id,
         legacy_porep_id,
         ApiVersion::V1_0_0,
-        Fr::from_repr(FrRepr([
+        Fr::from_u64s_le(&[
             0xd3faa96b9a0fba04,
             0xea81a283d106485e,
             0xe3d51b9afa5ac2b3,
             0x0462f4f4f1a68d37,
-        ]))
+        ])
         .unwrap(),
     );
 
@@ -492,12 +492,12 @@ fn test_stacked_porep_generate_labels() {
         replica_id,
         legacy_porep_id,
         ApiVersion::V1_0_0,
-        Fr::from_repr(FrRepr([
+        Fr::from_u64s_le(&[
             0x7e191e52c4a8da86,
             0x5ae8a1c9e6fac148,
             0xce239f3b88a894b8,
             0x234c00d1dc1d53be,
-        ]))
+        ])
         .unwrap(),
     );
 
@@ -507,12 +507,12 @@ fn test_stacked_porep_generate_labels() {
         replica_id,
         porep_id,
         ApiVersion::V1_1_0,
-        Fr::from_repr(FrRepr([
+        Fr::from_u64s_le(&[
             0xabb3f38bb70defcf,
             0x777a2e4d7769119f,
             0x3448959d495490bc,
             0x06021188c7a71cb5,
-        ]))
+        ])
         .unwrap(),
     );
 
@@ -522,12 +522,12 @@ fn test_stacked_porep_generate_labels() {
         replica_id,
         porep_id,
         ApiVersion::V1_1_0,
-        Fr::from_repr(FrRepr([
+        Fr::from_u64s_le(&[
             0x22ab81cf68c4676d,
             0x7a77a82fc7c9c189,
             0xc6c03d32c1e42d23,
             0x0f777c18cc2c55bd,
-        ]))
+        ])
         .unwrap(),
     );
 }
@@ -577,5 +577,5 @@ fn test_generate_labels_aux(
     let final_labels = labels.labels_for_last_layer().unwrap();
     let last_label = final_labels.read_at(nodes - 1).unwrap();
 
-    assert_eq!(expected_last_label.into_repr(), last_label.0);
+    assert_eq!(expected_last_label.to_repr(), last_label.0);
 }

--- a/storage-proofs-post/Cargo.toml
+++ b/storage-proofs-post/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 storage-proofs-core = { path = "../storage-proofs-core", version = "^9.0.0", default-features = false}
 filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-features = false, features = ["poseidon", "sha256"]}
-rand = "0.7"
+rand = "0.8"
 merkletree = "0.21.0"
 byteorder = "1"
 crossbeam = "0.8"
@@ -20,24 +20,23 @@ rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}
 blake2b_simd = "0.5"
 blake2s_simd = "0.5"
-ff = { version = "0.3.1", package = "fff" }
-bellperson = { version = "0.16", default-features = false }
+ff = "0.11.0"
+bellperson = { git = "https://github.com/filecoin-project/bellperson", branch = "master" }
 log = "0.4.7"
 hex = "0.4.0"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { version = "^4.0", default-features = false }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master" }
 num_cpus = "1.10.1"
 fr32 = { path = "../fr32", version = "^2.0.0", default-features = false }
+blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
 
 [dev-dependencies]
 tempfile = "3"
 pretty_assertions = "0.6.1"
-rand_xorshift = "0.2.0"
 filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
+rand_xorshift = "0.3.0"
 
 [features]
-default = ["blst", "gpu"]
+default = ["gpu"]
 gpu = ["storage-proofs-core/gpu", "filecoin-hashers/gpu", "fr32/gpu", "neptune/opencl"]
-pairing = ["storage-proofs-core/pairing", "bellperson/pairing", "neptune/pairing", "filecoin-hashers/pairing", "fr32/pairing"]
-blst = ["storage-proofs-core/blst", "bellperson/blst", "neptune/blst", "filecoin-hashers/blst", "fr32/blst"]

--- a/storage-proofs-post/src/election/circuit.rs
+++ b/storage-proofs-post/src/election/circuit.rs
@@ -1,10 +1,7 @@
 use std::marker::PhantomData;
 
-use bellperson::{
-    bls::{Bls12, Fr},
-    gadgets::num::AllocatedNum,
-    Circuit, ConstraintSystem, SynthesisError,
-};
+use bellperson::{gadgets::num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
+use blstrs::{Bls12, Scalar as Fr};
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonFunction, HashFunction, Hasher, PoseidonMDArity};
 use generic_array::typenum::Unsigned;

--- a/storage-proofs-post/src/election/compound.rs
+++ b/storage-proofs-post/src/election/compound.rs
@@ -1,9 +1,7 @@
 use std::marker::PhantomData;
 
-use bellperson::{
-    bls::{Bls12, Fr},
-    Circuit,
-};
+use bellperson::Circuit;
+use blstrs::{Bls12, Scalar as Fr};
 use generic_array::typenum::Unsigned;
 use storage_proofs_core::{
     compound_proof::{CircuitComponent, CompoundProof},

--- a/storage-proofs-post/src/election/vanilla.rs
+++ b/storage-proofs-post/src/election/vanilla.rs
@@ -3,7 +3,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::marker::PhantomData;
 
 use anyhow::{bail, ensure, Context};
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use byteorder::{ByteOrder, LittleEndian};
 use filecoin_hashers::{
     poseidon::{PoseidonDomain, PoseidonFunction},

--- a/storage-proofs-post/src/fallback/circuit.rs
+++ b/storage-proofs-post/src/fallback/circuit.rs
@@ -1,8 +1,5 @@
-use bellperson::{
-    bls::{Bls12, Fr},
-    gadgets::num::AllocatedNum,
-    Circuit, ConstraintSystem, SynthesisError,
-};
+use bellperson::{gadgets::num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
+use blstrs::{Bls12, Scalar as Fr};
 use ff::Field;
 use filecoin_hashers::{HashFunction, Hasher};
 use rayon::prelude::{ParallelIterator, ParallelSlice};

--- a/storage-proofs-post/src/fallback/compound.rs
+++ b/storage-proofs-post/src/fallback/compound.rs
@@ -1,10 +1,8 @@
 use std::marker::PhantomData;
 
 use anyhow::{anyhow, ensure};
-use bellperson::{
-    bls::{Bls12, Fr},
-    Circuit,
-};
+use bellperson::Circuit;
+use blstrs::{Bls12, Scalar as Fr};
 use filecoin_hashers::Hasher;
 use sha2::{Digest, Sha256};
 use storage_proofs_core::{

--- a/storage-proofs-post/src/fallback/vanilla.rs
+++ b/storage-proofs-post/src/fallback/vanilla.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeSet;
 use std::marker::PhantomData;
 
 use anyhow::ensure;
-use bellperson::bls::Fr;
+use blstrs::Scalar as Fr;
 use byteorder::{ByteOrder, LittleEndian};
 use filecoin_hashers::{Domain, HashFunction, Hasher};
 use generic_array::typenum::Unsigned;

--- a/storage-proofs-post/src/rational/circuit.rs
+++ b/storage-proofs-post/src/rational/circuit.rs
@@ -1,10 +1,7 @@
 use std::marker::PhantomData;
 
-use bellperson::{
-    bls::{Bls12, Fr},
-    gadgets::num::AllocatedNum,
-    Circuit, ConstraintSystem, SynthesisError,
-};
+use bellperson::{gadgets::num::AllocatedNum, Circuit, ConstraintSystem, SynthesisError};
+use blstrs::{Bls12, Scalar as Fr};
 use filecoin_hashers::{HashFunction, Hasher};
 use storage_proofs_core::{
     compound_proof::CircuitComponent, error::Result, gadgets::constraint, gadgets::por::PoRCircuit,

--- a/storage-proofs-post/src/rational/compound.rs
+++ b/storage-proofs-post/src/rational/compound.rs
@@ -1,8 +1,8 @@
 use std::marker::PhantomData;
 
 use anyhow::ensure;
-use bellperson::bls::{Bls12, Fr};
 use bellperson::{Circuit, ConstraintSystem, SynthesisError};
+use blstrs::{Bls12, Scalar as Fr};
 use generic_array::typenum::U2;
 use storage_proofs_core::{
     compound_proof::{CircuitComponent, CompoundProof},

--- a/storage-proofs-post/tests/election_circuit.rs
+++ b/storage-proofs-post/tests/election_circuit.rs
@@ -1,11 +1,8 @@
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
-use bellperson::{
-    bls::{Bls12, Fr},
-    util_cs::test_cs::TestConstraintSystem,
-    Circuit,
-};
+use bellperson::{util_cs::test_cs::TestConstraintSystem, Circuit};
+use blstrs::{Bls12, Scalar as Fr};
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, Domain, HashFunction, Hasher};
 use generic_array::typenum::{U0, U8};

--- a/storage-proofs-post/tests/fallback_circuit.rs
+++ b/storage-proofs-post/tests/fallback_circuit.rs
@@ -1,8 +1,8 @@
 use bellperson::{
-    bls::{Bls12, Fr},
     util_cs::{bench_cs::BenchCS, test_cs::TestConstraintSystem},
     Circuit,
 };
+use blstrs::{Bls12, Scalar as Fr};
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, Domain, HashFunction, Hasher};
 use generic_array::typenum::{U0, U2, U4, U8};

--- a/storage-proofs-post/tests/rational_circuit.rs
+++ b/storage-proofs-post/tests/rational_circuit.rs
@@ -1,11 +1,8 @@
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
 
-use bellperson::{
-    bls::{Bls12, Fr},
-    util_cs::test_cs::TestConstraintSystem,
-    Circuit,
-};
+use bellperson::{util_cs::test_cs::TestConstraintSystem, Circuit};
+use blstrs::{Bls12, Scalar as Fr};
 use ff::Field;
 use filecoin_hashers::{poseidon::PoseidonHasher, Domain, HashFunction, Hasher};
 use rand::{Rng, SeedableRng};


### PR DESCRIPTION
- [x] `filecoin-hashers`
- [x] `fr32`
- [x] `storage-proofs-core`
- [x] `storage-proofs-porep`
- [x] `storage-proofs-post`
- [x] `filecoin-proofs`
- [x] everything else

Note that this PR removes the `pairing` and `blst` features and drops support for `paired`'s BLS12-381 implementation.