### PR TITLE
fix: correctly set cache path for empty sector update proofs

### DIFF
--- a/filecoin-proofs/src/api/update.rs
+++ b/filecoin-proofs/src/api/update.rs
@@ -69,7 +69,8 @@ fn get_t_aux<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
     let t_aux_bytes = fs::read(&t_aux_path)
         .with_context(|| format!("could not read file t_aux={:?}", t_aux_path))?;
 
-    let res: TemporaryAux<Tree, DefaultPieceHasher> = deserialize(&t_aux_bytes)?;
+    let mut res: TemporaryAux<Tree, DefaultPieceHasher> = deserialize(&t_aux_bytes)?;
+    res.set_cache_path(cache_path);
 
     Ok(res)
 }


### PR DESCRIPTION
**This PR is mostly intended to indicate where I think a bug exists**

I'm not entirely sure whether this is the right fix, but something around the cache path here seems to be wrong, causing most users on SnapNet to be unable to upgrade their sectors (see https://github.com/filecoin-project/lotus/issues/7968).

We may only want to be setting the path in some of the use cases for this method.