### PR TITLE
fix data race when create label

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -487,6 +487,8 @@ pub fn create_labels_for_encoding<Tree: 'static + MerkleTreeTrait, T: AsRef<[u8]
             parents_cache.finish_reset()?;
         }
 
+        parents_cache.store_consumer(0);
+
         create_layer_labels(
             &parents_cache,
             replica_id.as_ref(),


### PR DESCRIPTION
After each layer calls create_layer_labels()，the parents_cache's cursor has drifted. At the beginning of creating the next layer label, ring_buf may read wrong data. And the error really happened widely. Although the labels are wrong, the sector can still pass C2 because [PoRep Challenges](https://spec.filecoin.io/#section-algorithms.sdr.porep-challenges) only challenge a small part of nodes. 

This error also causes a sector can't be unsealed correctly.


(This is my first pull request for open source project, if I did something wrong, please let me know, thank you~)