### PR TITLE
chore: update CircleCI to xcode 13.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,11 +273,14 @@ jobs:
           command: cargo +$(cat rust-toolchain) clippy --all-targets --workspace -- -D warnings
   test_darwin:
     macos:
-      xcode: "12.5.0"
+      xcode: "13.4.1"
     working_directory: ~/crate
     resource_class: large
     environment: *setup-env
     steps:
+      - run:
+          name: Delete simulators for more free disk space
+          command: sudo rm -rf /Library/Developer/CoreSimulator/Profiles/Runtimes/
       - checkout
       - run:
           name: Install hwloc with Homebrew
@@ -354,7 +357,7 @@ commands:
       - run: uname > os.txt
       - save_cache:
           name: "Save parameter cache"
-          key: proof-params-v28-k-{{ checksum "os.txt" }}-{{ checksum "filecoin-proofs/parameters.json" }}
+          key: proof-params-v28-l-{{ checksum "os.txt" }}-{{ checksum "filecoin-proofs/parameters.json" }}
           paths:
             - "/tmp/paramcache.awesome"
             - "/tmp/filecoin-proof-parameters/"
@@ -364,7 +367,7 @@ commands:
       - run: uname > os.txt
       - restore_cache:
           name: "Restore parameter cache"
-          key: proof-params-v28-k-{{ checksum "os.txt" }}-{{ checksum "filecoin-proofs/parameters.json" }}
+          key: proof-params-v28-l-{{ checksum "os.txt" }}-{{ checksum "filecoin-proofs/parameters.json" }}
 
 workflows:
   version: 2.1


### PR DESCRIPTION
Version 12.5.0 doesn't seem to be supported anymore, hence upgrade to the
latest non-beta release.

Simulators for iOS (which we don't need) are deleted, so that there's enough
space for the Filecoin params.