### PR TITLE
chore: CI: run no GPU tests in release mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,7 @@ jobs:
       - run:
           name: Test with no gpu
           command: |
-            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --verbose --no-default-features
+            cargo +<< pipeline.parameters.nightly-toolchain >> test --all --verbose --release --no-default-features
           no_output_timeout: 30m
 
   test_arm_no_gpu:


### PR DESCRIPTION
Those tests run for a long time, release mode reduced the time. The
tests now run under 20mins, compared to over 1h prior to this commit.