### PR TITLE
chore: remove unused dependencies from storage-proofs-update

### DIFF
--- a/storage-proofs-update/Cargo.toml
+++ b/storage-proofs-update/Cargo.toml
@@ -9,55 +9,27 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-crossbeam = "0.8"
-digest = "0.10.3"
 storage-proofs-core = { path = "../storage-proofs-core", version = "^11.0.0", default-features = false}
 storage-proofs-porep = { path = "../storage-proofs-porep", version = "^11.0.0", default-features = false}
-sha2raw = { path = "../sha2raw", version = "^6.0.0"}
 filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["poseidon", "sha256"]}
-rand = "0.8"
 merkletree = "0.21.0"
-mapr = "0.8.0"
-num-bigint = "0.4.3"
-num-traits = "0.2"
 rayon = "1.0.0"
 serde = { version = "1.0", features = ["derive"]}
-serde_json = "1.0"
 ff = "0.11.0"
 bellperson = "0.18.0"
 blstrs = "0.4.0"
 log = "0.4.7"
-pretty_assertions = "1.2.0"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
 neptune = { version = "5.1.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
-num_cpus = "1.10.1"
-hex = "0.4.2"
-bincode = "1.1.2"
-byteorder = "1.3.4"
 lazy_static = "1.2"
-byte-slice-cast = "1.0.0"
-hwloc = { version = "0.5.0", optional = true }
-libc = "0.2"
-fdlimit = "0.2.0"
 fr32 = { path = "../fr32", version = "^4.0.0", default-features = false }
-yastl = "0.1.2"
-fil_logger = "0.1.6"
 memmap = "0.7"
-
-[target."cfg(target_arch = \"aarch64\")".dependencies]
-sha2 = { version = "0.10.2", features = ["compress", "asm"] }
-[target."cfg(not(target_arch = \"aarch64\"))".dependencies]
-sha2 = { version = "0.10.2", features = ["compress"] }
 
 [dev-dependencies]
 tempfile = "3"
+rand = "0.8"
 rand_xorshift = "0.3.0"
-criterion = "0.3.2"
-glob = "0.3.0"
-pretty_env_logger = "0.4.0"
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
-storage-proofs-porep = { path = "../storage-proofs-porep", version = "^11.0.0", default-features = false }
 
 [features]
 default = ["opencl", "multicore-sdr"]


### PR DESCRIPTION
`storage-proofs-update` includes a lot of dependencies it isn't actually
using, this commit removes those.