### PR TITLE
chore: CI: don't always run test_seal_lifecycle_upgrade

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,6 @@ jobs:
             ulimit -u 20000
             ulimit -n 20000
             cargo +<< pipeline.parameters.nightly-toolchain >> test --all --verbose --release << parameters.cargo-args >> -- --nocapture << parameters.test-args >>
-            cargo +<< pipeline.parameters.nightly-toolchain >> test test_seal_lifecycle_upgrade --verbose --release << parameters.cargo-args >> -- --nocapture --ignored
           no_output_timeout: 30m
           environment:
             FIL_PROOFS_USE_GPU_COLUMN_BUILDER: true
@@ -444,7 +443,7 @@ workflows:
 
       - test_gpu_tree_building:
           name: test_gpu_tree_building_opencl (ignored)
-          test-args: "--ignored --skip test_seal_lifecycle_upgrade"
+          test-args: "--ignored"
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux


### PR DESCRIPTION
It probably was a debug left-over from the sector upgrade work. The
`test_seal_lifecycle_upgrade` test is included when running with
the default test arguments, so there's no need to mention it separately.
It was also run in the non-ignore case. There's no point of running
it twice.