### PR TITLE
fix: cli: make the default value of `clap` args work properly

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/main.rs
+++ b/fil-proofs-tooling/src/bin/benchy/main.rs
@@ -84,7 +84,6 @@ fn main() -> Result<()> {
         .arg(
             Arg::new("api_version")
                 .long("api-version")
-                .required(true)
                 .help("The api_version to use (default: 1.1.0)")
                 .default_value("1.1.0")
                 .takes_value(true),
@@ -108,7 +107,6 @@ fn main() -> Result<()> {
         .arg(
             Arg::new("api_version")
                 .long("api-version")
-                .required(true)
                 .help("The api_version to use (default: 1.1.0)")
                 .default_value("1.1.0")
                 .takes_value(true),
@@ -132,7 +130,6 @@ fn main() -> Result<()> {
         .arg(
             Arg::new("api_version")
                 .long("api-version")
-                .required(true)
                 .help("The api_version to use (default: 1.1.0)")
                 .default_value("1.1.0")
                 .takes_value(true),

--- a/fil-proofs-tooling/src/bin/update_tree_r_cache/main.rs
+++ b/fil-proofs-tooling/src/bin/update_tree_r_cache/main.rs
@@ -317,7 +317,6 @@ fn main() -> Result<()> {
         .about("Rebuild tree_r_last trees from replica")
         .arg(
             Arg::new("size")
-                .required(true)
                 .long("size")
                 .default_value("34359738368")
                 .help("The data size in bytes")
@@ -342,7 +341,6 @@ fn main() -> Result<()> {
         .about("Inspect tree_r_last trees and match with p_aux in cache")
         .arg(
             Arg::new("size")
-                .required(true)
                 .long("size")
                 .default_value("34359738368")
                 .help("The data size in bytes")
@@ -367,7 +365,6 @@ fn main() -> Result<()> {
         .about("Verify tree_r_last trees and check for cache mis-match")
         .arg(
             Arg::new("size")
-                .required(true)
                 .long("size")
                 .default_value("34359738368")
                 .help("The data size in bytes")


### PR DESCRIPTION
Remove `required(true)` if default value exists.

Resolves #1589 