### PR TITLE
halo2: Improve abstractions documenting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
       - run:
           name: Test (<< parameters.crate >>)
           command: cargo +$(cat rust-toolchain) test --verbose --package << parameters.crate >>
-          no_output_timeout: 30m
+          no_output_timeout: 45m
 
   test_release:
     executor: default

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,7 +401,7 @@ jobs:
             docker run
             --security-opt seccomp=unconfined
             -v "${PWD}:/volume"
-            -v "${FIL_PROOFS_PARAMETER_CACHE}:/var/tmp/filecoin-proof-parameters/"
+            -v "${FIL_PROOFS_PARAMETER_CACHE}:/tmp/filecoin-proof-parameters/"
             xd009642/tarpaulin
             sh -c "apt update && apt install -y libssl-dev ocl-icd-opencl-dev libhwloc-dev && cargo tarpaulin --timeout 1800 --release -v"
           no_output_timeout: 30m
@@ -666,4 +666,5 @@ workflows:
 
       - coverage-with-tarpaulin:
           requires:
+            - cargo_fetch
             - ensure_parameters_and_keys_linux

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,6 +1319,7 @@ dependencies = [
  "halo2_gadgets",
  "halo2_proofs",
  "neptune",
+ "pasta_curves",
  "rand",
  "rand_xorshift",
  "sha2 0.9.9",

--- a/fil-halo2-gadgets/Cargo.toml
+++ b/fil-halo2-gadgets/Cargo.toml
@@ -16,6 +16,7 @@ sha2 = "0.9.2"
 [dev-dependencies]
 rand = "0.8"
 rand_xorshift = "0.3.0"
+pasta_curves = "0.4.0"
 
 [features]
 all-chips = []

--- a/fil-halo2-gadgets/src/boolean.rs
+++ b/fil-halo2-gadgets/src/boolean.rs
@@ -219,11 +219,47 @@ impl<F: FieldExt, const LEN: usize> AssignedBits<F, LEN> {
     /// ***Panics*** if bits are assigned to instance column
     ///
     /// ```
-    /// // Consider `column` to be an advice/fixed column; `region` to be a particular circuit's region
-    /// const LEN: usize = 32;
-    /// let offset = 0;
-    /// let bits = Value::known([false; LEN]);
-    /// AssignedBits::<Fp, LEN>::assign_bits(&mut region, || "assign 32 zero bits", column, offset, bits);
+    /// # use pasta_curves::Fp;
+    /// # use halo2_proofs::plonk::{ConstraintSystem, Circuit, Error, Column, Advice};
+    /// # use halo2_proofs::circuit::{Value, SimpleFloorPlanner, Layouter};
+    /// # use fil_halo2_gadgets::boolean::AssignedBits;
+    ///
+    /// # struct TestCircuit;
+    /// # impl Circuit<Fp> for TestCircuit {
+    /// #    type Config = Column<Advice>;
+    /// #    type FloorPlanner = SimpleFloorPlanner;
+    /// #    fn without_witnesses(&self) -> Self {
+    /// #        todo!()
+    /// #    }
+    /// #    fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+    /// #        todo!()
+    /// #    }
+    /// #    fn synthesize(
+    /// #        &self,
+    /// #        config: Self::Config,
+    /// #        mut layouter: impl Layouter<Fp>,
+    /// #    ) -> Result<(), Error> {
+    /// #    let column = config;
+    ///
+    ///     const LEN: usize = 32;
+    ///     let offset = 0;
+    ///     let value = Value::known([false; 32]);
+    ///
+    ///     layouter.assign_region(
+    ///         || "test assignment",
+    ///         |mut region| {
+    ///             AssignedBits::<Fp, LEN>::assign_bits(
+    ///                 &mut region,
+    ///                 || "assign 32 zero bits",
+    ///                 column,
+    ///                 offset,
+    ///                 value,
+    ///             )
+    ///         },
+    ///     )?;
+    /// #    Ok(())
+    /// #   }
+    /// # }
     /// ```
     pub fn assign_bits<A, AR, T: TryInto<[bool; LEN]> + std::fmt::Debug + Clone>(
         region: &mut Region<'_, F>,
@@ -266,14 +302,50 @@ impl<F: FieldExt> AssignedBits<F, 16> {
     /// Assigns 16 bits represented as `u16` into assigned region of Halo2 circuit
     /// at a given `offset` using either advice or fixed column.
     ///
-    /// ***Panics*** if bits are assigned to instance column
+    /// ***Panics*** if bits are assigned to the instance column
     ///
     /// ```
-    /// // Consider `column` to be an advice/fixed column; `region` to be a particular circuit's region
-    /// const LEN: usize = 16;
-    /// let offset = 0;
-    /// let value = Value::known(0u16);
-    /// AssignedBits::<Fp, LEN>::assign(&mut region, || "assign 16-bits word", column, offset, value);
+    /// # use pasta_curves::Fp;
+    /// # use halo2_proofs::plonk::{ConstraintSystem, Circuit, Error, Column, Advice};
+    /// # use halo2_proofs::circuit::{Value, SimpleFloorPlanner, Layouter};
+    /// # use fil_halo2_gadgets::boolean::AssignedBits;
+    ///
+    /// # struct TestCircuit;
+    /// # impl Circuit<Fp> for TestCircuit {
+    /// #    type Config = Column<Advice>;
+    /// #    type FloorPlanner = SimpleFloorPlanner;
+    /// #    fn without_witnesses(&self) -> Self {
+    /// #        todo!()
+    /// #    }
+    /// #    fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+    /// #        todo!()
+    /// #    }
+    /// #    fn synthesize(
+    /// #        &self,
+    /// #        config: Self::Config,
+    /// #        mut layouter: impl Layouter<Fp>,
+    /// #    ) -> Result<(), Error> {
+    /// #    let column = config;
+    ///
+    ///     const LEN: usize = 16;
+    ///     let offset = 0;
+    ///     let value = Value::known(0u16);
+    ///
+    ///     layouter.assign_region(
+    ///         || "test assignment",
+    ///         |mut region| {
+    ///             AssignedBits::<Fp, LEN>::assign(
+    ///                 &mut region,
+    ///                 || "assign 16-bits word",
+    ///                 column,
+    ///                 offset,
+    ///                 value,
+    ///             )
+    ///         },
+    ///     )?;
+    /// #    Ok(())
+    /// #   }
+    /// # }
     /// ```
     pub fn assign<A, AR>(
         region: &mut Region<'_, F>,
@@ -316,11 +388,47 @@ impl<F: FieldExt> AssignedBits<F, 32> {
     /// ***Panics*** if bits are assigned to instance column
     ///
     /// ```
-    /// // Consider `column` to be an advice/fixed column; `region` to be a particular circuit's region
-    /// const LEN: usize = 32;
-    /// let offset = 0;
-    /// let value = Value::known(0u32);
-    /// AssignedBits::<Fp, LEN>::assign(&mut region, || "assign 32-bits word", column, offset, value);
+    /// # use pasta_curves::Fp;
+    /// # use halo2_proofs::plonk::{ConstraintSystem, Circuit, Error, Column, Advice};
+    /// # use halo2_proofs::circuit::{Value, SimpleFloorPlanner, Layouter};
+    /// # use fil_halo2_gadgets::boolean::AssignedBits;
+    ///
+    /// # struct TestCircuit;
+    /// # impl Circuit<Fp> for TestCircuit {
+    /// #    type Config = Column<Advice>;
+    /// #    type FloorPlanner = SimpleFloorPlanner;
+    /// #    fn without_witnesses(&self) -> Self {
+    /// #        todo!()
+    /// #    }
+    /// #    fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+    /// #        todo!()
+    /// #    }
+    /// #    fn synthesize(
+    /// #        &self,
+    /// #        config: Self::Config,
+    /// #        mut layouter: impl Layouter<Fp>,
+    /// #    ) -> Result<(), Error> {
+    /// #    let column = config;
+    ///
+    ///     const LEN: usize = 32;
+    ///     let offset = 0;
+    ///     let value = Value::known(0u32);
+    ///
+    ///     layouter.assign_region(
+    ///         || "test assignment",
+    ///         |mut region| {
+    ///             AssignedBits::<Fp, LEN>::assign(
+    ///                 &mut region,
+    ///                 || "assign 32-bits word",
+    ///                 column,
+    ///                 offset,
+    ///                 value,
+    ///             )
+    ///         },
+    ///     )?;
+    /// #    Ok(())
+    /// #   }
+    /// # }
     /// ```
     pub fn assign<A, AR>(
         region: &mut Region<'_, F>,

--- a/fil-halo2-gadgets/src/boolean.rs
+++ b/fil-halo2-gadgets/src/boolean.rs
@@ -195,6 +195,12 @@ impl From<u32> for Bits<32> {
     }
 }
 
+/// Utility for convenient assigning bits (`Bit`) into Halo2 circuit
+///
+/// It's implementation is motivated by SHA-256 chip (and its optimizations),
+/// which operates with 32-bit words. Halo2 circuit stores information as field elements,
+/// so regardless of number of bits assigned 1 or 64, they both will occupy single field element.
+///
 #[derive(Clone, Debug)]
 pub struct AssignedBits<F: FieldExt, const LEN: usize>(pub(crate) AssignedCell<Bits<LEN>, F>);
 
@@ -207,6 +213,19 @@ impl<F: FieldExt, const LEN: usize> std::ops::Deref for AssignedBits<F, LEN> {
 }
 
 impl<F: FieldExt, const LEN: usize> AssignedBits<F, LEN> {
+
+    /// Assigns up to 64 bits represented as [bool; LEN] into assigned region of Halo2 circuit
+    /// at a given `offset` using either advice or fixed column.
+    ///
+    /// ***Panics*** if bits are assigned to instance column
+    ///
+    /// ```
+    /// // Consider `column` to be an advice/fixed column; `region` to be a particular circuit's region
+    /// const LEN: usize = 32;
+    /// let offset = 0;
+    /// let bits = Value::known([false; LEN]);
+    /// AssignedBits::<Fp, LEN>::assign_bits(&mut region, || "assign 32 zero bits", column, offset, bits);
+    /// ```
     pub fn assign_bits<A, AR, T: TryInto<[bool; LEN]> + std::fmt::Debug + Clone>(
         region: &mut Region<'_, F>,
         annotation: A,
@@ -245,6 +264,18 @@ impl<F: FieldExt> AssignedBits<F, 16> {
         self.value().map(|v| v.into())
     }
 
+    /// Assigns 16 bits represented as `u16` into assigned region of Halo2 circuit
+    /// at a given `offset` using either advice or fixed column.
+    ///
+    /// ***Panics*** if bits are assigned to instance column
+    ///
+    /// ```
+    /// // Consider `column` to be an advice/fixed column; `region` to be a particular circuit's region
+    /// const LEN: usize = 16;
+    /// let offset = 0;
+    /// let value = Value::known(0u16);
+    /// AssignedBits::<Fp, LEN>::assign(&mut region, || "assign 16-bits word", column, offset, value);
+    /// ```
     pub fn assign<A, AR>(
         region: &mut Region<'_, F>,
         annotation: A,
@@ -280,6 +311,18 @@ impl<F: FieldExt> AssignedBits<F, 32> {
         self.value().map(|v| v.into())
     }
 
+    /// Assigns 32 bits represented as `u32` into assigned region of Halo2 circuit
+    /// at a given `offset` using either advice or fixed column.
+    ///
+    /// ***Panics*** if bits are assigned to instance column
+    ///
+    /// ```
+    /// // Consider `column` to be an advice/fixed column; `region` to be a particular circuit's region
+    /// const LEN: usize = 32;
+    /// let offset = 0;
+    /// let value = Value::known(0u32);
+    /// AssignedBits::<Fp, LEN>::assign(&mut region, || "assign 32-bits word", column, offset, value);
+    /// ```
     pub fn assign<A, AR>(
         region: &mut Region<'_, F>,
         annotation: A,

--- a/fil-halo2-gadgets/src/boolean.rs
+++ b/fil-halo2-gadgets/src/boolean.rs
@@ -213,7 +213,6 @@ impl<F: FieldExt, const LEN: usize> std::ops::Deref for AssignedBits<F, LEN> {
 }
 
 impl<F: FieldExt, const LEN: usize> AssignedBits<F, LEN> {
-
     /// Assigns up to 64 bits represented as [bool; LEN] into assigned region of Halo2 circuit
     /// at a given `offset` using either advice or fixed column.
     ///

--- a/fil-halo2-gadgets/src/lib.rs
+++ b/fil-halo2-gadgets/src/lib.rs
@@ -175,18 +175,29 @@ impl AdviceIter {
     /// Returns next `(offset, column)` tuple, considering previous data assignment.
     ///
     /// ```
-    ///  // Consider `advice_columns` to be `[Column<Advice>; 8]`
+    ///  use pasta_curves::Fp;
+    ///  use halo2_proofs::plonk::{ ConstraintSystem, Column, Advice };
+    ///  use fil_halo2_gadgets::AdviceIter;
     ///
-    ///  let mut advice_iter = AdviceIter::from(advice_columns.to_vec());
+    ///  let mut cs = ConstraintSystem::<Fp>::default();
+    ///
+    ///  let advice_columns = (0..8).into_iter().map(|_| cs.advice_column()).collect::<Vec<Column<Advice>>>();
+    ///
+    ///  let mut advice_iter = AdviceIter::from(advice_columns);
     ///
     ///  for index in 0..8 {
-    ///      let (offset, col) = advice_iter.next();
-    ///           assert_eq!(offset, 0);
-    ///      }
-    ///      for index in 8..16 {
-    ///           let (offset, col) = advice_iter.next();
-    ///           assert_eq!(offset, 1);
-    ///      }
+    ///     let (offset, col) = advice_iter.next();
+    ///     assert_eq!(offset, 0);
+    ///  }
+    ///
+    ///  for index in 8..16 {
+    ///     let (offset, col) = advice_iter.next();
+    ///     assert_eq!(offset, 1);
+    ///  }
+    ///
+    ///  for index in 16..24 {
+    ///     let (offset, col) = advice_iter.next();
+    ///     assert_eq!(offset, 2);
     ///  }
     /// ```
     #[allow(clippy::should_implement_trait)]

--- a/fil-proofs-tooling/src/metadata.rs
+++ b/fil-proofs-tooling/src/metadata.rs
@@ -40,7 +40,7 @@ impl GitMetadata {
         let repo = Repository::discover(&repo_path)?;
         let head = repo.head()?;
         let commit = head.peel_to_commit()?;
-        let date = Utc.timestamp(commit.time().seconds(), 0);
+        let date = Utc.timestamp_opt(commit.time().seconds(), 0).unwrap();
 
         Ok(GitMetadata {
             hash: commit.id().to_string(),


### PR DESCRIPTION
As a result of our latest weekly meeting, I'm going to submit series of PRs dedicated to improving documentation of our current Halo2 abstractions.

There are following arguments for doing so:
- Hopefully, it should make circuit's code more understandable by rest of the team;
- It can be useful for future Halo2 delivering to Lotus;
- It allows continuing further experimenting with Halo2 circuits codebase using already defined abstractions and keep track of their change without interfering Jake's work a lot.

