### PR TITLE
chore: ignore sector update compound tests

### DIFF
--- a/storage-proofs-update/tests/compound.rs
+++ b/storage-proofs-update/tests/compound.rs
@@ -222,31 +222,37 @@ where
 }
 
 #[test]
+#[ignore]
 fn test_empty_sector_update_compound_1kib() {
     test_empty_sector_update_compound::<U8, U4, U0>(SECTOR_SIZE_1_KIB);
 }
 
 #[test]
+#[ignore]
 fn test_empty_sector_update_compound_2kib() {
     test_empty_sector_update_compound::<U8, U0, U0>(SECTOR_SIZE_2_KIB);
 }
 
 #[test]
+#[ignore]
 fn test_empty_sector_update_compound_4kib() {
     test_empty_sector_update_compound::<U8, U2, U0>(SECTOR_SIZE_4_KIB);
 }
 
 #[test]
+#[ignore]
 fn test_empty_sector_update_compound_8kib() {
     test_empty_sector_update_compound::<U8, U4, U0>(SECTOR_SIZE_8_KIB);
 }
 
 #[test]
+#[ignore]
 fn test_empty_sector_update_compound_16kib() {
     test_empty_sector_update_compound::<U8, U8, U0>(SECTOR_SIZE_16_KIB);
 }
 
 #[test]
+#[ignore]
 fn test_empty_sector_update_compound_32kib() {
     test_empty_sector_update_compound::<U8, U8, U2>(SECTOR_SIZE_32_KIB);
 }


### PR DESCRIPTION
The sector update compound tests take a long time to run, ignore them
by default, like other long running tests (e.g. the lifecycle ones).

The CI run for `test_arm_no_gpu` is reduced to about 30min (was 75min). `test_darwin` is down to about 45min (was 60min). The tree building "ignored" tests now obviously take longer to run, but still < 60min. The total run time on CI is down to 55min (was 75min).