### PR TITLE
fix: upgrade to latest versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ executors:
     resource_class: 2xlarge+
   gpu:
     machine:
-      image: ubuntu-1604-cuda-10.1:201909-23
+      image: ubuntu-2004-cuda-11.2:202103-01
     working_directory: ~/gpuci
     resource_class: gpu.nvidia.medium
   arm:
@@ -148,6 +148,11 @@ jobs:
   test_gpu_tree_building:
     executor: gpu
     environment: *setup-env
+    parameters:
+      cargo-args:
+        description: Addtional arguments for the cargo command
+        type: string
+        default: ""
     steps:
       - checkout
       - attach_workspace:
@@ -157,12 +162,12 @@ jobs:
       - run:
           name: Set the PATH env variable
           command: |
-            echo 'export PATH="~/.cargo/bin:$PATH"' | tee --append $BASH_ENV
+            echo 'export PATH="~/.cargo/bin:/usr/local/cuda-11.2/bin:$PATH"' | tee --append $BASH_ENV
             source $BASH_ENV
       - run:
           name: Install required libraries for GPU support
           command: |
-            sudo apt-get update -y
+            sudo apt update
             sudo apt install -y ocl-icd-opencl-dev libhwloc-dev
       - run:
           name: Test with GPU column and tree builders.
@@ -170,12 +175,13 @@ jobs:
             ulimit -n 20000
             ulimit -u 20000
             ulimit -n 20000
-            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --verbose --release lifecycle -- --ignored --nocapture
+            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --verbose --release lifecycle << parameters.cargo-args >> -- --ignored --nocapture
           no_output_timeout: 30m
           environment:
             RUST_TEST_THREADS: 1
             FIL_PROOFS_USE_GPU_COLUMN_BUILDER: true
             FIL_PROOFS_USE_GPU_TREE_BUILDER: true
+            BELLMAN_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
 
   test_no_gpu:
     executor: default
@@ -392,8 +398,15 @@ workflows:
             - ensure_groth_parameters_and_keys_linux
 
       - test_gpu_tree_building:
+          name: test_gpu_tree_building_opencl
           requires:
-            #- cargo_fetch_gpu
+            - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
+
+      - test_gpu_tree_building:
+          name: test_gpu_tree_building_cuda
+          cargo-args: "--features cuda"
+          requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The `hwloc` dependency is optional and may be disabled.  Disabling it will not a
 To disable `multicore sdr` so that `hwloc` is not required, you can build proofs like this:
 
 ```
-> cargo build --release --all --no-default-features --features gpu
+> cargo build --release --all --no-default-features --features opencl
 ```
 
 Note that the `multicore-sdr` feature is omitted from the specified feature list, which removes it from being used by default.

--- a/fil-proofs-param/Cargo.toml
+++ b/fil-proofs-param/Cargo.toml
@@ -62,9 +62,10 @@ failure = "0.1.7"
 tempfile = "3"
 
 [features]
-default = ["gpu"]
+default = ["opencl"]
 cpu-profile = ["gperftools"]
 heap-profile = ["gperftools/heap"]
 simd = ["storage-proofs-core/simd"]
 asm = ["storage-proofs-core/asm"]
-gpu = ["storage-proofs-core/gpu", "storage-proofs-porep/gpu", "storage-proofs-post/gpu", "bellperson/gpu"]
+cuda = ["storage-proofs-core/cuda", "storage-proofs-porep/cuda", "storage-proofs-post/cuda", "bellperson/cuda"]
+opencl = ["storage-proofs-core/opencl", "storage-proofs-porep/opencl", "storage-proofs-post/opencl", "bellperson/opencl"]

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -54,14 +54,22 @@ humansize = "1.1.0"
 blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
 
 [features]
