### PR TITLE
fix(storage-proofs-porep): return last layer from Labels

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/params.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/params.rs
@@ -655,7 +655,7 @@ impl<Tree: MerkleTreeTrait> Labels<Tree> {
 
     /// Returns label for the last layer.
     pub fn labels_for_last_layer(&self) -> Result<DiskStore<<Tree::Hasher as Hasher>::Domain>> {
-        self.labels_for_layer(self.labels.len() - 1)
+        self.labels_for_layer(self.labels.len())
     }
 
     /// How many layers are available.


### PR DESCRIPTION
An off-by-one error had caused `Labels::labels_for_last_layer` to return the second last layer.