### PR TITLE
chore: lock versions to the correct minor, and update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,6 +316,9 @@ commands:
   ensure_filecoin_parameters:
     steps:
       - run:
+          name: Create parameters directory
+          command: mkdir -p ${FIL_PROOFS_PARAMETER_CACHE}
+      - run:
           name: Build paramcache if it doesn't already exist
           command: |
             set -x; test -f /tmp/paramcache.awesome \
@@ -327,8 +330,11 @@ commands:
       - run:
           name: Obtain filecoin ipp parameter file
           command: |
-            cargo run --release --bin paramfetch -- -a -j srs-inner-product.json
-          no_output_timeout: 60m
+            # paramfetch is using `ipget` which currently always times out on
+            # CI, hence get this file via HTTP instead.
+            #cargo run --release --bin paramfetch -- -a -j srs-inner-product.json
+            # `--insecure` is needed due to an outdated base systems.
+            curl --insecure https://proofs.filecoin.io/v28-fil-inner-product-v1.srs --output ${FIL_PROOFS_PARAMETER_CACHE}v28-fil-inner-product-v1.srs
       - run:
           name: Make the parameters world readable
           command: chmod -R 755 ${FIL_PROOFS_PARAMETER_CACHE}

--- a/fil-proofs-param/Cargo.toml
+++ b/fil-proofs-param/Cargo.toml
@@ -9,12 +9,12 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-storage-proofs-core = { path = "../storage-proofs-core", version = "^11.0.0", default-features = false}
-storage-proofs-porep = { path = "../storage-proofs-porep", version = "^11.0.0", default-features = false }
-storage-proofs-post = { path = "../storage-proofs-post", version = "^11.0.0", default-features = false }
-storage-proofs-update = { path = "../storage-proofs-update", version = "^11.0.0", default-features = false }
-filecoin-hashers = { version = "^6.0.0", path = "../filecoin-hashers", default-features = false, features = ["poseidon", "sha256"] }
-filecoin-proofs = { version = "^11.0.0", path = "../filecoin-proofs", default-features = false }
+storage-proofs-core = { path = "../storage-proofs-core", version = "~11.1.0", default-features = false}
+storage-proofs-porep = { path = "../storage-proofs-porep", version = "~11.1.0", default-features = false }
+storage-proofs-post = { path = "../storage-proofs-post", version = "~11.1.0", default-features = false }
+storage-proofs-update = { path = "../storage-proofs-update", version = "~11.1.0", default-features = false }
+filecoin-hashers = { version = "~6.1.0", path = "../filecoin-hashers", default-features = false, features = ["poseidon", "sha256"] }
+filecoin-proofs = { version = "~11.1.0", path = "../filecoin-proofs", default-features = false }
 bitvec = "0.17"
 rand = "0.8"
 lazy_static = "1.2"

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -10,12 +10,12 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-storage-proofs-core = { path = "../storage-proofs-core", version = "^11.0.0", default-features = false}
-storage-proofs-porep = { path = "../storage-proofs-porep", version = "^11.0.0", default-features = false }
-storage-proofs-post = { path = "../storage-proofs-post", version = "^11.0.0", default-features = false }
-storage-proofs-update = { path = "../storage-proofs-update", version = "^11.0.0", default-features = false }
-filecoin-proofs = { path = "../filecoin-proofs", default-features = false }
-filecoin-hashers = { path = "../filecoin-hashers", default-features = false, features = ["poseidon", "blake2s", "sha256"] }
+storage-proofs-core = { path = "../storage-proofs-core", version = "~11.1.0", default-features = false}
+storage-proofs-porep = { path = "../storage-proofs-porep", version = "~11.1.0", default-features = false }
+storage-proofs-post = { path = "../storage-proofs-post", version = "~11.1.0", default-features = false }
+storage-proofs-update = { path = "../storage-proofs-update", version = "~11.1.0", default-features = false }
+filecoin-proofs = { path = "../filecoin-proofs", version = "~11.1.0", default-features = false }
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "blake2s", "sha256"] }
 clap = "2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/filecoin-hashers/Cargo.toml
+++ b/filecoin-hashers/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1.0.34"
 serde = "1.0.117"
 rand = "0.8.0"
 
