### PR TITLE
API Features

### DIFF
--- a/fil-proofs-param/src/bin/paramcache.rs
+++ b/fil-proofs-param/src/bin/paramcache.rs
@@ -9,7 +9,7 @@ use filecoin_proofs::{
         WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT,
     },
     parameters::{public_params, window_post_public_params, winning_post_public_params},
-    types::{PaddedBytesAmount, PoRepConfig, PoRepProofPartitions, PoStConfig, SectorSize},
+    types::{PoRepConfig, PoStConfig, SectorSize},
     with_shape, PoStType,
 };
 use humansize::{file_size_opts, FileSize};
@@ -33,8 +33,8 @@ fn cache_porep_params<Tree: 'static + MerkleTreeTrait>(porep_config: PoRepConfig
     info!("generating PoRep groth params");
 
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )

--- a/fil-proofs-tooling/src/bin/benchy/prodbench.rs
+++ b/fil-proofs-tooling/src/bin/benchy/prodbench.rs
@@ -11,9 +11,8 @@ use fil_proofs_tooling::{
 use filecoin_hashers::sha256::Sha256Hasher;
 use filecoin_proofs::{
     clear_cache, parameters::public_params, seal_commit_phase1, seal_commit_phase2,
-    validate_cache_for_commit, DefaultOctLCTree, DefaultOctTree, PaddedBytesAmount, PoRepConfig,
-    PoRepProofPartitions, SectorSize, DRG_DEGREE, EXP_DEGREE, LAYERS, POREP_MINIMUM_CHALLENGES,
-    POREP_PARTITIONS,
+    validate_cache_for_commit, DefaultOctLCTree, DefaultOctTree, PoRepConfig, PoRepProofPartitions,
+    SectorSize, DRG_DEGREE, EXP_DEGREE, LAYERS, POREP_MINIMUM_CHALLENGES, POREP_PARTITIONS,
 };
 use log::info;
 use rand::SeedableRng;
@@ -217,7 +216,7 @@ pub fn run(
                 )?;
 
                 let phase1_output = seal_commit_phase1::<_, DefaultOctLCTree>(
-                    cfg,
+                    &cfg,
                     &replica_info.private_replica_info.cache_dir_path(),
                     &replica_info.private_replica_info.replica_path(),
                     PROVER_ID,
@@ -232,7 +231,7 @@ pub fn run(
                     replica_info.private_replica_info.cache_dir_path(),
                 )?;
 
-                seal_commit_phase2(cfg, phase1_output, PROVER_ID, *sector_id)
+                seal_commit_phase2(&cfg, phase1_output, PROVER_ID, *sector_id)
             })
             .expect("failed to prove sector");
 
