### PR TITLE
expose 'multicore-sdr' feature

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -72,6 +72,7 @@ opencl = [
     "filecoin-hashers/opencl",
     "fr32/opencl",
 ]
+multicore-sdr = ["storage-proofs-porep/multicore-sdr"]
 
 [[bench]]
 name = "preprocessing"


### PR DESCRIPTION
You can't use the multicore-sdr feature through filecoin-proofs in current implemention.