-neptune = { version = "5.2.0", optional = true, features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
+neptune = { version = "~5.2.0", optional = true, features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 lazy_static = { version = "1.4.0", optional = true }
 blake2s_simd = { version = "0.5.11", optional = true }
 sha2 = { version = "0.9.2", optional = true }

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -9,11 +9,11 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-storage-proofs-core = { path = "../storage-proofs-core", version = "^11.0.0", default-features = false}
-storage-proofs-porep = { path = "../storage-proofs-porep", version = "^11.0.0", default-features = false }
-storage-proofs-post = { path = "../storage-proofs-post", version = "^11.0.0", default-features = false }
-storage-proofs-update = { path = "../storage-proofs-update", version = "^11.0.0", default-features = false }
-filecoin-hashers = { version = "^6.0.0", path = "../filecoin-hashers", default-features = false, features = ["poseidon", "sha256"] }
+storage-proofs-core = { path = "../storage-proofs-core", version = "~11.1.0", default-features = false}
+storage-proofs-porep = { path = "../storage-proofs-porep", version = "~11.1.0", default-features = false }
+storage-proofs-post = { path = "../storage-proofs-post", version = "~11.1.0", default-features = false }
+storage-proofs-update = { path = "../storage-proofs-update", version = "~11.1.0", default-features = false }
+filecoin-hashers = { version = "~6.1.0", path = "../filecoin-hashers", default-features = false, features = ["poseidon", "sha256"] }
 bitvec = "0.17"
 rand = "0.8"
 lazy_static = "1.2"
@@ -40,7 +40,7 @@ gperftools = { version = "0.2", optional = true }
 generic-array = "0.14.4"
 group = "0.11.0"
 byte-slice-cast = "1.0.0"
-fr32 = { path = "../fr32", version = "^4.0.0", default-features = false }
+fr32 = { path = "../fr32", version = "~4.1.0", default-features = false }
 once_cell = "1.8.0"
 blstrs = "0.4.0"
 

--- a/storage-proofs-core/Cargo.toml
+++ b/storage-proofs-core/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 bench = false
 
 [dependencies]
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["sha256", "poseidon"] }
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["sha256", "poseidon"] }
 rand = "0.8"
 merkletree = "0.21.0"
 byteorder = "1"
@@ -39,12 +39,12 @@ hex = "0.4.0"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
 thiserror = "1.0.6"
-neptune = { version = "5.2.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
+neptune = { version = "~5.2.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 cpu-time = { version = "1.0", optional = true }
 gperftools = { version = "0.2", optional = true }
 num_cpus = "1.10.1"
 semver = "0.11.0"
-fr32 = { path = "../fr32", version = "^4.0.0"}
+fr32 = { path = "../fr32", version = "~4.1.0"}
 pairing = "0.21"
 blstrs = "0.4.0"
 
@@ -55,7 +55,7 @@ bitvec = "0.17"
 rand_xorshift = "0.3.0"
 pretty_assertions = "0.6.1"
 sha2raw = { path = "../sha2raw", version = "^6.0.0"}
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["blake2s", "sha256", "poseidon"] }
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["blake2s", "sha256", "poseidon"] }
 
 [features]
 default = ["opencl"]

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 [dependencies]
 crossbeam = "0.8"
 digest = "0.9"
-storage-proofs-core = { path = "../storage-proofs-core", version = "^11.0.0", default-features = false}
+storage-proofs-core = { path = "../storage-proofs-core", version = "~11.1.0", default-features = false}
 sha2raw = { path = "../sha2raw", version = "^6.0.0"}
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["poseidon", "sha256"]}
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "sha256"]}
 rand = "0.8"
 merkletree = "0.21.0"
 mapr = "0.8.0"
