### PR TITLE
feat(storage-proofs-post): add grindability tests

### DIFF
--- a/storage-proofs-post/tests/fallback_vanilla.rs
+++ b/storage-proofs-post/tests/fallback_vanilla.rs
@@ -18,96 +18,112 @@ use tempfile::tempdir;
 fn test_fallback_post_poseidon_single_partition_base_8() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 5, 1, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 5, 1, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_single_partition_smaller_base_8() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 5, 1, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 5, 1, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_base_8() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_smaller_base_8() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_single_partition_sub_8_4() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 5, 1, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 5, 1, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_single_partition_smaller_sub_8_4() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 5, 1, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 5, 1, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_sub_8_4() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(4, 2, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(4, 2, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(4, 2, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_sub_8_8() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(4, 2, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(4, 2, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(4, 2, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_smaller_sub_8_4() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 3, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_smaller_sub_8_8() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(5, 3, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_single_partition_top_8_4_2() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 5, 1, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 5, 1, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_single_partition_top_8_8_2() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 5, 1, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 5, 1, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_single_partition_smaller_top_8_4_2() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 5, 1, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 5, 1, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_top_8_4_2() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(4, 2, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(4, 2, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(4, 2, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_smaller_top_8_4_2() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 3, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_fallback_post_poseidon_two_partitions_smaller_top_8_8_2() {
     test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 3, 2, ApiVersion::V1_0_0);
     test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 fn test_fallback_post<Tree: MerkleTreeTrait>(
@@ -123,7 +139,7 @@ fn test_fallback_post<Tree: MerkleTreeTrait>(
     let leaves = 64 * get_base_tree_count::<Tree>();
     let sector_size = leaves * NODE_SIZE;
 
-    let pub_params = fallback::PublicParams {
+    let mut pub_params = fallback::PublicParams {
         sector_size: sector_size as u64,
         challenge_count: 10,
         sector_count,
@@ -183,102 +199,129 @@ fn test_fallback_post<Tree: MerkleTreeTrait>(
         .expect("verification failed");
 
     assert!(is_valid);
+
+    // Challenge generation algorithm changed in version `ApiVersion::V1_2_0`.
+    let mismatched_challenge_gen_version = match pub_params.api_version {
+        ApiVersion::V1_0_0 | ApiVersion::V1_1_0 => ApiVersion::V1_2_0,
+        _ => ApiVersion::V1_1_0,
+    };
+    pub_params.api_version = mismatched_challenge_gen_version;
+    assert!(
+        !FallbackPoSt::<Tree>::verify_all_partitions(&pub_params, &pub_inputs, &proof)
+            .expect("verification failed")
+    );
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_single_partition_base_8() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 5, 1, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 5, 1, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_single_partition_smaller_base_8() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 5, 1, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 5, 1, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(3, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_base_8() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(4, 2, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_smaller_base_8() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U0, U0>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_single_partition_sub_8_4() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 5, 1, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 5, 1, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_single_partition_smaller_sub_8_4() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 5, 1, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 5, 1, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(3, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_sub_8_4() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(4, 2, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(4, 2, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(4, 2, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_sub_8_8() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(4, 2, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(4, 2, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(4, 2, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_smaller_sub_8_4() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 3, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U0>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_smaller_sub_8_8() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(5, 3, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U0>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_single_partition_top_8_4_2() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 5, 1, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 5, 1, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_single_partition_top_8_8_2() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 5, 1, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 5, 1, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_single_partition_smaller_top_8_4_2() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 5, 1, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 5, 1, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(3, 5, 1, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_top_8_4_2() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(4, 2, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(4, 2, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(4, 2, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_smaller_top_8_4_2() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 3, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U4, U2>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 #[test]
 fn test_invalid_fallback_post_poseidon_two_partitions_smaller_top_8_8_2() {
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 3, 2, ApiVersion::V1_0_0);
     test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 3, 2, ApiVersion::V1_1_0);
+    test_invalid_fallback_post::<LCTree<PoseidonHasher, U8, U8, U2>>(5, 3, 2, ApiVersion::V1_2_0);
 }
 
 fn test_invalid_fallback_post<Tree: MerkleTreeTrait>(


### PR DESCRIPTION
- Adds Fallback-PoSt tests for version `ApiVersion::V1_2_0`.
- Tests that the challenge generation algorithm in `ApiVersion::V1_2_0` is incompatible with previous versions.