### PR TITLE
Improve multicore SDR

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -83,7 +83,8 @@ fn fill_buffer(
     };
 
     if cur_node > MIN_BASE_PARENT_NODE {
-        // Mark base parent predrecessor as missing
+        // Mark base parent predecessor as missing
+        base_parent_missing.clear();
         base_parent_missing.set(predecessor_index);
 
         // Skip the last base parent - it always points to the preceding node,

--- a/storage-proofs-porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/graph.rs
@@ -260,6 +260,11 @@ where
         // round 7 (37)
         hasher.finish_with(parents[0])
     }
+
+    /// Returns the current `ApiVersion`.
+    pub fn api_version(&self) -> ApiVersion {
+        self.api_version
+    }
 }
 
 impl<H, G> ParameterSetMetadata for StackedGraph<H, G>

--- a/storage-proofs-porep/src/stacked/vanilla/utils.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/utils.rs
@@ -84,6 +84,11 @@ impl BitMask {
     pub fn get(self, i: usize) -> bool {
         self.0 & (1 << i) != 0
     }
+
+    #[inline]
+    pub fn clear(&mut self) {
+        self.0 = 0;
+    }
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
Based on #1477 this updates the parent selection logic in multicore sdr. 

It **does not** implement the bitmask update, as that is not thread safe, and only the thread that fills the buffer is allowed to set this value. This I missed in my earlier review.