### PR TITLE
fix: clean up tree definitions

### DIFF
--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -7,7 +7,7 @@ pub use storage_proofs_porep::stacked::EXP_DEGREE;
 use filecoin_hashers::{poseidon::PoseidonHasher, sha256::Sha256Hasher, Hasher};
 use lazy_static::lazy_static;
 use storage_proofs_core::{
-    merkle::{BinaryMerkleTree, LCTree, OctLCMerkleTree, OctMerkleTree},
+    merkle::{BinaryMerkleTree, DiskTree, LCTree},
     util::NODE_SIZE,
     MAX_LEGACY_POREP_REGISTERED_PROOF_ID,
 };
@@ -164,9 +164,15 @@ pub type DefaultPieceDomain = <DefaultPieceHasher as Hasher>::Domain;
 pub type DefaultTreeHasher = PoseidonHasher;
 pub type DefaultTreeDomain = <DefaultTreeHasher as Hasher>::Domain;
 
+/// A binary merkle tree with Poseidon hashing, where all levels have arity 2. It's fully
+/// persisted to disk.
 pub type DefaultBinaryTree = BinaryMerkleTree<DefaultTreeHasher>;
-pub type DefaultOctTree = OctMerkleTree<DefaultTreeHasher>;
-pub type DefaultOctLCTree = OctLCMerkleTree<DefaultTreeHasher>;
+/// A merkle tree with Poseidon hashing, where all levels have arity 8. It's fully persisted to
+/// disk.
+pub type DefaultOctTree = DiskTree<DefaultTreeHasher, U8, U0, U0>;
+/// A merkle tree with Poseidon hashing, where all levels have arity 8. Some levels are not
+/// persisted to disk, but only cached in memory.
+pub type DefaultOctLCTree = LCTree<DefaultTreeHasher, U8, U0, U0>;
 
 // Generic shapes
 pub type SectorShapeBase = LCTree<DefaultTreeHasher, U8, U0, U0>;

--- a/storage-proofs-core/src/merkle/mod.rs
+++ b/storage-proofs-core/src/merkle/mod.rs
@@ -5,7 +5,7 @@ use std::fs::File;
 pub use merkletree::store::{DiskStore, ExternalReader, Store};
 
 use filecoin_hashers::Hasher;
-use generic_array::typenum::{U0, U2, U4, U8};
+use generic_array::typenum::{U0, U2};
 use merkletree::store::LevelCacheStore;
 
 mod builders;
@@ -16,28 +16,30 @@ pub use builders::*;
 pub use proof::*;
 pub use tree::*;
 
-pub type LCStore<E> = LevelCacheStore<E, File>;
-
-pub type MerkleStore<T> = DiskStore<T>;
-
+/// A tree that is fully persisted to disk.
+///
+/// It's generic over the hash function `H`, the base arity `U`, sub-tree arity `V` and top tree
+/// arity `W`.
+///
+/// The base arity is used for the leaves. If all other arities are zero, then this arity is used
+/// for all levels.
+/// The sub-tree arity is for all levels between the level above the leaves and the level below the
+/// root (which is always a single item).
+/// The top-tree arity is used for the top level that then results in the roor node.
 pub type DiskTree<H, U, V, W> = MerkleTreeWrapper<H, DiskStore<<H as Hasher>::Domain>, U, V, W>;
-pub type LCTree<H, U, V, W> = MerkleTreeWrapper<H, LCStore<<H as Hasher>::Domain>, U, V, W>;
 
-pub type MerkleTree<H, U> = DiskTree<H, U, U0, U0>;
-pub type LCMerkleTree<H, U> = LCTree<H, U, U0, U0>;
+/// A tree that is partially stored on disk, some levels are in memory.
+///
+/// It's generic over the hash function `H`, the base arity `U`, sub-tree arity `V` and top tree
+/// arity `W`.
+///
+/// The base arity is used for the leaves. If all other arities are zero, then this arity is used
+/// for all levels.
+/// The sub-tree arity is for all levels between the level above the leaves and the level below the
+/// root (which is always a single item).
+/// The top-tree arity is used for the top level that then results in the roor node.
+pub type LCTree<H, U, V, W> =
+    MerkleTreeWrapper<H, LevelCacheStore<<H as Hasher>::Domain, File>, U, V, W>;
 
