### PR TITLE
fix: make builds on stable and aarch64 possible

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,5 @@
 version: 2.1
 
-parameters:
-  nightly-toolchain:
-    type: string
-    default: "nightly-2022-05-09"
-
 executors:
   default:
     docker:
@@ -71,7 +66,7 @@ jobs:
       - restore_parameter_cache
       - run:
           name: Test (<< parameters.crate >>)
-          command: cargo +$(cat rust-toolchain) test --verbose --package << parameters.crate >>
+          command: cargo test --verbose --package << parameters.crate >>
           no_output_timeout: 30m
 
   test_release:
@@ -131,7 +126,6 @@ jobs:
           at: "."
       - restore_rustup_cache
       - restore_parameter_cache
-      - run: rustup install << pipeline.parameters.nightly-toolchain >>
       - run:
           name: Test with use_multicore_sdr
           command: |
@@ -220,7 +214,6 @@ jobs:
             curl https://sh.rustup.rs -sSf | sh -s -- -y
       - run: rustup install $(cat rust-toolchain)
       - run: rustup default $(cat rust-toolchain)
-      - run: rustup install << pipeline.parameters.nightly-toolchain >>
       - run: cargo update
       - run: cargo fetch
       - run:
@@ -231,7 +224,7 @@ jobs:
       - run:
           name: Test arm with no gpu
           command: |
-            cargo +<< pipeline.parameters.nightly-toolchain >> -Zpackage-features test --release --all --verbose --no-default-features
+            cargo test --release --all --verbose --no-default-features
           no_output_timeout: 90m
 
   bench:
@@ -245,7 +238,7 @@ jobs:
       - restore_parameter_cache
       - run:
           name: Benchmarks
-          command: cargo +$(cat rust-toolchain) build --benches --verbose --workspace
+          command: cargo build --benches --verbose --workspace
           no_output_timeout: 15m
 
   rustfmt:
@@ -270,7 +263,7 @@ jobs:
       - restore_rustup_cache
       - run:
           name: Run cargo clippy
-          command: cargo +$(cat rust-toolchain) clippy --all-targets --workspace -- -D warnings
+          command: cargo clippy --all-targets --workspace -- -D warnings
   test_darwin:
     macos:
       xcode: "13.4.1"

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -40,6 +40,9 @@ fr32 = { path = "../fr32", version = "~6.0.0", default-features = false }
 yastl = "0.1.2"
 blstrs = "0.6.0"
 
+[build-dependencies]
+rustversion = "1.0"
+
 [target."cfg(target_arch = \"aarch64\")".dependencies]
 sha2 = { version = "0.10.2", features = ["compress", "asm"] }
 [target."cfg(not(target_arch = \"aarch64\"))".dependencies]

--- a/storage-proofs-porep/build.rs
+++ b/storage-proofs-porep/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    cfg_if_nightly()
+}
+
+#[rustversion::nightly]
+fn cfg_if_nightly() {
+    println!("cargo:rustc-cfg=nightly");
+}
+
+#[rustversion::not(nightly)]
+fn cfg_if_nightly() {}

--- a/storage-proofs-porep/src/lib.rs
+++ b/storage-proofs-porep/src/lib.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all, clippy::perf, clippy::correctness, rust_2018_idioms)]
 #![warn(clippy::unwrap_used)]
-#![cfg_attr(target_arch = "aarch64", feature(stdsimd))]
+#![cfg_attr(all(target_arch = "aarch64", nightly), feature(stdsimd))]
 #![warn(clippy::unnecessary_wraps)]
 
 use std::path::PathBuf;

--- a/storage-proofs-porep/src/stacked/vanilla/macros.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/macros.rs
@@ -55,11 +55,14 @@ macro_rules! prefetch {
 
             x86::_mm_prefetch($val, x86::_MM_HINT_T0);
         }
-        #[cfg(target_arch = "aarch64")]
+        #[cfg(all(nightly, target_arch = "aarch64"))]
         unsafe {
             use std::arch::aarch64::{_prefetch, _PREFETCH_LOCALITY3, _PREFETCH_READ};
             _prefetch($val, _PREFETCH_READ, _PREFETCH_LOCALITY3);
         }
+        // Make sure that there are not warnings about unused variables.
+        #[cfg(all(not(nightly), target_arch = "aarch64"))]
+        let _ = ($val);
     };
 }
 

--- a/storage-proofs-porep/src/stacked/vanilla/macros.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/macros.rs
@@ -55,6 +55,9 @@ macro_rules! prefetch {
 
             x86::_mm_prefetch($val, x86::_MM_HINT_T0);
         }
+
+        // Prefetch on AArch64 is an unstable feature in Rust. Hence it can only be enabled if a
+        // nightly version of Rust is used. On stable Rust this macro is a no-op.
         #[cfg(all(nightly, target_arch = "aarch64"))]
         unsafe {
             use std::arch::aarch64::{_prefetch, _PREFETCH_LOCALITY3, _PREFETCH_READ};


### PR DESCRIPTION
When using Rust nightly we are able to enable an optimization for aarch64.
With this change it's now possible to compile for aarch64 on stable rust,
while the optimization is still enabled when compiled with nightly.

A similar fix was made for bellperson at
https://github.com/filecoin-project/bellperson/pull/269

This fix can be tested even on x86_64 on Linux with cross compiling
for aarch64:

    cargo build --target aarch64-unknown-linux-gnu

Fixes https://github.com/filecoin-project/rust-fil-proofs/issues/1652.