### PR TITLE
chore: CI times out due to ipget issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,6 +315,9 @@ commands:
   ensure_filecoin_parameters:
     steps:
       - run:
+          name: Create parameters directory
+          command: mkdir -p ${FIL_PROOFS_PARAMETER_CACHE}
+      - run:
           name: Build paramcache if it doesn't already exist
           command: |
             set -x; test -f /tmp/paramcache.awesome \
@@ -326,8 +329,11 @@ commands:
       - run:
           name: Obtain filecoin ipp parameter file
           command: |
-            cargo run --release --bin paramfetch -- -a -j srs-inner-product.json
-          no_output_timeout: 60m
+            # paramfetch is using `ipget` which currently always times out on
+            # CI, hence get this file via HTTP instead.
+            #cargo run --release --bin paramfetch -- -a -j srs-inner-product.json
+            # `--insecure` is needed due to an outdated base systems.
+            curl --insecure https://proofs.filecoin.io/v28-fil-inner-product-v1.srs --output ${FIL_PROOFS_PARAMETER_CACHE}v28-fil-inner-product-v1.srs
       - run:
           name: Make the parameters world readable
           command: chmod -R 755 ${FIL_PROOFS_PARAMETER_CACHE}


### PR DESCRIPTION
Instead of using `paramfetch`, which is using `ipget`, get the file
via HTTP. This should solve problems with the CI job timing out.