### PR TITLE
optimize: copy_parents_data only needs base parents

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/graph.rs
@@ -174,9 +174,9 @@ where
             let cache_parents = cache.read(node)?;
             Ok(self.copy_parents_data_inner(&cache_parents, base_data, hasher))
         } else {
-            let mut cache_parents = [0u32; DEGREE];
+            let mut cache_parents = [0u32; BASE_DEGREE];
 
-            self.parents(node as usize, &mut cache_parents[..])
+            self.base_parents(node as usize, &mut cache_parents[..])
                 .expect("parents failure");
             Ok(self.copy_parents_data_inner(&cache_parents, base_data, hasher))
         }


### PR DESCRIPTION
[`copy_parents_data_inner`](https://github.com/filecoin-project/rust-fil-proofs/blob/master/storage-proofs-porep/src/stacked/vanilla/graph.rs#L224) only uses base parents, so there's no need to fetch extension parents at the caller side.