### PR TITLE
feat: add API features

### DIFF
--- a/fil-proofs-param/src/bin/paramcache.rs
+++ b/fil-proofs-param/src/bin/paramcache.rs
@@ -9,7 +9,7 @@ use filecoin_proofs::{
         WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT,
     },
     parameters::{public_params, window_post_public_params, winning_post_public_params},
-    types::{PaddedBytesAmount, PoRepConfig, PoRepProofPartitions, PoStConfig, SectorSize},
+    types::{PoRepConfig, PoStConfig, SectorSize},
     with_shape, PoStType,
 };
 use humansize::{file_size_opts, FileSize};
@@ -33,8 +33,8 @@ fn cache_porep_params<Tree: 'static + MerkleTreeTrait>(porep_config: PoRepConfig
     info!("generating PoRep groth params");
 
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )

--- a/fil-proofs-tooling/src/bin/benchy/prodbench.rs
+++ b/fil-proofs-tooling/src/bin/benchy/prodbench.rs
@@ -11,9 +11,8 @@ use fil_proofs_tooling::{
 use filecoin_hashers::sha256::Sha256Hasher;
 use filecoin_proofs::{
     clear_cache, parameters::public_params, seal_commit_phase1, seal_commit_phase2,
-    validate_cache_for_commit, DefaultOctLCTree, DefaultOctTree, PaddedBytesAmount, PoRepConfig,
-    PoRepProofPartitions, SectorSize, DRG_DEGREE, EXP_DEGREE, LAYERS, POREP_MINIMUM_CHALLENGES,
-    POREP_PARTITIONS,
+    validate_cache_for_commit, DefaultOctLCTree, DefaultOctTree, PoRepConfig, PoRepProofPartitions,
+    SectorSize, DRG_DEGREE, EXP_DEGREE, LAYERS, POREP_MINIMUM_CHALLENGES, POREP_PARTITIONS,
 };
 use log::info;
 use rand::SeedableRng;
@@ -217,7 +216,7 @@ pub fn run(
                 )?;
 
                 let phase1_output = seal_commit_phase1::<_, DefaultOctLCTree>(
-                    cfg,
+                    &cfg,
                     &replica_info.private_replica_info.cache_dir_path(),
                     &replica_info.private_replica_info.replica_path(),
                     PROVER_ID,
@@ -232,7 +231,7 @@ pub fn run(
                     replica_info.private_replica_info.cache_dir_path(),
                 )?;
 
-                seal_commit_phase2(cfg, phase1_output, PROVER_ID, *sector_id)
+                seal_commit_phase2(&cfg, phase1_output, PROVER_ID, *sector_id)
             })
             .expect("failed to prove sector");
 
