### PR TITLE
fix: make arguments mutually exclusive

### DIFF
--- a/fil-proofs-param/src/bin/paramcache.rs
+++ b/fil-proofs-param/src/bin/paramcache.rs
@@ -153,9 +153,13 @@ fn cache_empty_sector_update_params<Tree: 'static + MerkleTreeTrait<Hasher = Tre
     about = "generates and caches SDR PoRep, Winning-PoSt, Window-PoSt, and EmptySectorUpdate groth params"
 )]
 struct Opt {
-    #[structopt(long, help = "Only cache PoSt groth params.")]
+    #[structopt(long, group = "onlyonecache", help = "Only cache PoSt groth params.")]
     only_post: bool,
-    #[structopt(long, help = "Only cache EmptySectorUpdate groth params.")]
+    #[structopt(
+        long,
+        group = "onlyonecache",
+        help = "Only cache EmptySectorUpdate groth params."
+    )]
     only_sector_update: bool,
     #[structopt(
         short = "z",


### PR DESCRIPTION
The command line argumens `--only-post` and `--only-sector-update` are mutually
exclusive. With this commit you'll get an error message if both are used at the
same time:

    error: The argument '--only-sector-update' cannot be used with one or more of the other specified arguments

    USAGE:
        paramcache --api-version <SEMANTIC VERSION> <--only-post|--only-sector-update>

    For more information try --help