### PR TITLE
chore: CI: use parameter cache also for macOS

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,21 @@ setup-env: &setup-env
 
 
 jobs:
+  # This job is needed for macOS, which doesn't support restoring caches that
+  # were created on Linux. This job will run on Linux, restore the cache and
+  # then persist it to the workspace, so that the macOS job can then use the
+  # files from the workspace.
+  persist_parameters_to_workspace:
+    executor: default
+    environment: *setup-env
+    steps:
+      - checkout
+      - restore_parameter_cache
+      - persist_to_workspace:
+          root: /tmp
+          paths:
+            - filecoin-proof-parameters
+
   ensure_groth_parameters_and_keys_linux:
     executor: default
     environment: *setup-env
@@ -283,6 +298,9 @@ jobs:
     environment: *setup-env
     steps:
       - checkout
+      # In case of macOS, the workspace contains the parameter files.
+      - attach_workspace:
+          at: "/tmp"
       - run:
           name: Install hwloc 2.3.0
           command: |
@@ -374,6 +392,9 @@ workflows:
   test_all:
     jobs:
       - ensure_groth_parameters_and_keys_linux
+      - persist_parameters_to_workspace:
+          requires:
+            - ensure_groth_parameters_and_keys_linux
       - cargo_fetch
       - rustfmt:
           requires:
@@ -521,7 +542,9 @@ workflows:
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
-      - test_darwin
+      - test_darwin:
+          requires:
+            - persist_parameters_to_workspace
 
       - test:
           name: test_fr32


### PR DESCRIPTION
In CircleCI you cannot restore a cache on macOS that was saved on Linux.
The workaround is to persist those files in a workspace. That workspace
can then be attached on macOS. So the workflow for macOS is:

  1. (Linux) Generate parameters and cache them
  2. (Linux) Restore cache and preserve in workspace
  3. (macOS) Attach workspace