@@ -322,8 +321,8 @@ fn generate_params(i: &ProdbenchInputs) {
 
 fn cache_porep_params(porep_config: PoRepConfig) {
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )

--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -154,7 +154,7 @@ fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
 
         let seal_pre_commit_phase1_measurement: FuncMeasurement<SealPreCommitPhase1Output<Tree>> = measure(|| {
             seal_pre_commit_phase1::<_, _, _, Tree>(
-                porep_config,
+                &porep_config,
                 cache_dir.clone(),
                 staged_file_path.clone(),
                 sealed_file_path.clone(),
@@ -257,7 +257,7 @@ fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
         let seal_pre_commit_phase2_measurement: FuncMeasurement<SealPreCommitOutput> =
             measure(|| {
                 seal_pre_commit_phase2::<_, _, Tree>(
-                    porep_config,
+                    &porep_config,
                     precommit_phase1_output,
                     cache_dir.clone(),
                     sealed_file_path.clone(),
@@ -408,7 +408,7 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
 
         let seal_commit_phase1_measurement = measure(|| {
             seal_commit_phase1::<_, Tree>(
-                porep_config,
+                &porep_config,
                 cache_dir.clone(),
                 sealed_file_path.clone(),
                 PROVER_ID,
@@ -469,7 +469,7 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
         };
 
         let seal_commit_phase2_measurement = measure(|| {
-            seal_commit_phase2::<Tree>(porep_config, commit_phase1_output, PROVER_ID, sector_id)
+            seal_commit_phase2::<Tree>(&porep_config, commit_phase1_output, PROVER_ID, sector_id)
         })
         .expect("failed in seal_commit_phase2");
 

--- a/fil-proofs-tooling/src/bin/circuitinfo/main.rs
+++ b/fil-proofs-tooling/src/bin/circuitinfo/main.rs
@@ -5,10 +5,9 @@ use blstrs::Scalar as Fr;
 use dialoguer::{theme::ColorfulTheme, MultiSelect};
 use filecoin_proofs::{
     parameters::{public_params, window_post_public_params, winning_post_public_params},
-    with_shape, DefaultPieceHasher, PaddedBytesAmount, PoRepConfig, PoRepProofPartitions,
-    PoStConfig, PoStType, SectorSize, POREP_PARTITIONS, PUBLISHED_SECTOR_SIZES,
-    WINDOW_POST_CHALLENGE_COUNT, WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT,
-    WINNING_POST_SECTOR_COUNT,
+    with_shape, DefaultPieceHasher, PoRepConfig, PoRepProofPartitions, PoStConfig, PoStType,
+    SectorSize, POREP_PARTITIONS, PUBLISHED_SECTOR_SIZES, WINDOW_POST_CHALLENGE_COUNT,
+    WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT,
 };
 use humansize::{file_size_opts, FileSize};
 use log::{info, warn};
@@ -40,8 +39,8 @@ fn get_porep_info<Tree: 'static + MerkleTreeTrait>(porep_config: PoRepConfig) ->
     info!("PoRep info");
 
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )

--- a/fil-proofs-tooling/src/shared.rs
+++ b/fil-proofs-tooling/src/shared.rs
@@ -220,7 +220,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
                     )?;
                     let comm_r = fauxrep_aux::<_, _, _, Tree>(
                         &mut rng,
-                        porep_config,
+                        &porep_config,
                         &cache_dirs[i].path(),
                         &sealed_files[i],
                     )?;
@@ -240,7 +240,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
                 .map(
                     |((((cache_dir, staged_file), sealed_file), sector_id), piece_infos)| {
                         seal_pre_commit_phase1(
-                            porep_config,
+                            &porep_config,
                             cache_dir,
                             staged_file,
                             sealed_file,
@@ -262,7 +262,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
                         &sealed_files[i],
                         &phase1,
                     )?;
-                    seal_pre_commit_phase2(porep_config, phase1, &cache_dirs[i], &sealed_files[i])
+                    seal_pre_commit_phase2(&porep_config, phase1, &cache_dirs[i], &sealed_files[i])
                 })
                 .collect::<Result<Vec<_>, _>>()
         }

--- a/filecoin-proofs/benches/aggregation.rs
+++ b/filecoin-proofs/benches/aggregation.rs
@@ -45,7 +45,7 @@ fn bench_seal_inputs(c: &mut Criterion) {
                 b.iter(|| {
                     for _ in 0..iterations {
                         get_seal_inputs::<SectorShape2KiB>(
-                            config, comm_r, comm_d, prover_id, sector_id, ticket, seed,
+                            &config, comm_r, comm_d, prover_id, sector_id, ticket, seed,
                         )
                         .expect("get seal inputs failed");
                     }
@@ -78,7 +78,7 @@ fn bench_stacked_srs_key(c: &mut Criterion) {
             |b| {
                 b.iter(|| {
                     black_box(
-                        get_stacked_srs_key::<SectorShape32GiB>(config, num_proofs_to_aggregate)
+                        get_stacked_srs_key::<SectorShape32GiB>(&config, num_proofs_to_aggregate)
                             .expect("get stacked srs key failed"),
                     )
                 })
@@ -110,7 +110,7 @@ fn bench_stacked_srs_verifier_key(c: &mut Criterion) {
                     b.iter(|| {
                         black_box(
                             get_stacked_srs_verifier_key::<SectorShape32GiB>(
-                                config,
+                                &config,
                                 num_proofs_to_aggregate,
                             )
                             .expect("get stacked srs key failed"),

--- a/filecoin-proofs/benches/preprocessing.rs
+++ b/filecoin-proofs/benches/preprocessing.rs
@@ -131,7 +131,7 @@ fn get_seal_inputs_benchmark(c: &mut Criterion) {
                 b.iter(|| {
                     for _ in 0..iterations {
                         get_seal_inputs::<SectorShape2KiB>(
-                            config, comm_r, comm_d, prover_id, sector_id, ticket, seed,
+                            &config, comm_r, comm_d, prover_id, sector_id, ticket, seed,
                         )
                         .unwrap();
                     }

--- a/filecoin-proofs/src/api/fake_seal.rs
+++ b/filecoin-proofs/src/api/fake_seal.rs
@@ -11,11 +11,11 @@ use storage_proofs_porep::stacked::StackedDrg;
 
 use crate::{
     constants::DefaultPieceHasher,
-    types::{Commitment, PaddedBytesAmount, PoRepConfig},
+    types::{Commitment, PoRepConfig},
 };
 
 pub fn fauxrep<R: AsRef<Path>, S: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: R,
     out_path: S,
 ) -> Result<Commitment> {
@@ -25,11 +25,11 @@ pub fn fauxrep<R: AsRef<Path>, S: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
 
 pub fn fauxrep_aux<R: Rng, S: AsRef<Path>, T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
     mut rng: &mut R,
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: S,
     out_path: T,
 ) -> Result<Commitment> {
-    let sector_bytes = PaddedBytesAmount::from(porep_config).0;
+    let sector_bytes = porep_config.padded_bytes_amount().0;
 
     {
         // Create a sector full of null bytes at `out_path`.

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -33,9 +33,8 @@ use crate::{
     parameters::public_params,
     pieces::{get_piece_alignment, sum_piece_bytes_with_alignment},
     types::{
-        Commitment, MerkleTreeTrait, PaddedBytesAmount, PieceInfo, PoRepConfig,
-        PoRepProofPartitions, ProverId, SealPreCommitPhase1Output, Ticket, UnpaddedByteIndex,
-        UnpaddedBytesAmount,
+        Commitment, MerkleTreeTrait, PaddedBytesAmount, PieceInfo, PoRepConfig, ProverId,
+        SealPreCommitPhase1Output, Ticket, UnpaddedByteIndex, UnpaddedBytesAmount,
     },
 };
 
@@ -76,7 +75,7 @@ pub use storage_proofs_update::constants::{hs, partition_count};
 /// * `num_bytes` - the number of bytes that we want to read.
 #[allow(clippy::too_many_arguments)]
 pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: T,
     sealed_path: T,
     output_path: T,
@@ -130,7 +129,7 @@ pub fn get_unsealed_range<T: Into<PathBuf> + AsRef<Path>, Tree: 'static + Merkle
 /// * `num_bytes` - the number of bytes that we want to read.
 #[allow(clippy::too_many_arguments)]
 pub fn unseal_range<P, R, W, Tree>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: P,
     mut sealed_sector: R,
     unsealed_output: W,
@@ -198,7 +197,7 @@ where
 /// * `num_bytes` - the number of bytes that we want to read.
 #[allow(clippy::too_many_arguments)]
 pub fn unseal_range_mapped<P, W, Tree>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: P,
     sealed_path: PathBuf,
     unsealed_output: W,
@@ -267,7 +266,7 @@ where
 /// * `num_bytes` - the number of bytes that we want to read.
 #[allow(clippy::too_many_arguments)]
 fn unseal_range_inner<P, W, Tree>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: P,
     data: &mut [u8],
     mut unsealed_output: W,
@@ -293,8 +292,8 @@ where
         ),
     );
     let pp = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;

--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -43,15 +43,15 @@ use crate::{
     parameters::setup_params,
     pieces::{self, verify_pieces},
     types::{
-        AggregateSnarkProof, Commitment, PaddedBytesAmount, PieceInfo, PoRepConfig,
-        PoRepProofPartitions, ProverId, SealCommitOutput, SealCommitPhase1Output,
-        SealPreCommitOutput, SealPreCommitPhase1Output, SectorSize, Ticket, BINARY_ARITY,
+        AggregateSnarkProof, Commitment, PieceInfo, PoRepConfig, ProverId, SealCommitOutput,
+        SealCommitPhase1Output, SealPreCommitOutput, SealPreCommitPhase1Output, SectorSize, Ticket,
+        BINARY_ARITY,
     },
 };
 
 #[allow(clippy::too_many_arguments)]
 pub fn seal_pre_commit_phase1<R, S, T, Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: R,
     in_path: S,
     out_path: T,
@@ -89,7 +89,7 @@ where
         "cache_path must be a directory"
     );
 
-    let sector_bytes = usize::from(PaddedBytesAmount::from(porep_config));
+    let sector_bytes = usize::from(porep_config.padded_bytes_amount());
     fs::metadata(&in_path)
         .with_context(|| format!("could not read in_path={:?})", in_path.as_ref().display()))?;
 
@@ -127,12 +127,12 @@ where
 
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(
-            PaddedBytesAmount::from(porep_config),
-            usize::from(PoRepProofPartitions::from(porep_config)),
+            porep_config.padded_bytes_amount(),
+            usize::from(porep_config.partitions),
             porep_config.porep_id,
             porep_config.api_version,
         )?,
-        partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
+        partitions: Some(usize::from(porep_config.partitions)),
         priority: false,
     };
 
@@ -182,7 +182,7 @@ where
     trace!("verifying pieces");
 
     ensure!(
-        verify_pieces(&comm_d, piece_infos, porep_config.into())?,
+        verify_pieces(&comm_d, piece_infos, porep_config.sector_size)?,
         "pieces and comm_d do not match"
     );
 
@@ -212,7 +212,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 pub fn seal_pre_commit_phase2<R, S, Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     phase1_output: SealPreCommitPhase1Output<Tree>,
     cache_path: S,
     replica_path: R,
@@ -286,12 +286,12 @@ where
 
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(
-            PaddedBytesAmount::from(porep_config),
-            usize::from(PoRepProofPartitions::from(porep_config)),
+            porep_config.padded_bytes_amount(),
+            usize::from(porep_config.partitions),
             porep_config.porep_id,
             porep_config.api_version,
         )?,
-        partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
+        partitions: Some(usize::from(porep_config.partitions)),
         priority: false,
     };
 
@@ -336,7 +336,7 @@ where
 
 #[allow(clippy::too_many_arguments)]
 pub fn seal_commit_phase1<T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     cache_path: T,
     replica_path: T,
     prover_id: ProverId,
@@ -363,7 +363,7 @@ pub fn seal_commit_phase1<T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
     ensure!(comm_d != [0; 32], "Invalid all zero commitment (comm_d)");
     ensure!(comm_r != [0; 32], "Invalid all zero commitment (comm_r)");
     ensure!(
-        verify_pieces(&comm_d, piece_infos, porep_config.into())?,
+        verify_pieces(&comm_d, piece_infos, porep_config.sector_size)?,
         "pieces and comm_d do not match"
     );
 
@@ -421,12 +421,12 @@ pub fn seal_commit_phase1<T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
 
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(
-            PaddedBytesAmount::from(porep_config),
-            usize::from(PoRepProofPartitions::from(porep_config)),
+            porep_config.padded_bytes_amount(),
+            usize::from(porep_config.partitions),
             porep_config.porep_id,
             porep_config.api_version,
         )?,
-        partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
+        partitions: Some(usize::from(porep_config.partitions)),
         priority: false,
     };
 
@@ -464,7 +464,7 @@ pub fn seal_commit_phase1<T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
 
 #[allow(clippy::too_many_arguments)]
 pub fn seal_commit_phase2<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     phase1_output: SealCommitPhase1Output<Tree>,
     prover_id: ProverId,
     sector_id: SectorId,
@@ -500,17 +500,17 @@ pub fn seal_commit_phase2<Tree: 'static + MerkleTreeTrait>(
 
     trace!(
         "got groth params ({}) while sealing",
-        u64::from(PaddedBytesAmount::from(porep_config))
+        u64::from(porep_config.padded_bytes_amount())
     );
 
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(
-            PaddedBytesAmount::from(porep_config),
-            usize::from(PoRepProofPartitions::from(porep_config)),
+            porep_config.padded_bytes_amount(),
+            usize::from(porep_config.partitions),
             porep_config.porep_id,
             porep_config.api_version,
         )?,
-        partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
+        partitions: Some(usize::from(porep_config.partitions)),
         priority: false,
     };
 
@@ -531,9 +531,8 @@ pub fn seal_commit_phase2<Tree: 'static + MerkleTreeTrait>(
 
     let proof = MultiProof::new(groth_proofs, &groth_params.pvk);
 
-    let mut buf = Vec::with_capacity(
-        SINGLE_PARTITION_PROOF_LEN * usize::from(PoRepProofPartitions::from(porep_config)),
-    );
+    let mut buf =
+        Vec::with_capacity(SINGLE_PARTITION_PROOF_LEN * usize::from(porep_config.partitions));
 
     proof.write(&mut buf)?;
 
@@ -574,7 +573,7 @@ pub fn seal_commit_phase2<Tree: 'static + MerkleTreeTrait>(
 /// * `ticket` - the ticket used to generate this sector's replica-id.
 /// * `seed` - the seed used to derive the porep challenges.
 pub fn get_seal_inputs<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     comm_r: Commitment,
     comm_d: Commitment,
     prover_id: ProverId,
@@ -610,12 +609,12 @@ pub fn get_seal_inputs<Tree: 'static + MerkleTreeTrait>(
 
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(
-            PaddedBytesAmount::from(porep_config),
-            usize::from(PoRepProofPartitions::from(porep_config)),
+            porep_config.padded_bytes_amount(),
+            usize::from(porep_config.partitions),
             porep_config.porep_id,
             porep_config.api_version,
         )?,
-        partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
+        partitions: Some(usize::from(porep_config.partitions)),
         priority: false,
     };
 
@@ -733,7 +732,7 @@ fn pad_inputs_to_target(
 /// * `seeds` - an ordered list of seeds used to derive the PoRep challenges.
 /// * `commit_outputs` - an ordered list of seal proof outputs returned from 'seal_commit_phase2'.
 pub fn aggregate_seal_commit_proofs<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     comm_rs: &[[u8; 32]],
     seeds: &[[u8; 32]],
     commit_outputs: &[SealCommitOutput],
@@ -746,7 +745,7 @@ pub fn aggregate_seal_commit_proofs<Tree: 'static + MerkleTreeTrait>(
         "cannot aggregate with empty outputs"
     );
 
-    let partitions = usize::from(PoRepProofPartitions::from(porep_config));
+    let partitions = usize::from(porep_config.partitions);
     let verifying_key = get_stacked_verifying_key::<Tree>(porep_config)?;
     let mut proofs: Vec<_> =
         commit_outputs
@@ -819,7 +818,7 @@ pub fn aggregate_seal_commit_proofs<Tree: 'static + MerkleTreeTrait>(
 /// * `commit_inputs` - a flattened/combined and ordered list of all public inputs, which must match
 ///    the ordering of the seal proofs when aggregated.
 pub fn verify_aggregate_seal_commit_proofs<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     aggregate_proof_bytes: AggregateSnarkProof,
     comm_rs: &[[u8; 32]],
     seeds: &[[u8; 32]],
@@ -932,7 +931,7 @@ pub fn compute_comm_d(sector_size: SectorSize, piece_infos: &[PieceInfo]) -> Res
 /// * `proof_vec` - the porep circuit proof serialized into a vector of bytes.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     comm_r_in: Commitment,
     comm_d_in: Commitment,
     prover_id: ProverId,
@@ -960,12 +959,12 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
 
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(
-            PaddedBytesAmount::from(porep_config),
-            usize::from(PoRepProofPartitions::from(porep_config)),
+            porep_config.padded_bytes_amount(),
+            usize::from(porep_config.partitions),
             porep_config.porep_id,
             porep_config.api_version,
         )?,
-        partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
+        partitions: Some(usize::from(porep_config.partitions)),
         priority: false,
     };
 
@@ -983,7 +982,7 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
         };
 
     let result = {
-        let sector_bytes = PaddedBytesAmount::from(porep_config);
+        let sector_bytes = porep_config.padded_bytes_amount();
         let verifying_key = get_stacked_verifying_key::<Tree>(porep_config)?;
 
         trace!(
@@ -992,7 +991,7 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
         );
 
         let proof = MultiProof::new_from_reader(
-            Some(usize::from(PoRepProofPartitions::from(porep_config))),
+            Some(usize::from(porep_config.partitions)),
             proof_vec,
             &verifying_key,
         )?;
@@ -1003,7 +1002,7 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
             &proof,
             &ChallengeRequirements {
                 minimum_challenges: POREP_MINIMUM_CHALLENGES
-                    .from_sector_size(u64::from(SectorSize::from(porep_config))),
+                    .from_sector_size(u64::from(porep_config.sector_size)),
             },
         )
     };
@@ -1026,7 +1025,7 @@ pub fn verify_seal<Tree: 'static + MerkleTreeTrait>(
 /// * `[proof_vecs]` - list of porep circuit proofs serialized into a vector of bytes.
 #[allow(clippy::too_many_arguments)]
 pub fn verify_batch_seal<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     comm_r_ins: &[Commitment],
     comm_d_ins: &[Commitment],
     prover_ids: &[ProverId],
@@ -1062,7 +1061,7 @@ pub fn verify_batch_seal<Tree: 'static + MerkleTreeTrait>(
         ensure!(!proofs.is_empty(), "Invalid proof (empty bytes) found");
     }
 
-    let sector_bytes = PaddedBytesAmount::from(porep_config);
+    let sector_bytes = porep_config.padded_bytes_amount();
 
     let verifying_key = get_stacked_verifying_key::<Tree>(porep_config)?;
     trace!(
@@ -1072,12 +1071,12 @@ pub fn verify_batch_seal<Tree: 'static + MerkleTreeTrait>(
 
     let compound_setup_params = compound_proof::SetupParams {
         vanilla_params: setup_params(
-            PaddedBytesAmount::from(porep_config),
-            usize::from(PoRepProofPartitions::from(porep_config)),
+            porep_config.padded_bytes_amount(),
+            usize::from(porep_config.partitions),
             porep_config.porep_id,
             porep_config.api_version,
         )?,
-        partitions: Some(usize::from(PoRepProofPartitions::from(porep_config))),
+        partitions: Some(usize::from(porep_config.partitions)),
         priority: false,
     };
 
@@ -1111,7 +1110,7 @@ pub fn verify_batch_seal<Tree: 'static + MerkleTreeTrait>(
             k: None,
         });
         proofs.push(MultiProof::new_from_reader(
-            Some(usize::from(PoRepProofPartitions::from(porep_config))),
+            Some(usize::from(porep_config.partitions)),
             proof_vecs[i],
             &verifying_key,
         )?);
@@ -1123,7 +1122,7 @@ pub fn verify_batch_seal<Tree: 'static + MerkleTreeTrait>(
         &proofs,
         &ChallengeRequirements {
             minimum_challenges: POREP_MINIMUM_CHALLENGES
-                .from_sector_size(u64::from(SectorSize::from(porep_config))),
+                .from_sector_size(u64::from(porep_config.sector_size)),
         },
     )
     .map_err(Into::into);

--- a/filecoin-proofs/src/api/update.rs
+++ b/filecoin-proofs/src/api/update.rs
@@ -140,7 +140,7 @@ fn get_new_configs_from_t_aux_old<Tree: 'static + MerkleTreeTrait<Hasher = TreeR
 /// new_cache_path).
 #[allow(clippy::too_many_arguments)]
 pub fn encode_into<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     new_replica_path: &Path,
     new_cache_path: &Path,
     sector_key_path: &Path,
@@ -187,7 +187,7 @@ pub fn encode_into<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
         "Invalid all zero commitment (comm_r)"
     );
     ensure!(
-        verify_pieces(&comm_d, piece_infos, porep_config.into())?,
+        verify_pieces(&comm_d, piece_infos, porep_config.sector_size)?,
         "pieces and comm_d do not match"
     );
 
@@ -473,7 +473,7 @@ pub fn verify_partition_proofs<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHas
 pub fn generate_empty_sector_update_proof_with_vanilla<
     Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>,
 >(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     vanilla_proofs: Vec<PartitionProof<Tree>>,
     comm_r_old: Commitment,
     comm_r_new: Commitment,
@@ -521,7 +521,7 @@ pub fn generate_empty_sector_update_proof_with_vanilla<
 
 #[allow(clippy::too_many_arguments)]
 pub fn generate_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     comm_r_old: Commitment,
     comm_r_new: Commitment,
     comm_d_new: Commitment,
@@ -587,7 +587,7 @@ pub fn generate_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher
 }
 
 pub fn verify_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     proof_bytes: &[u8],
     comm_r_old: Commitment,
     comm_r_new: Commitment,

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -19,7 +19,7 @@ use storage_proofs_update::{
 use crate::{
     constants::{DefaultPieceHasher, PUBLISHED_SECTOR_SIZES},
     parameters::{public_params, window_post_public_params, winning_post_public_params},
-    types::{PaddedBytesAmount, PoRepConfig, PoRepProofPartitions, PoStConfig, PoStType},
+    types::{PoRepConfig, PoStConfig, PoStType},
 };
 
 type Bls12GrothParams = groth16::MappedParameters<Bls12>;
@@ -196,11 +196,11 @@ where
 }
 
 pub fn get_stacked_params<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
 ) -> Result<Arc<Bls12GrothParams>> {
     let public_params = public_params::<Tree>(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;
@@ -216,7 +216,7 @@ pub fn get_stacked_params<Tree: 'static + MerkleTreeTrait>(
     lookup_groth_params(
         format!(
             "STACKED[{}]",
-            usize::from(PaddedBytesAmount::from(porep_config))
+            usize::from(porep_config.padded_bytes_amount())
         ),
         parameters_generator,
     )
@@ -268,7 +268,7 @@ pub fn get_post_params<Tree: 'static + MerkleTreeTrait>(
 }
 
 pub fn get_empty_sector_update_params<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
 ) -> Result<Arc<Bls12GrothParams>> {
     let public_params: storage_proofs_update::PublicParams =
         PublicParams::from_sector_size(u64::from(porep_config.sector_size));
@@ -284,18 +284,18 @@ pub fn get_empty_sector_update_params<Tree: 'static + MerkleTreeTrait<Hasher = T
     lookup_groth_params(
         format!(
             "SECTOR-UPDATE[{}]",
-            usize::from(PaddedBytesAmount::from(porep_config))
+            usize::from(porep_config.padded_bytes_amount())
         ),
         parameters_generator,
     )
 }
 
 pub fn get_stacked_verifying_key<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
 ) -> Result<Arc<Bls12PreparedVerifyingKey>> {
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;
@@ -311,7 +311,7 @@ pub fn get_stacked_verifying_key<Tree: 'static + MerkleTreeTrait>(
     lookup_verifying_key(
         format!(
             "STACKED[{}]",
-            usize::from(PaddedBytesAmount::from(porep_config))
+            usize::from(porep_config.padded_bytes_amount())
         ),
         vk_generator,
     )
@@ -363,12 +363,12 @@ pub fn get_post_verifying_key<Tree: 'static + MerkleTreeTrait>(
 }
 
 pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     num_proofs_to_aggregate: usize,
 ) -> Result<Arc<Bls12ProverSRSKey>> {
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;
@@ -376,7 +376,7 @@ pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
     let srs_generator = || {
         trace!(
             "get_stacked_srs_key specializing STACKED[{}-{}]",
-            usize::from(PaddedBytesAmount::from(porep_config)),
+            usize::from(porep_config.padded_bytes_amount()),
             num_proofs_to_aggregate,
         );
         <StackedCompound<Tree, DefaultPieceHasher> as CompoundProof<
@@ -388,7 +388,7 @@ pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
     lookup_srs_key(
         format!(
             "STACKED[{}-{}]",
-            usize::from(PaddedBytesAmount::from(porep_config)),
+            usize::from(porep_config.padded_bytes_amount()),
             num_proofs_to_aggregate,
         ),
         srs_generator,
@@ -396,12 +396,12 @@ pub fn get_stacked_srs_key<Tree: 'static + MerkleTreeTrait>(
 }
 
 pub fn get_stacked_srs_verifier_key<Tree: 'static + MerkleTreeTrait>(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
     num_proofs_to_aggregate: usize,
 ) -> Result<Arc<Bls12VerifierSRSKey>> {
     let public_params = public_params(
-        PaddedBytesAmount::from(porep_config),
-        usize::from(PoRepProofPartitions::from(porep_config)),
+        porep_config.padded_bytes_amount(),
+        usize::from(porep_config.partitions),
         porep_config.porep_id,
         porep_config.api_version,
     )?;
@@ -409,7 +409,7 @@ pub fn get_stacked_srs_verifier_key<Tree: 'static + MerkleTreeTrait>(
     let srs_verifier_generator = || {
         trace!(
             "get_stacked_srs_verifier_key specializing STACKED[{}-{}]",
-            usize::from(PaddedBytesAmount::from(porep_config)),
+            usize::from(porep_config.padded_bytes_amount()),
             num_proofs_to_aggregate,
         );
         <StackedCompound<Tree, DefaultPieceHasher> as CompoundProof<
@@ -423,7 +423,7 @@ pub fn get_stacked_srs_verifier_key<Tree: 'static + MerkleTreeTrait>(
     lookup_srs_verifier_key(
         format!(
             "STACKED[{}-{}]",
-            usize::from(PaddedBytesAmount::from(porep_config)),
+            usize::from(porep_config.padded_bytes_amount()),
             num_proofs_to_aggregate,
         ),
         srs_verifier_generator,
@@ -433,7 +433,7 @@ pub fn get_stacked_srs_verifier_key<Tree: 'static + MerkleTreeTrait>(
 pub fn get_empty_sector_update_verifying_key<
     Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>,
 >(
-    porep_config: PoRepConfig,
+    porep_config: &PoRepConfig,
 ) -> Result<Arc<Bls12PreparedVerifyingKey>> {
     let public_params: storage_proofs_update::PublicParams =
         PublicParams::from_sector_size(u64::from(porep_config.sector_size));
@@ -449,7 +449,7 @@ pub fn get_empty_sector_update_verifying_key<
     lookup_verifying_key(
         format!(
             "SECTOR-UPDATE[{}]",
-            usize::from(PaddedBytesAmount::from(porep_config))
+            usize::from(porep_config.padded_bytes_amount())
         ),
         vk_generator,
     )

--- a/filecoin-proofs/src/types/porep_config.rs
+++ b/filecoin-proofs/src/types/porep_config.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use storage_proofs_core::{
-    api_version::ApiVersion,
+    api_version::{ApiFeature, ApiVersion},
     merkle::MerkleTreeTrait,
     parameter_cache::{
         parameter_cache_metadata_path, parameter_cache_params_path,
@@ -18,12 +18,13 @@ use crate::{
     POREP_PARTITIONS,
 };
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub struct PoRepConfig {
     pub sector_size: SectorSize,
     pub partitions: PoRepProofPartitions,
     pub porep_id: [u8; 32],
     pub api_version: ApiVersion,
+    pub api_features: Vec<ApiFeature>,
 }
 
 impl From<PoRepConfig> for PaddedBytesAmount {
@@ -68,7 +69,29 @@ impl PoRepConfig {
             ),
             porep_id,
             api_version,
+            api_features: vec![],
         }
+    }
+
+    #[inline]
+    pub fn with_feature(mut self, feat: ApiFeature) -> Self {
+        self.enable_feature(feat);
+        self
+    }
+
+    #[inline]
+    pub fn enable_feature(&mut self, feat: ApiFeature) {
+        self.api_features.push(feat);
+    }
+
+    #[inline]
+    pub fn padded_bytes_amount(&self) -> PaddedBytesAmount {
+        PaddedBytesAmount::from(self.sector_size)
+    }
+
+    #[inline]
+    pub fn unpadded_bytes_amount(&self) -> UnpaddedBytesAmount {
+        self.padded_bytes_amount().into()
     }
 
     /// Returns the cache identifier as used by `storage-proofs::parameter_cache`.

--- a/filecoin-proofs/src/types/sector_class.rs
+++ b/filecoin-proofs/src/types/sector_class.rs
@@ -23,6 +23,7 @@ impl From<SectorClass> for PoRepConfig {
             partitions,
             porep_id,
             api_version,
+            api_features: vec![],
         }
     }
 }

--- a/filecoin-proofs/src/types/sector_update_config.rs
+++ b/filecoin-proofs/src/types/sector_update_config.rs
@@ -12,7 +12,7 @@ pub struct SectorUpdateConfig {
 }
 
 impl SectorUpdateConfig {
-    pub fn from_porep_config(porep_config: PoRepConfig) -> Self {
+    pub fn from_porep_config(porep_config: &PoRepConfig) -> Self {
         let nodes_count = u64::from(porep_config.sector_size) as usize / NODE_SIZE;
 
         SectorUpdateConfig {

--- a/filecoin-proofs/tests/mod.rs
+++ b/filecoin-proofs/tests/mod.rs
@@ -26,7 +26,7 @@ fn test_verify_seal_fr32_validation() {
     // Test failure for invalid comm_r conversion.
     {
         let result = verify_seal::<DefaultOctLCTree>(
-            PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
+            &PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
             not_convertible_to_fr_bytes,
             convertible_to_fr_bytes,
             [0; 32],
@@ -54,7 +54,7 @@ fn test_verify_seal_fr32_validation() {
     // Test failure for invalid comm_d conversion.
     {
         let result = verify_seal::<DefaultOctLCTree>(
-            PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
+            &PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
             convertible_to_fr_bytes,
             not_convertible_to_fr_bytes,
             [0; 32],
@@ -86,7 +86,7 @@ fn test_verify_seal_fr32_validation() {
         assert!(out.is_ok(), "tripwire");
 
         let result = verify_seal::<DefaultOctLCTree>(
-            PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
+            &PoRepConfig::new_groth16(SECTOR_SIZE_2_KIB, arbitrary_porep_id, ApiVersion::V1_1_0),
             non_zero_commitment_fr_bytes,
             non_zero_commitment_fr_bytes,
             [0; 32],

--- a/storage-proofs-core/src/api_version.rs
+++ b/storage-proofs-core/src/api_version.rs
@@ -32,6 +32,20 @@ impl ApiVersion {
             ApiVersion::V1_2_0 => Version::new(1, 2, 0),
         }
     }
+
+    #[inline]
+    pub fn supports_feature(&self, feat: &ApiFeature) -> bool {
+        self >= &feat.first_supported_version()
+            && feat
+                .last_supported_version()
+                .map(|v_last| self <= &v_last)
+                .unwrap_or(true)
+    }
+
+    #[inline]
+    pub fn supports_features(&self, feats: &[ApiFeature]) -> bool {
+        feats.iter().all(|feat| self.supports_feature(feat))
+    }
 }
 
 impl Debug for ApiVersion {
@@ -66,6 +80,21 @@ impl FromStr for ApiVersion {
                 "Could not parse API Version from string (major)"
             )),
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ApiFeature {}
+
+impl ApiFeature {
+    #[inline]
+    pub fn first_supported_version(&self) -> ApiVersion {
+        unimplemented!();
+    }
+
+    #[inline]
+    pub fn last_supported_version(&self) -> Option<ApiVersion> {
+        unimplemented!();
     }
 }
 

--- a/storage-proofs-core/src/api_version.rs
+++ b/storage-proofs-core/src/api_version.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::str::FromStr;
 
@@ -9,6 +10,18 @@ pub enum ApiVersion {
     V1_0_0,
     V1_1_0,
     V1_2_0,
+}
+
+impl Ord for ApiVersion {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.as_semver().cmp(&other.as_semver())
+    }
+}
+
+impl PartialOrd for ApiVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 impl ApiVersion {
@@ -43,7 +56,7 @@ impl FromStr for ApiVersion {
             (1, 0, 0) => Ok(ApiVersion::V1_0_0),
             (1, 1, 0) => Ok(ApiVersion::V1_1_0),
             (1, 2, 0) => Ok(ApiVersion::V1_2_0),
-            (1, 1, _) | (1, 0, _) => Err(format_err!(
+            (1, 0, _) | (1, 1, _) | (1, 2, _) => Err(format_err!(
                 "Could not parse API Version from string (patch)"
             )),
             (1, _, _) => Err(format_err!(
@@ -74,4 +87,9 @@ fn test_as_semver() {
     assert_eq!(ApiVersion::V1_0_0.as_semver().patch, 0);
     assert_eq!(ApiVersion::V1_1_0.as_semver().patch, 0);
     assert_eq!(ApiVersion::V1_2_0.as_semver().patch, 0);
+}
+
+#[test]
+fn test_api_version_order() {
+    assert!(ApiVersion::V1_0_0 < ApiVersion::V1_1_0 && ApiVersion::V1_1_0 < ApiVersion::V1_2_0);
 }


### PR DESCRIPTION
This PR allows for optional API features to be enabled within a supported range of `ApiVersion`s.

This PR is currently a draft because:
- It should be merged into master after the grindability fix PR [#1661](#1661) is merged.
- `enum ApiFeature` contains no variants, i.e. this PR does not add prospective API features such as Synthetic-PoRep