-pub type BinaryMerkleTree<H> = MerkleTree<H, U2>;
-pub type BinaryLCMerkleTree<H> = LCMerkleTree<H, U2>;
-
-pub type BinarySubMerkleTree<H> = DiskTree<H, U2, U2, U0>;
-
-pub type QuadMerkleTree<H> = MerkleTree<H, U4>;
-pub type QuadLCMerkleTree<H> = LCMerkleTree<H, U4>;
-
-pub type OctMerkleTree<H> = DiskTree<H, U8, U0, U0>;
-pub type OctSubMerkleTree<H> = DiskTree<H, U8, U2, U0>;
-pub type OctTopMerkleTree<H> = DiskTree<H, U8, U8, U2>;
-
-pub type OctLCMerkleTree<H> = LCTree<H, U8, U0, U0>;
-pub type OctLCSubMerkleTree<H> = LCTree<H, U8, U2, U0>;
-pub type OctLCTopMerkleTree<H> = LCTree<H, U8, U8, U2>;
+/// A binary merkle tree, where all levels have arity 2. It's fully persisted to disk.
+pub type BinaryMerkleTree<H> = DiskTree<H, U2, U0, U0>;

--- a/storage-proofs-core/src/merkle/mod.rs
+++ b/storage-proofs-core/src/merkle/mod.rs
@@ -37,7 +37,7 @@ pub type DiskTree<H, U, V, W> = MerkleTreeWrapper<H, DiskStore<<H as Hasher>::Do
 /// for all levels.
 /// The sub-tree arity is for all levels between the level above the leaves and the level below the
 /// root (which is always a single item).
-/// The top-tree arity is used for the top level that then results in the roor node.
+/// The top-tree arity is used for the top level that then results in the root node.
 pub type LCTree<H, U, V, W> =
     MerkleTreeWrapper<H, LevelCacheStore<<H as Hasher>::Domain, File>, U, V, W>;
 

--- a/storage-proofs-core/src/merkle/mod.rs
+++ b/storage-proofs-core/src/merkle/mod.rs
@@ -25,7 +25,7 @@ pub use tree::*;
 /// for all levels.
 /// The sub-tree arity is for all levels between the level above the leaves and the level below the
 /// root (which is always a single item).
-/// The top-tree arity is used for the top level that then results in the roor node.
+/// The top-tree arity is used for the top level that then results in the root node.
 pub type DiskTree<H, U, V, W> = MerkleTreeWrapper<H, DiskStore<<H as Hasher>::Domain>, U, V, W>;
 
 /// A tree that is partially stored on disk, some levels are in memory.

--- a/storage-proofs-core/src/merkle/mod.rs
+++ b/storage-proofs-core/src/merkle/mod.rs
@@ -18,14 +18,13 @@ pub use tree::*;
 
 /// A tree that is fully persisted to disk.
 ///
-/// It's generic over the hash function `H`, the base arity `U`, sub-tree arity `V` and top tree
+/// It's generic over the hash function `H`, the base arity `U`, sub-tree arity `V` and top-tree
 /// arity `W`.
 ///
-/// The base arity is used for the leaves. If all other arities are zero, then this arity is used
-/// for all levels.
-/// The sub-tree arity is for all levels between the level above the leaves and the level below the
-/// root (which is always a single item).
-/// The top-tree arity is used for the top level that then results in the root node.
+/// The base arity is used for for all levels up to the top. Non zero arties of the top-tree and/or
+/// sub-tree each add another layer on top. So a tree with e.g. `U = 8`, `V = 4`, `W = 2` would
+/// create a tree where the top level has two children, the levels below 4 children and all other
+/// levels below have 8 children.
 pub type DiskTree<H, U, V, W> = MerkleTreeWrapper<H, DiskStore<<H as Hasher>::Domain>, U, V, W>;
 
 /// A tree that is partially stored on disk, some levels are in memory.
@@ -33,11 +32,10 @@ pub type DiskTree<H, U, V, W> = MerkleTreeWrapper<H, DiskStore<<H as Hasher>::Do
 /// It's generic over the hash function `H`, the base arity `U`, sub-tree arity `V` and top tree
 /// arity `W`.
 ///