-default = ["gpu", "measurements"]
-gpu = [
-    "storage-proofs-core/gpu",
-    "storage-proofs-porep/gpu",
-    "storage-proofs-post/gpu",
-    "filecoin-proofs/gpu",
-    "bellperson/gpu",
-    "filecoin-hashers/gpu",
+default = ["opencl", "measurements"]
+cuda = [
+    "storage-proofs-core/cuda",
+    "storage-proofs-porep/cuda",
+    "storage-proofs-post/cuda",
+    "filecoin-proofs/cuda",
+    "bellperson/cuda",
+    "filecoin-hashers/cuda",
+]
+opencl = [
+    "storage-proofs-core/opencl",
+    "storage-proofs-porep/opencl",
+    "storage-proofs-post/opencl",
+    "filecoin-proofs/opencl",
+    "bellperson/opencl",
+    "filecoin-hashers/opencl",
 ]
 measurements = ["storage-proofs-core/measurements"]
 profile = ["storage-proofs-core/profile", "measurements"]

--- a/filecoin-hashers/Cargo.toml
+++ b/filecoin-hashers/Cargo.toml
@@ -18,16 +18,17 @@ anyhow = "1.0.34"
 serde = "1.0.117"
 rand = "0.8.0"
 
-neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master", optional = true }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master", optional = true, features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 lazy_static = { version = "1.4.0", optional = true }
 blake2s_simd = { version = "0.5.11", optional = true }
 sha2 = { version = "0.9.2", optional = true }
 hex = "0.4.2"
 
 [features]
-default = ["gpu", "blake2s", "poseidon", "sha256"]
+default = ["opencl", "blake2s", "poseidon", "sha256"]
 
-gpu = ["bellperson/gpu", "neptune/opencl"]
+cuda = ["bellperson/cuda", "neptune/cuda"]
+opencl = ["bellperson/opencl", "neptune/opencl"]
 
 # available hashers
 blake2s = ["blake2s_simd"]

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -51,18 +51,26 @@ failure = "0.1.7"
 tempfile = "3"
 
 [features]
-default = ["gpu"]
+default = ["opencl"]
 cpu-profile = ["gperftools"]
 heap-profile = ["gperftools/heap"]
 simd = ["storage-proofs-core/simd"]
 asm = ["storage-proofs-core/asm"]
-gpu = [
-    "storage-proofs-core/gpu",
-    "storage-proofs-porep/gpu",
-    "storage-proofs-post/gpu",
-    "bellperson/gpu",
-    "filecoin-hashers/gpu",
-    "fr32/gpu",
+cuda = [
+    "storage-proofs-core/cuda",
+    "storage-proofs-porep/cuda",
+    "storage-proofs-post/cuda",
+    "bellperson/cuda",
+    "filecoin-hashers/cuda",
+    "fr32/cuda",
+]
+opencl = [
+    "storage-proofs-core/opencl",
+    "storage-proofs-porep/opencl",
+    "storage-proofs-post/opencl",
+    "bellperson/opencl",
+    "filecoin-hashers/opencl",
+    "fr32/opencl",
 ]
 
 [[bench]]

--- a/fr32/Cargo.toml
+++ b/fr32/Cargo.toml
@@ -26,7 +26,8 @@ rand_xorshift = "0.3"
 
 [features]
 default = []
-gpu = ["bellperson/gpu"]
+cuda = ["bellperson/cuda"]
+opencl = ["bellperson/opencl"]
 
 [[bench]]
 name = "fr"

--- a/storage-proofs-core/Cargo.toml
+++ b/storage-proofs-core/Cargo.toml
@@ -39,7 +39,7 @@ hex = "0.4.0"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
-neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master" }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"
@@ -58,14 +58,15 @@ sha2raw = { path = "../sha2raw", version = "^4.0.0"}
 filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-features = false, features = ["blake2s", "sha256", "poseidon"] }
 
 [features]
-default = ["gpu"]
+default = ["opencl"]
 simd = []
 asm = ["sha2/sha2-asm"]
 big-sector-sizes-bench = []
 measurements = ["cpu-time", "gperftools"]
 profile = ["measurements"]
 
-gpu = ["bellperson/gpu", "neptune/opencl", "filecoin-hashers/gpu", "fr32/gpu"]
+cuda = ["bellperson/cuda", "neptune/cuda", "filecoin-hashers/cuda", "fr32/cuda"]
+opencl = ["bellperson/opencl", "neptune/opencl", "filecoin-hashers/opencl", "fr32/opencl"]
 
 [[bench]]
 name = "sha256"

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -28,7 +28,7 @@ log = "0.4.7"
 pretty_assertions = "0.6.1"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master" }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 num_cpus = "1.10.1"
 hex = "0.4.2"
 bincode = "1.1.2"
@@ -58,8 +58,9 @@ pretty_env_logger = "0.4.0"
 filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
 
 [features]
-default = ["gpu", "multicore-sdr"]
-gpu = ["storage-proofs-core/gpu", "filecoin-hashers/gpu", "neptune/opencl", "bellperson/gpu", "fr32/gpu"]
+default = ["opencl", "multicore-sdr"]
+cuda = ["storage-proofs-core/cuda", "filecoin-hashers/cuda", "neptune/cuda", "bellperson/cuda", "fr32/cuda"]
+opencl = ["storage-proofs-core/opencl", "filecoin-hashers/opencl", "neptune/opencl", "bellperson/opencl", "fr32/opencl"]
 isolated-testing = []
 multicore-sdr = ["hwloc"]
 

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -416,7 +416,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         Ok(tree)
     }
 
