### PR TITLE
chore: upgrade to latest bellperson release

### DIFF
--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -22,7 +22,7 @@ regex = "1.3.7"
 commandspec = "0.12.2"
 chrono = { version = "0.4.7", features = ["serde"] }
 memmap = "0.7.0"
-bellperson = "0.18.0"
+bellperson = "0.20.0"
 rand = "0.8"
 tempfile = "3.0.8"
 cpu-time = "1.0.0"

--- a/filecoin-hashers/Cargo.toml
+++ b/filecoin-hashers/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-bellperson = "0.18.0"
+bellperson = "0.20.0"
 blstrs = "0.4.0"
 generic-array = "0.14.4"
 merkletree = "0.21.0"
@@ -18,7 +18,7 @@ anyhow = "1.0.34"
 serde = "1.0.117"
 rand = "0.8.0"
 
-neptune = { version = "5.1.0", optional = true, features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
+neptune = { version = "6.1.0", optional = true, features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 lazy_static = { version = "1.4.0", optional = true }
 blake2s_simd = { version = "1.0.0", optional = true }
 sha2 = { version = "0.10.2", optional = true }

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -20,7 +20,7 @@ memmap = "0.7"
 serde = { version = "1.0", features = ["rc", "derive"] }
 serde_json = "1.0"
 blake2b_simd = "1.0.0"
-bellperson = "0.18.0"
+bellperson = "0.20.0"
 log = "0.4.7"
 rayon = "1.1.0"
 hex = "0.4.0"

--- a/storage-proofs-core/Cargo.toml
+++ b/storage-proofs-core/Cargo.toml
@@ -27,7 +27,7 @@ rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}
 blake2b_simd = "1.0.0"
 ff = "0.11.0"
-bellperson = "0.18.0"
+bellperson = "0.20.0"
 serde_json = "1.0"
 log = "0.4.7"
 rand_chacha = "0.3"

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -21,12 +21,12 @@ rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}
 serde_json = "1.0"
 ff = "0.11.0"
-bellperson = "0.18.0"
+bellperson = "0.20.0"
 log = "0.4.7"
 pretty_assertions = "1.2.0"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { version = "5.1.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
+neptune = { version = "6.1.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 num_cpus = "1.10.1"
 hex = "0.4.2"
 bincode = "1.1.2"

--- a/storage-proofs-post/Cargo.toml
+++ b/storage-proofs-post/Cargo.toml
@@ -17,7 +17,7 @@ rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}
 blake2b_simd = "1.0.0"
 ff = "0.11.0"
-bellperson = "0.18.0"
+bellperson = "0.20.0"
 log = "0.4.7"
 hex = "0.4.0"
 generic-array = "0.14.4"

--- a/storage-proofs-update/Cargo.toml
+++ b/storage-proofs-update/Cargo.toml
@@ -16,12 +16,12 @@ merkletree = "0.21.0"
 rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}
 ff = "0.11.0"
-bellperson = "0.18.0"
+bellperson = "0.20.0"
 blstrs = "0.4.0"
 log = "0.4.7"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { version = "5.1.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
+neptune = { version = "6.1.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 lazy_static = "1.2"
 fr32 = { path = "../fr32", version = "^4.0.0", default-features = false }
 memmap = "0.7"


### PR DESCRIPTION
Neptune also needs to be upgraded so that we use the same bellperson
version in the whole dependency tree.