-/// The base arity is used for the leaves. If all other arities are zero, then this arity is used
-/// for all levels.
-/// The sub-tree arity is for all levels between the level above the leaves and the level below the
-/// root (which is always a single item).
-/// The top-tree arity is used for the top level that then results in the root node.
+/// The base arity is used for for all levels up to the top. Non zero arties of the top-tree and/or
+/// sub-tree each add another layer on top. So a tree with e.g. `U = 8`, `V = 4`, `W = 2` would
+/// create a tree where the top level has two children, the levels below 4 children and all other
+/// levels below have 8 children.
 pub type LCTree<H, U, V, W> =
     MerkleTreeWrapper<H, LevelCacheStore<<H as Hasher>::Domain, File>, U, V, W>;
 

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -29,7 +29,7 @@ use storage_proofs_core::{
     measurements::{measure_op, Operation},
     merkle::{
         create_disk_tree, create_lc_tree, get_base_tree_count, split_config,
-        split_config_and_replica, BinaryMerkleTree, DiskTree, LCTree, MerkleProofTrait, MerkleTree,
+        split_config_and_replica, BinaryMerkleTree, DiskTree, LCTree, MerkleProofTrait,
         MerkleTreeTrait,
     },
     settings::SETTINGS,
@@ -427,7 +427,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         let leafs = tree_data.len() / NODE_SIZE;
         assert_eq!(tree_data.len() % NODE_SIZE, 0);
 
-        let tree = MerkleTree::from_par_iter_with_config(
+        let tree = BinaryMerkleTree::from_par_iter_with_config(
             (0..leafs)
                 .into_par_iter()
                 // TODO: proper error handling instead of `unwrap()`

--- a/storage-proofs-post/tests/fallback_circuit.rs
+++ b/storage-proofs-post/tests/fallback_circuit.rs
@@ -12,7 +12,7 @@ use storage_proofs_core::{
     api_version::ApiVersion,
     compound_proof::CompoundProof,
     error::Result,
-    merkle::{generate_tree, get_base_tree_count, LCTree, MerkleTreeTrait, OctMerkleTree},
+    merkle::{generate_tree, get_base_tree_count, DiskTree, LCTree, MerkleTreeTrait},
     proof::ProofScheme,
     util::NODE_SIZE,
     TEST_SEED,
@@ -211,11 +211,11 @@ fn test_fallback_post_circuit_poseidon_base_8_bench_cs() {
         api_version: ApiVersion::V1_1_0,
     };
 
-    let pp = FallbackPoSt::<OctMerkleTree<PoseidonHasher>>::setup(&params)
+    let pp = FallbackPoSt::<DiskTree<PoseidonHasher, U8, U0, U0>>::setup(&params)
         .expect("fallback post setup failure");
 
     let mut cs = BenchCS::<Fr>::new();
-    FallbackPoStCompound::<OctMerkleTree<PoseidonHasher>>::blank_circuit(&pp)
+    FallbackPoStCompound::<DiskTree<PoseidonHasher, U8, U0, U0>>::blank_circuit(&pp)
         .synthesize(&mut cs)
         .expect("blank circuit failure");
 

--- a/storage-proofs-update/src/constants.rs
+++ b/storage-proofs-update/src/constants.rs
@@ -11,7 +11,7 @@ use neptune::{
     poseidon::PoseidonConstants,
     Strength,
 };
-use storage_proofs_core::merkle::{BinaryMerkleTree, LCStore, LCTree, MerkleTreeTrait};
+use storage_proofs_core::merkle::{BinaryMerkleTree, LCTree, MerkleTreeTrait};
 
 // Use a custom domain separation tag when generating randomness phi, rho, and challenges bits.
 pub const HASH_TYPE_GEN_RANDOMNESS: HashType<Fr, U2> = HashType::Custom(CType::Arbitrary(1));
@@ -58,7 +58,6 @@ pub type TreeDArity = U2;
 
 pub type TreeRHasher = PoseidonHasher;
 pub type TreeRDomain = PoseidonDomain;
-pub type TreeRStore = LCStore<TreeRDomain>;
 // All valid TreeR's have the same base-tree shape.
 pub type TreeRBaseTree = LCTree<TreeRHasher, U8, U0, U0>;
 


### PR DESCRIPTION
There were quite a few public type definitions, that were mostly replaced by the `SectorShape*` types. This commit cleans them up and moves them around if appropriate.

This should make the code easier to follow and the public API surface smaller.

BREAKING CHANGE: `BinaryLCMerkleTree`, `BinaryMerkleTree`, `BinarySubMerkleTree`, `LCMerkleTree`, `LCStore`, `MerkleStore`, `MerkleTree`, `OctLCMerkleTree`, `OctLCSubMerkleTree`, `OctLCTopMerkleTree`, `OctMerkleTree`, `OctSubMerkleTree`, `OctTopMerkleTree`, `QuadLCMerkleTree` and `QuadMerkleTree` are removed from the public interface.

---

This PR was triggered by a question about optimizing the GPU usage. I then dug deeper into the code to find out which tree sizes we are actually using and then found out that there are lots of types we don't actually use.