@@ -322,8 +321,8 @@ fn generate_params(i: &ProdbenchInputs) {
 
 fn cache_porep_params(porep_config: PoRepConfig) {
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )

--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -154,7 +154,7 @@ fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
 
         let seal_pre_commit_phase1_measurement: FuncMeasurement<SealPreCommitPhase1Output<Tree>> = measure(|| {
             seal_pre_commit_phase1::<_, _, _, Tree>(
-                porep_config,
+                &porep_config,
                 cache_dir.clone(),
                 staged_file_path.clone(),
                 sealed_file_path.clone(),
@@ -257,7 +257,7 @@ fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
         let seal_pre_commit_phase2_measurement: FuncMeasurement<SealPreCommitOutput> =
             measure(|| {
                 seal_pre_commit_phase2::<_, _, Tree>(
-                    porep_config,
+                    &porep_config,
                     precommit_phase1_output,
                     cache_dir.clone(),
                     sealed_file_path.clone(),
@@ -408,7 +408,7 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
 
         let seal_commit_phase1_measurement = measure(|| {
             seal_commit_phase1::<_, Tree>(
-                porep_config,
+                &porep_config,
                 cache_dir.clone(),
                 sealed_file_path.clone(),
                 PROVER_ID,
@@ -469,7 +469,7 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
         };
 
         let seal_commit_phase2_measurement = measure(|| {
-            seal_commit_phase2::<Tree>(porep_config, commit_phase1_output, PROVER_ID, sector_id)
+            seal_commit_phase2::<Tree>(&porep_config, commit_phase1_output, PROVER_ID, sector_id)
         })
         .expect("failed in seal_commit_phase2");
 

--- a/fil-proofs-tooling/src/bin/circuitinfo/main.rs
+++ b/fil-proofs-tooling/src/bin/circuitinfo/main.rs
@@ -5,10 +5,9 @@ use blstrs::Scalar as Fr;
 use dialoguer::{theme::ColorfulTheme, MultiSelect};
 use filecoin_proofs::{
     parameters::{public_params, window_post_public_params, winning_post_public_params},
-    with_shape, DefaultPieceHasher, PaddedBytesAmount, PoRepConfig, PoRepProofPartitions,
-    PoStConfig, PoStType, SectorSize, POREP_PARTITIONS, PUBLISHED_SECTOR_SIZES,
-    WINDOW_POST_CHALLENGE_COUNT, WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT,
-    WINNING_POST_SECTOR_COUNT,
+    with_shape, DefaultPieceHasher, PoRepConfig, PoRepProofPartitions, PoStConfig, PoStType,
+    SectorSize, POREP_PARTITIONS, PUBLISHED_SECTOR_SIZES, WINDOW_POST_CHALLENGE_COUNT,
+    WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT,
 };
 use humansize::{file_size_opts, FileSize};
 use log::{info, warn};
@@ -40,8 +39,8 @@ fn get_porep_info<Tree: 'static + MerkleTreeTrait>(porep_config: PoRepConfig) ->
     info!("PoRep info");
 
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )

--- a/fil-proofs-tooling/src/shared.rs
+++ b/fil-proofs-tooling/src/shared.rs
@@ -220,7 +220,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
                     )?;
                     let comm_r = fauxrep_aux::<_, _, _, Tree>(
                         &mut rng,
-                        porep_config,
+                        &porep_config,
                         &cache_dirs[i].path(),
                         &sealed_files[i],
                     )?;
@@ -240,7 +240,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
                 .map(
                     |((((cache_dir, staged_file), sealed_file), sector_id), piece_infos)| {
                         seal_pre_commit_phase1(
-                            porep_config,
+                            &porep_config,
                             cache_dir,
                             staged_file,
                             sealed_file,
@@ -262,7 +262,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
                         &sealed_files[i],
                         &phase1,
                     )?;
-                    seal_pre_commit_phase2(porep_config, phase1, &cache_dirs[i], &sealed_files[i])
+                    seal_pre_commit_phase2(&porep_config, phase1, &cache_dirs[i], &sealed_files[i])
                 })
                 .collect::<Result<Vec<_>, _>>()
         }

--- a/filecoin-proofs/benches/aggregation.rs
+++ b/filecoin-proofs/benches/aggregation.rs
@@ -45,7 +45,7 @@ fn bench_seal_inputs(c: &mut Criterion) {
                 b.iter(|| {
                     for _ in 0..iterations {
                         get_seal_inputs::<SectorShape2KiB>(
-                            config, comm_r, comm_d, prover_id, sector_id, ticket, seed,
+                            &config, comm_r, comm_d, prover_id, sector_id, ticket, seed,
                         )
                         .expect("get seal inputs failed");
                     }
@@ -78,7 +78,7 @@ fn bench_stacked_srs_key(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     black_box(
-                        get_stacked_srs_key::<SectorShape32GiB>(config, num_proofs_to_aggregate)
+                        get_stacked_srs_key::<SectorShape32GiB>(&config, num_proofs_to_aggregate)
                             .expect("get stacked srs key failed"),
                     )
                 })
@@ -110,7 +110,7 @@ fn bench_stacked_srs_verifier_key(c: &mut Criterion) {
                     b.iter(|| {
                         black_box(
                             get_stacked_srs_verifier_key::<SectorShape32GiB>(
-                                config,
+                                &config,
                                 num_proofs_to_aggregate,
                             )
                             .expect("get stacked srs key failed"),

--- a/filecoin-proofs/benches/preprocessing.rs
+++ b/filecoin-proofs/benches/preprocessing.rs
@@ -131,7 +131,7 @@ fn get_seal_inputs_benchmark(c: &mut Criterion) {
                 b.iter(|| {
                     for _ in 0..iterations {
                         get_seal_inputs::<SectorShape2KiB>(
-                            config, comm_r, comm_d, prover_id, sector_id, ticket, seed,
+                            &config, comm_r, comm_d, prover_id, sector_id, ticket, seed,
                         )
                         .unwrap();
                     }

--- a/filecoin-proofs/src/api/fake_seal.rs
+++ b/filecoin-proofs/src/api/fake_seal.rs
@@ -11,11 +11,11 @@ use storage_proofs_porep::stacked::StackedDrg;
 
 use crate::{
     constants::DefaultPieceHasher,
-    types::{Commitment, PaddedBytesAmount, PoRepConfig},
+    types::{Commitment, PoRepConfig},
 };
 
 pub fn fauxrep<R: AsRef<Path>, S: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: R,
     out_path: S,
 ) -> Result<Commitment> {
@@ -25,11 +25,11 @@ pub fn fauxrep<R: AsRef<Path>, S: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
 
 pub fn fauxrep_aux<R: Rng, S: AsRef<Path>, T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
     mut rng: &mut R,
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: S,
     out_path: T,
 ) -> Result<Commitment> {
-    let sector_bytes = PaddedBytesAmount::from(porep_config).0;
+    let sector_bytes = porep_config.padded_bytes_amount().0;
 
     {
         // Create a sector full of null bytes at `out_path`.

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -33,9 +33,8 @@ use crate::{
     parameters::public_params,
     pieces::{get_piece_alignment, sum_piece_bytes_with_alignment},
     types::{
-        Commitment, MerkleTreeTrait, PaddedBytesAmount, PieceInfo, PoRepConfig,
-        ProverId, SealPreCommitPhase1Output, Ticket, UnpaddedByteIndex,
-        UnpaddedBytesAmount,
+        Commitment, MerkleTreeTrait, PaddedBytesAmount, PieceInfo, PoRepConfig, ProverId,
+        SealPreCommitPhase1Output, Ticket, UnpaddedByteIndex, UnpaddedBytesAmount,
     },
 };
 

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -34,7 +34,7 @@ use crate::{
     pieces::{get_piece_alignment, sum_piece_bytes_with_alignment},
     types::{
         Commitment, MerkleTreeTrait, PaddedBytesAmount, PieceInfo, PoRepConfig,
-        PoRepProofPartitions, ProverId, SealPreCommitPhase1Output, Ticket, UnpaddedByteIndex,
+        ProverId, SealPreCommitPhase1Output, Ticket, UnpaddedByteIndex,
         UnpaddedBytesAmount,
     },
 };
@@ -76,7 +76,7 @@ pub use storage_proofs_update::constants::{hs, partition_count};
 /// * `num_bytes` - the number of bytes that we want to read.
 #[allow(clippy::too_many_arguments)]
 pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: T,
     sealed_path: T,
     output_path: T,
@@ -130,7 +130,7 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>, Tree: 'static + Merkle
 /// * `num_bytes` - the number of bytes that we want to read.
 #[allow(clippy::too_many_arguments)]
 pub fn unseal_range<P, R, W, Tree>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: P,
     mut sealed_sector: R,
     unsealed_output: W,
@@ -198,7 +198,7 @@ where
 /// * `num_bytes` - the number of bytes that we want to read.
 #[allow(clippy::too_many_arguments)]
 pub fn unseal_range_mapped<P, W, Tree>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: P,
     sealed_path: PathBuf,
     unsealed_output: W,
@@ -267,7 +267,7 @@ where
 /// * `num_bytes` - the number of bytes that we want to read.
 #[allow(clippy::too_many_arguments)]
 fn unseal_range_inner<P, W, Tree>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: P,
     data: &mut [u8],
     mut unsealed_output: W,
@@ -293,8 +293,8 @@ where
         ),
     );
     let pp = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -43,9 +43,9 @@ use crate::{
     parameters::setup_params,
     pieces::{self, verify_pieces},
     types::{
-        AggregateSnarkProof, Commitment, PieceInfo, PoRepConfig,
-        ProverId, SealCommitOutput, SealCommitPhase1Output,
-        SealPreCommitOutput, SealPreCommitPhase1Output, SectorSize, Ticket, BINARY_ARITY,
+        AggregateSnarkProof, Commitment, PieceInfo, PoRepConfig, ProverId, SealCommitOutput,
+        SealCommitPhase1Output, SealPreCommitOutput, SealPreCommitPhase1Output, SectorSize, Ticket,
+        BINARY_ARITY,
     },
 };
 
@@ -518,9 +518,8 @@ pub fn seal_commit_phase2<Tree: 'static + MerkleTreeTrait>(
 
     let proof = MultiProof::new(groth_proofs, &groth_params.pvk);
 
-    let mut buf = Vec::with_capacity(
-        SINGLE_PARTITION_PROOF_LEN * usize::from(porep_config.partitions),
-    );
+    let mut buf =
+        Vec::with_capacity(SINGLE_PARTITION_PROOF_LEN * usize::from(porep_config.partitions));
 
     proof.write(&mut buf)?;
 

--- a/filecoin-proofs/src/api/update.rs
+++ b/filecoin-proofs/src/api/update.rs
@@ -140,7 +140,7 @@ fn get_new_configs_from_t_aux_old<Tree: 'static + MerkleTreeTrait<Hasher = TreeR
 /// new_cache_path).
 #[allow(clippy::too_many_arguments)]
 pub fn encode_into<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     new_replica_path: &Path,
     new_cache_path: &Path,
     sector_key_path: &Path,
@@ -187,7 +187,7 @@ pub fn encode_into<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
         "Invalid all zero commitment (comm_r)"
     );
     ensure!(
-        verify_pieces(&comm_d, piece_infos, porep_config.into())?,
+        verify_pieces(&comm_d, piece_infos, porep_config.sector_size)?,
         "pieces and comm_d do not match"
     );
 
@@ -473,7 +473,7 @@ pub fn verify_partition_proofs<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHas
 pub fn generate_empty_sector_update_proof_with_vanilla<
     Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>,
 >(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     vanilla_proofs: Vec<PartitionProof<Tree>>,
     comm_r_old: Commitment,
     comm_r_new: Commitment,
@@ -521,7 +521,7 @@ pub fn generate_empty_sector_update_proof_with_vanilla<
 
 #[allow(clippy::too_many_arguments)]
 pub fn generate_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     comm_r_old: Commitment,
     comm_r_new: Commitment,
     comm_d_new: Commitment,
@@ -587,7 +587,7 @@ pub fn generate_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher
 }
 
 pub fn verify_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     proof_bytes: &[u8],
     comm_r_old: Commitment,
     comm_r_new: Commitment,

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -19,7 +19,7 @@ use storage_proofs_update::{
 use crate::{
     constants::{DefaultPieceHasher, PUBLISHED_SECTOR_SIZES},
     parameters::{public_params, window_post_public_params, winning_post_public_params},
-    types::{PaddedBytesAmount, PoRepConfig, PoRepProofPartitions, PoStConfig, PoStType},
+    types::{PoRepConfig, PoStConfig, PoStType},
 };
 
 type Bls12GrothParams = groth16::MappedParameters<Bls12>;
@@ -196,11 +196,11 @@ where
 }
 
 pub fn get_stacked_params<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
 ) -> Result<Arc<Bls12GrothParams>> {
     let public_params = public_params::<Tree>(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;
@@ -216,7 +216,7 @@ pub fn get_stacked_params<Tree: 'static + MerkleTreeTrait>(
     lookup_groth_params(
         format!(
             "STACKED[{}]",
-            usize::from(PaddedBytesAmount::from(porep_config))
+            usize::from(porep_config.padded_bytes_amount())
         ),
         parameters_generator,
     )
@@ -268,7 +268,7 @@ pub fn get_post_params<Tree: 'static + MerkleTreeTrait>(
 }
 
 pub fn get_empty_sector_update_params<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
 ) -> Result<Arc<Bls12GrothParams>> {
     let public_params: storage_proofs_update::PublicParams =
         PublicParams::from_sector_size(u64::from(porep_config.sector_size));
@@ -284,18 +284,18 @@ pub fn get_empty_sector_update_params<Tree: 'static + MerkleTreeTrait<Hasher = T
     lookup_groth_params(
         format!(
             "SECTOR-UPDATE[{}]",
-            usize::from(PaddedBytesAmount::from(porep_config))
+            usize::from(porep_config.padded_bytes_amount()),
         ),
         parameters_generator,
     )
 }
 
 pub fn get_stacked_verifying_key<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
 ) -> Result<Arc<Bls12PreparedVerifyingKey>> {
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;
@@ -311,7 +311,7 @@ pub fn get_stacked_verifying_key<Tree: 'static + MerkleTreeTrait>(
     lookup_verifying_key(
         format!(
             "STACKED[{}]",
-            usize::from(PaddedBytesAmount::from(porep_config))
+            usize::from(porep_config.padded_bytes_amount()),
         ),
         vk_generator,
     )
@@ -363,12 +363,12 @@ pub fn get_post_verifying_key<Tree: 'static + MerkleTreeTrait>(
 }
 
 pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     num_proofs_to_aggregate: usize,
 ) -> Result<Arc<Bls12ProverSRSKey>> {
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;
@@ -376,7 +376,7 @@ pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
     let srs_generator = || {
         trace!(
             "get_stacked_srs_key specializing STACKED[{}-{}]",
-            usize::from(PaddedBytesAmount::from(porep_config)),
+            usize::from(porep_config.padded_bytes_amount()),
             num_proofs_to_aggregate,
         );
         <StackedCompound<Tree, DefaultPieceHasher> as CompoundProof<
@@ -388,7 +388,7 @@ pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
     lookup_srs_key(
         format!(
             "STACKED[{}-{}]",
-            usize::from(PaddedBytesAmount::from(porep_config)),
+            usize::from(porep_config.padded_bytes_amount()),
             num_proofs_to_aggregate,
         ),
         srs_generator,
@@ -396,12 +396,12 @@ pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
 }
 
 pub fn get_stacked_srs_verifier_key<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     num_proofs_to_aggregate: usize,
 ) -> Result<Arc<Bls12VerifierSRSKey>> {
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;
@@ -409,7 +409,7 @@ pub fn get_stacked_srs_verifier_key<Tree: 'static + MerkleTreeTrait>(
     let srs_verifier_generator = || {
         trace!(
             "get_stacked_srs_verifier_key specializing STACKED[{}-{}]",
-            usize::from(PaddedBytesAmount::from(porep_config)),
+            usize::from(porep_config.padded_bytes_amount()),
             num_proofs_to_aggregate,
         );
         <StackedCompound<Tree, DefaultPieceHasher> as CompoundProof<
@@ -423,7 +423,7 @@ pub fn get_stacked_srs_verifier_key<Tree: 'static + MerkleTreeTrait>(
     lookup_srs_verifier_key(
         format!(
             "STACKED[{}-{}]",
-            usize::from(PaddedBytesAmount::from(porep_config)),
+            usize::from(porep_config.padded_bytes_amount()),
             num_proofs_to_aggregate,
         ),
         srs_verifier_generator,
@@ -433,7 +433,7 @@ pub fn get_stacked_srs_verifier_key<Tree: 'static + MerkleTreeTrait>(
 pub fn get_empty_sector_update_verifying_key<
     Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>,
 >(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
 ) -> Result<Arc<Bls12PreparedVerifyingKey>> {
     let public_params: storage_proofs_update::PublicParams =
         PublicParams::from_sector_size(u64::from(porep_config.sector_size));
@@ -449,7 +449,7 @@ pub fn get_empty_sector_update_verifying_key<
     lookup_verifying_key(
         format!(
             "SECTOR-UPDATE[{}]",
-            usize::from(PaddedBytesAmount::from(porep_config))
+            usize::from(porep_config.padded_bytes_amount()),
         ),
         vk_generator,
     )

--- a/filecoin-proofs/src/types/porep_config.rs
+++ b/filecoin-proofs/src/types/porep_config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use storage_proofs_core::{
-    api_version::ApiVersion,
+    api_version::{ApiFeature, ApiVersion},
     merkle::MerkleTreeTrait,
     parameter_cache::{
         parameter_cache_metadata_path, parameter_cache_params_path,
@@ -18,12 +18,13 @@ use crate::{
     POREP_PARTITIONS,
 };
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct PoRepConfig {
     pub sector_size: SectorSize,
     pub partitions: PoRepProofPartitions,
     pub porep_id: [u8; 32],
     pub api_version: ApiVersion,
+    pub api_features: Vec<ApiFeature>,
 }
 
 impl From<PoRepConfig> for PaddedBytesAmount {
@@ -68,7 +69,29 @@ impl PoRepConfig {
             ),
             porep_id,
             api_version,
+            api_features: vec![],
         }
+    }
+
+    #[inline]
+    pub fn with_feature(mut self, feat: ApiFeature) -> Self {
+        self.enable_feature(feat);
+        self
+    }
+
+    #[inline]
+    pub fn enable_feature(&mut self, feat: ApiFeature) {
+        self.api_features.push(feat);
+    }
+
+    #[inline]
+    pub fn padded_bytes_amount(&self) -> PaddedBytesAmount {
+        PaddedBytesAmount::from(self.sector_size)
+    }
+
+    #[inline]
+    pub fn unpadded_bytes_amount(&self) -> UnpaddedBytesAmount {
+        self.padded_bytes_amount().into()
     }
 
     /// Returns the cache identifier as used by `storage-proofs::parameter_cache`.

--- a/filecoin-proofs/src/types/sector_class.rs
+++ b/filecoin-proofs/src/types/sector_class.rs
@@ -23,6 +23,7 @@ impl From<SectorClass> for PoRepConfig {
             partitions,
             porep_id,
             api_version,
+            api_features: vec![],
         }
     }
 }

--- a/filecoin-proofs/src/types/sector_update_config.rs
+++ b/filecoin-proofs/src/types/sector_update_config.rs
@@ -12,7 +12,7 @@ pub struct SectorUpdateConfig {
 }
 
 impl SectorUpdateConfig {
-    pub fn from_porep_config(porep_config: PoRepConfig) -> Self {
+    pub fn from_porep_config(porep_config: &PoRepConfig) -> Self {
         let nodes_count = u64::from(porep_config.sector_size) as usize / NODE_SIZE;
 
         SectorUpdateConfig {

--- a/filecoin-proofs/tests/mod.rs
+++ b/filecoin-proofs/tests/mod.rs
@@ -26,7 +26,7 @@ fn test_verify_seal_fr32_validation() {
     // Test failure for invalid comm_r conversion.
     {
         let result = verify_seal::<DefaultOctLCTree>(
-            PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
+            &PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
             not_convertible_to_fr_bytes,
             convertible_to_fr_bytes,
             [0; 32],
@@ -54,7 +54,7 @@ fn test_verify_seal_fr32_validation() {
     // Test failure for invalid comm_d conversion.
     {
         let result = verify_seal::<DefaultOctLCTree>(
-            PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
+            &PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
             convertible_to_fr_bytes,
             not_convertible_to_fr_bytes,
             [0; 32],
@@ -86,7 +86,7 @@ fn test_verify_seal_fr32_validation() {
         assert!(out.is_ok(), "tripwire");
 
         let result = verify_seal::<DefaultOctLCTree>(
-            PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
+            &PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
             non_zero_commitment_fr_bytes,
             non_zero_commitment_fr_bytes,
             [0; 32],

--- a/storage-proofs-core/src/api_version.rs
+++ b/storage-proofs-core/src/api_version.rs
@@ -38,19 +38,13 @@ impl ApiVersion {
         self >= &feat.first_supported_version()
             && feat
                 .last_supported_version()
-                .map(|v| self <= &v)
+                .map(|v_last| self <= &v_last)
                 .unwrap_or(true)
     }
 
     #[inline]
     pub fn supports_features(&self, feats: &[ApiFeature]) -> bool {
-        feats.iter().all(|feat| {
-            self >= &feat.first_supported_version()
-                && feat
-                    .last_supported_version()
-                    .map(|v_last| self <= &v_last)
-                    .unwrap_or(true)
-        })
+        feats.iter().all(|feat| self.supports_feature(feat))
     }
 }
 
@@ -76,7 +70,7 @@ impl FromStr for ApiVersion {
             (1, 0, 0) => Ok(ApiVersion::V1_0_0),
             (1, 1, 0) => Ok(ApiVersion::V1_1_0),
             (1, 2, 0) => Ok(ApiVersion::V1_2_0),
-            (1, 1, _) | (1, 0, _) => Err(format_err!(
+            (1, 0, _) | (1, 1, _) | (1, 2, _) => Err(format_err!(
                 "Could not parse API Version from string (patch)"
             )),
             (1, _, _) => Err(format_err!(

--- a/storage-proofs-core/src/api_version.rs
+++ b/storage-proofs-core/src/api_version.rs
@@ -5,15 +5,20 @@ use std::str::FromStr;
 use anyhow::{format_err, Error, Result};
 use semver::Version;
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub enum ApiVersion {
     V1_0_0,
     V1_1_0,
     V1_2_0,
 }
 
+impl Ord for ApiVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_semver().cmp(&other.as_semver())
+    }
+}
+
 impl PartialOrd for ApiVersion {
-    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.as_semver().cmp(&other.as_semver()))
     }
@@ -30,15 +35,21 @@ impl ApiVersion {
 
     #[inline]
     pub fn supports_feature(&self, feat: &ApiFeature) -> bool {
-        self >= &feat.first_supported_version() &&
-            feat.last_supported_version().map(|v| self <= &v).unwrap_or(true)
+        self >= &feat.first_supported_version()
+            && feat
+                .last_supported_version()
+                .map(|v| self <= &v)
+                .unwrap_or(true)
     }
 
     #[inline]
     pub fn supports_features(&self, feats: &[ApiFeature]) -> bool {
         feats.iter().all(|feat| {
-            self >= &feat.first_supported_version() &&
-                feat.last_supported_version().map(|v_last| self <= &v_last).unwrap_or(true)
+            self >= &feat.first_supported_version()
+                && feat
+                    .last_supported_version()
+                    .map(|v_last| self <= &v_last)
+                    .unwrap_or(true)
         })
     }
 }

--- a/storage-proofs-core/src/drgraph.rs
+++ b/storage-proofs-core/src/drgraph.rs
@@ -165,7 +165,7 @@ impl<H: Hasher> Graph<H> for BucketGraph<H> {
 
                 let (predecessor_index, other_drg_parents) = match self.api_version {
                     ApiVersion::V1_0_0 => (m_prime, &mut parents[..]),
-                    ApiVersion::V1_1_0 => (0, &mut parents[1..]),
+                    _ => (0, &mut parents[1..]),
                 };
 
                 for parent in other_drg_parents.iter_mut().take(m_prime) {
@@ -337,7 +337,7 @@ mod tests {
                             "immediate predecessor was not last DRG parent"
                         );
                     }
-                    ApiVersion::V1_1_0 => {
+                    _ => {
                         assert_eq!(
                             i - 1,
                             pa1[0] as usize,

--- a/storage-proofs-porep/src/stacked/vanilla/graph.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/graph.rs
@@ -374,7 +374,7 @@ where
 
         match self.api_version {
             ApiVersion::V1_0_0 => transformed as u32 / self.expansion_degree as u32,
-            ApiVersion::V1_1_0 => u32::try_from(transformed as u64 / self.expansion_degree as u64)
+            _ => u32::try_from(transformed as u64 / self.expansion_degree as u64)
                 .expect("invalid transformation"),
         }
 
@@ -516,6 +516,9 @@ mod tests {
 
         test_pathology_aux(porep_id(8), sector32_nodes, ApiVersion::V1_1_0);
         test_pathology_aux(porep_id(9), sector64_nodes, ApiVersion::V1_1_0);
+
+        test_pathology_aux(porep_id(10), sector32_nodes, ApiVersion::V1_2_0);
+        test_pathology_aux(porep_id(11), sector64_nodes, ApiVersion::V1_2_0);
     }
 
     fn test_pathology_aux(porep_id: PoRepID, nodes: u32, api_version: ApiVersion) {
@@ -529,10 +532,7 @@ mod tests {
         // is sound.
         let test_n = 1_000;
 
-        let expect_pathological = match api_version {
-            ApiVersion::V1_0_0 => true,
-            ApiVersion::V1_1_0 => false,
-        };
+        let expect_pathological = api_version == ApiVersion::V1_0_0;
 
         let graph = StackedBucketGraph::<PoseidonHasher>::new_stacked(
             nodes as usize,


### PR DESCRIPTION
- Implements `PartialOrd` and `Ord` for `ApiVersion` so that features can be constrained to a range of versions
- Adds `enum ApiFeatures` where each variant has an associated minimum and maximum allowed `ApiVersion`
    - Added one variant `ApiFeatures::SynthPorep` so that the `enum` isn't empty 
- Adds `PoRepConfig` features vector `PoRepConfig { api_features: Vec<ApiFeature> }`
    - This makes `PoRepConfig` not-`Copy` due to the `Vec`; its copies were changed to borrows and getters, e.g. changed `UnpaddedBytesAmount::from(porep_config)` to `porep_config.unpadded_bytes_amount()`.