-    #[cfg(any(feature = "gpu"))]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     fn generate_tree_c<ColumnArity, TreeArity>(
         layers: usize,
         nodes_count: usize,
@@ -447,7 +447,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         }
     }
 
-    #[cfg(not(any(feature = "gpu")))]
+    #[cfg(not(any(feature = "cuda", feature = "opencl")))]
     fn generate_tree_c<ColumnArity, TreeArity>(
         layers: usize,
         nodes_count: usize,
@@ -469,7 +469,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     }
 
     #[allow(clippy::needless_range_loop)]
-    #[cfg(any(feature = "gpu"))]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     fn generate_tree_c_gpu<ColumnArity, TreeArity>(
         layers: usize,
         nodes_count: usize,
@@ -794,7 +794,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         })
     }
 
-    #[cfg(any(feature = "gpu"))]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     fn generate_tree_r_last<TreeArity>(
         data: &mut Data<'_>,
         nodes_count: usize,
@@ -827,7 +827,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         }
     }
 
-    #[cfg(not(any(feature = "gpu")))]
+    #[cfg(not(any(feature = "cuda", feature = "opencl")))]
     fn generate_tree_r_last<TreeArity>(
         data: &mut Data<'_>,
         nodes_count: usize,
@@ -849,7 +849,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         )
     }
 
-    #[cfg(any(feature = "gpu"))]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     fn generate_tree_r_last_gpu<TreeArity>(
         data: &mut Data<'_>,
         nodes_count: usize,
@@ -1403,7 +1403,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     // Assumes data is all zeros.
     // Replica path is used to create configs, but is not read.
     // Instead new zeros are provided (hence the need for replica to be all zeros).
-    #[cfg(any(feature = "gpu"))]
+    #[cfg(any(feature = "cuda", feature = "opencl"))]
     fn generate_fake_tree_r_last<TreeArity>(
         nodes_count: usize,
         tree_count: usize,
@@ -1535,7 +1535,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     // Assumes data is all zeros.
     // Replica path is used to create configs, but is not read.
     // Instead new zeros are provided (hence the need for replica to be all zeros).
-    #[cfg(not(any(feature = "gpu")))]
+    #[cfg(not(any(feature = "cuda", feature = "opencl")))]
     fn generate_fake_tree_r_last<TreeArity>(
         nodes_count: usize,
         tree_count: usize,

--- a/storage-proofs-post/Cargo.toml
+++ b/storage-proofs-post/Cargo.toml
@@ -26,7 +26,7 @@ log = "0.4.7"
 hex = "0.4.0"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master" }
+neptune = { git = "https://github.com/filecoin-project/neptune", branch = "master", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 num_cpus = "1.10.1"
 fr32 = { path = "../fr32", version = "^2.0.0", default-features = false }
 blstrs = { git = "https://github.com/filecoin-project/blstrs", branch = "master" }
@@ -38,5 +38,6 @@ filecoin-hashers = { path = "../filecoin-hashers", version = "^4.0.0", default-f
 rand_xorshift = "0.3.0"
 
 [features]
-default = ["gpu"]
-gpu = ["storage-proofs-core/gpu", "filecoin-hashers/gpu", "fr32/gpu", "neptune/opencl"]
+default = ["opencl"]
+cuda = ["storage-proofs-core/cuda", "filecoin-hashers/cuda", "fr32/cuda", "neptune/cuda"]
+opencl = ["storage-proofs-core/opencl", "filecoin-hashers/opencl", "fr32/opencl", "neptune/opencl"]


### PR DESCRIPTION
The latest versions of the gpu dependencies contain support for CUDA. Therefore
the `gpu` feature is split into `cuda` and `opencl`. By default only `opencl` is
enabled.

BREAKING CHANGE: The `gpu` feature is replaced by the `opencl` feature.