### PR TITLE
fix: SDR: update comment

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -239,7 +239,8 @@ fn create_layer_labels(
     // Next node to be filled
     let cur_awaiting = AtomicU64::new(1);
 
-    // These UnsafeSlices are managed through the 3 Atomics above, to minimize any locking overhead.
+    // These UnsafeSlices are managed through the 2 Atomics above and the `CacheReader`, to
+    // minimize any locking overhead.
     let layer_labels = UnsafeSlice::from_slice(
         layer_labels
             .as_mut_slice_of::<u32>()


### PR DESCRIPTION
This commit fixes a comment that was outdated. Originally three atomics
were used. With commit [a43f3a9dbb9ef76b0053a9639e638a0478337f32] the
atomic that is tracking which node the consumer is currently working on
was moved into the `CacheReader`.

[a43f3a9dbb9ef76b0053a9639e638a0478337f32]: https://github.com/filecoin-project/rust-fil-proofs/commit/a43f3a9dbb9ef76b0053a9639e638a0478337f32#diff-c1a5ea514dd1555f26b0c1c63a7435ef2804e8759e44de747904ed4bcb47bf20L230-L231

Closes #1602.