### PR TITLE
fix: benchy: print help if no command is given

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 
 use anyhow::Result;
 use byte_unit::Byte;
-use clap::{value_t, App, Arg, SubCommand};
+use clap::{value_t, App, AppSettings, Arg, SubCommand};
 
 use storage_proofs_core::api_version::ApiVersion;
 
@@ -171,6 +171,7 @@ fn main() -> Result<()> {
         );
 
     let matches = App::new("benchy")
+        .setting(AppSettings::ArgRequiredElseHelp)
         .version("0.1")
         .subcommand(window_post_cmd)
         .subcommand(winning_post_cmd)
@@ -240,7 +241,7 @@ fn main() -> Result<()> {
             serde_json::to_writer(stdout(), &outputs)
                 .expect("failed to write ProdbenchOutput to stdout")
         }
-        _ => panic!("carnation"),
+        _ => unreachable!(),
     }
 
     Ok(())


### PR DESCRIPTION
Prior to this change benchy will panic if there were no options given.
Now it prints the help.

I wanted to do this for years, finally I did.