@@ -28,7 +28,7 @@ log = "0.4.7"
 pretty_assertions = "0.6.1"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { version = "5.2.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
+neptune = { version = "~5.2.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 num_cpus = "1.10.1"
 hex = "0.4.2"
 bincode = "1.1.2"
@@ -38,7 +38,7 @@ byte-slice-cast = "1.0.0"
 hwloc = { version = "0.3.0", optional = true }
 libc = "0.2"
 fdlimit = "0.2.0"
-fr32 = { path = "../fr32", version = "^4.0.0", default-features = false }
+fr32 = { path = "../fr32", version = "~4.1.0", default-features = false }
 yastl = "0.1.2"
 fil_logger = "0.1"
 pairing = "0.21"
@@ -55,7 +55,7 @@ rand_xorshift = "0.3.0"
 criterion = "0.3.2"
 glob = "0.3.0"
 pretty_env_logger = "0.4.0"
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
 
 [features]
 default = ["opencl", "multicore-sdr"]

--- a/storage-proofs-post/Cargo.toml
+++ b/storage-proofs-post/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-storage-proofs-core = { path = "../storage-proofs-core", version = "^11.0.0", default-features = false}
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["poseidon", "sha256"]}
+storage-proofs-core = { path = "../storage-proofs-core", version = "~11.1.0", default-features = false}
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "sha256"]}
 rand = "0.8"
 merkletree = "0.21.0"
 byteorder = "1"
@@ -26,15 +26,15 @@ log = "0.4.7"
 hex = "0.4.0"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { version = "5.2.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
+neptune = { version = "~5.2.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 num_cpus = "1.10.1"
-fr32 = { path = "../fr32", version = "^4.0.0", default-features = false }
+fr32 = { path = "../fr32", version = "~4.1.0", default-features = false }
 blstrs = "0.4.0"
 
 [dev-dependencies]
 tempfile = "3"
 pretty_assertions = "0.6.1"
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
 rand_xorshift = "0.3.0"
 
 [features]

--- a/storage-proofs-update/Cargo.toml
+++ b/storage-proofs-update/Cargo.toml
@@ -11,10 +11,10 @@ readme = "README.md"
 [dependencies]
 crossbeam = "0.8"
 digest = "0.9"
-storage-proofs-core = { path = "../storage-proofs-core", version = "^11.0.0", default-features = false}
-storage-proofs-porep = { path = "../storage-proofs-porep", version = "^11.0.0", default-features = false}
+storage-proofs-core = { path = "../storage-proofs-core", version = "~11.1.0", default-features = false}
+storage-proofs-porep = { path = "../storage-proofs-porep", version = "~11.1.0", default-features = false}
 sha2raw = { path = "../sha2raw", version = "^6.0.0"}
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["poseidon", "sha256"]}
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "sha256"]}
 rand = "0.8"
 merkletree = "0.21.0"
 mapr = "0.8.0"
@@ -30,7 +30,7 @@ log = "0.4.7"
 pretty_assertions = "0.6.1"
 generic-array = "0.14.4"
 anyhow = "1.0.23"
-neptune = { version = "5.2.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
+neptune = { version = "~5.2.0", features = ["arity2", "arity4", "arity8", "arity11", "arity16", "arity24", "arity36"] }
 num_cpus = "1.10.1"
 hex = "0.4.2"
 bincode = "1.1.2"
@@ -40,7 +40,7 @@ byte-slice-cast = "1.0.0"
 hwloc = { version = "0.3.0", optional = true }
 libc = "0.2"
 fdlimit = "0.2.0"
-fr32 = { path = "../fr32", version = "^4.0.0", default-features = false }
+fr32 = { path = "../fr32", version = "~4.1.0", default-features = false }
 yastl = "0.1.2"
 fil_logger = "0.1"
 memmap = "0.7"
@@ -56,8 +56,8 @@ rand_xorshift = "0.3.0"
 criterion = "0.3.2"
 glob = "0.3.0"
 pretty_env_logger = "0.4.0"
-filecoin-hashers = { path = "../filecoin-hashers", version = "^6.0.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
-storage-proofs-porep = { path = "../storage-proofs-porep", version = "^11.0.0", default-features = false }
+filecoin-hashers = { path = "../filecoin-hashers", version = "~6.1.0", default-features = false, features = ["poseidon", "sha256", "blake2s"]}
+storage-proofs-porep = { path = "../storage-proofs-porep", version = "~11.1.0", default-features = false }
 
 [features]
 default = ["opencl", "multicore-sdr"]


### PR DESCRIPTION
1. Update minimum versions for in-workspace crates.
2. Use the tilde constraint to ensure that we don't update to the next
   minor version. The next minor version is going to revert the change.