### PR TITLE
test: make sure that WindowPoSt also works on read-only files

### DIFF
--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -41,6 +41,7 @@ tempfile = "3"
 ff = "0.12.0"
 fil_logger = "0.1.6"
 rand_xorshift = "0.3.0"
+walkdir = "2.3.2"
 
 [features]
 default = ["opencl"]

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -865,6 +865,10 @@ fn winning_post<Tree: 'static + MerkleTreeTrait>(
     let challenges =
         generate_fallback_sector_challenges::<Tree>(&config, &randomness, &[sector_id], prover_id)?;
 
+    // Make sure that files can be read-only for a window post.
+    set_readonly_flag(replica.path(), true);
+    set_readonly_flag(cache_dir.path(), true);
+
     let single_proof = generate_single_vanilla_proof::<Tree>(
         &config,
         sector_id,
@@ -885,6 +889,10 @@ fn winning_post<Tree: 'static + MerkleTreeTrait>(
     let valid =
         verify_winning_post::<Tree>(&config, &randomness, &pub_replicas[..], prover_id, &proof)?;
     assert!(valid, "proof did not verify");
+
+    // Make files writeable again, so that the temporary directory can be removed.
+    set_readonly_flag(replica.path(), false);
+    set_readonly_flag(cache_dir.path(), false);
 
     replica.close()?;
 

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -1229,7 +1229,7 @@ fn partition_window_post<Tree: 'static + MerkleTreeTrait>(
     Ok(())
 }
 
-/// Make all files recursively read-only/writeable, starting at the given directory.
+/// Make all files recursively read-only/writeable, starting at the given directory/file.
 fn set_readonly_flag(path: &Path, readonly: bool) {
     for entry in walkdir::WalkDir::new(path) {
         let entry = entry.expect("couldn't get file");
@@ -1324,7 +1324,8 @@ fn window_post<Tree: 'static + MerkleTreeTrait>(
     let mut vanilla_proofs = Vec::with_capacity(replica_sectors.len());
 
     // Make sure that files can be read-only for a window post.
-    for (_, _, _, cache_dir, _) in &sectors {
+    for (_, replica, _, cache_dir, _) in &sectors {
+        set_readonly_flag(replica.path(), true);
         set_readonly_flag(cache_dir.path(), true);
     }
 
@@ -1344,7 +1345,8 @@ fn window_post<Tree: 'static + MerkleTreeTrait>(
     assert!(valid, "proof did not verify");
 
     // Make files writeable again, so that the temporary directory can be removed.
-    for (_, _, _, cache_dir, _) in &sectors {
+    for (_, replica, _, cache_dir, _) in &sectors {
+        set_readonly_flag(replica.path(), false);
         set_readonly_flag(cache_dir.path(), false);
     }
 


### PR DESCRIPTION
This commit adapts the test to make the generated files read-only before a WindowPoSt is performed. This simulates the use case when you mount your sectors read-only after generation.