### PR TITLE
chore: update release.toml config

### DIFF
--- a/fil-proofs-tooling/release.toml
+++ b/fil-proofs-tooling/release.toml
@@ -1,4 +1,0 @@
-disable-push = true
-disable-publish = true
-disable-tag = true
-no-dev-version = true

--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,1 @@
-pre-release-commit-message = "chore({{crate_name}}): release {{version}}"
-pro-release-commit-message = "chore({{crate_name}}): starting development cycle for {{next_version}}"
-no-dev-version = true
+consolidate-commits = false


### PR DESCRIPTION
This way releases can be made with the most recent version 0.25.5 of cargo-release. New major releases can be cut with simply running:

    cargo release major --execute

Prior to this change `fil-proofs-tooling` wasn't tagged. With this change it's tagged just like any other crates. That adds more consistency. It still isn't published to crates.io as intended.

The `consolidate-commits = false` option makes sure that each crate gets its own tag with a commit message that contains its version number. Without this setting, it would only say "Release" without further information.