### PR TITLE
fix: remove FIL_PROOFS_CUDA_NVCC_ARGS environment variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,7 +184,8 @@ jobs:
           environment:
             FIL_PROOFS_USE_GPU_COLUMN_BUILDER: true
             FIL_PROOFS_USE_GPU_TREE_BUILDER: true
-            FIL_PROOFS_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
+            BELLMAN_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
+            NEPTUNE_CUDA_NVCC_ARGS: --fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75
 
   test_no_gpu:
     executor: default

--- a/README.md
+++ b/README.md
@@ -319,11 +319,12 @@ FIL_PROOFS_GPU_FRAMEWORK=cuda
 
 You can set it to `opencl` to use OpenCL instead.  The default value is `cuda`, when you set nothing or any other (invalid) value.
 
-CUDA kernels are compiled and build time.  By default, they are built for recent architectures, Turing (`sm_75` and Ampere (`sm_80`, `sm_86`).  This increases the overall build time by several minutes.  You can reduce it by compiling it only for the specific aritecture you need.  For example if you only need the CUDA kernels to work on the Turing architecture, you can set
+CUDA kernels are compiled and build time.  By default, they are built for recent architectures, Turing (`sm_75` and Ampere (`sm_80`, `sm_86`).  This increases the overall build time by several minutes.  You can reduce it by compiling it only for the specific aritecture you need.  For example if you only need the CUDA kernels to work on the Turing architecture, you can set on all dependencies that use CUDA kernels:
 
-`FIL_PROOFS_CUDA_NVCC_ARGS="--fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75"`
-
-Note that this environment variable is forwarded to underlying dependencies, which might not be automatically be rebuilt.  If you change this variable, best is to start from a clean build.
+```
+BELLMAN_CUDA_NVCC_ARGS="--fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75"
+NEPTUNE_CUDA_NVCC_ARGS="--fatbin --gpu-architecture=sm_75 --generate-code=arch=compute_75,code=sm_75"
+```
 
 ### Memory
 

--- a/storage-proofs-core/src/settings.rs
+++ b/storage-proofs-core/src/settings.rs
@@ -88,20 +88,9 @@ fn set_gpu_framework() {
     }
 }
 
-/// Set CUDA nvcc compile flags (if set) for the dependencies.
-///
-/// If one of those environment variables is already set, it won't be overridden.
-fn set_cuda_nvcc_args() {
-    if let Ok(nvcc_args) = env::var(format!("{}_CUDA_NVCC_ARGS", PREFIX)) {
-        set_env_var_if_unset("BELLMAN_CUDA_NVCC_ARGS", &nvcc_args);
-        set_env_var_if_unset("NEPTUNE_CUDA_NVCC_ARGS", &nvcc_args);
-    }
-}
-
 impl Settings {
     fn new() -> Result<Settings, ConfigError> {
         set_gpu_framework();
-        set_cuda_nvcc_args();
 
         let mut s = Config::new();
 


### PR DESCRIPTION
The `FIL_PROOFS_CUDA_NVCC_ARGS` variable doesn't work as expected. The
problem is that its value would need to be forwarded to the dependencies
at compile-time. That currently isn't possible.

The solution is to set the `BELLMAN_CUDA_NVCC_ARGS` and
`NEPTUNE_CUDA_NVCC_ARGS` environment variable individually.

Set properly, the CI runs are 4mins faster :)