### PR TITLE
perf(filecoin-proofs): increase parallelism in window-post

### DIFF
--- a/filecoin-proofs/src/api/window_post.rs
+++ b/filecoin-proofs/src/api/window_post.rs
@@ -3,6 +3,7 @@ use std::collections::BTreeMap;
 use anyhow::{ensure, Context, Result};
 use filecoin_hashers::Hasher;
 use log::info;
+use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
 use storage_proofs_core::{
     compound_proof::{self, CompoundProof},
     merkle::MerkleTreeTrait,
@@ -126,7 +127,7 @@ pub fn generate_window_post<Tree: 'static + MerkleTreeTrait>(
     let groth_params = get_post_params::<Tree>(post_config)?;
 
     let trees: Vec<_> = replicas
-        .iter()
+        .par_iter()
         .map(|(sector_id, replica)| {
             replica
                 .merkle_tree(post_config.sector_size)


### PR DESCRIPTION
This improves the parallelism when generating merkle tree.