### PR TITLE
fix: Benchy test without git code cannot output result

### DIFF
--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -26,7 +26,6 @@ bellperson = "0.24.0"
 rand = "0.8"
 tempfile = "3.0.8"
 cpu-time = "1.0.0"
-git2 = "0.14.2"
 heim = { git = "https://github.com/heim-rs/heim", rev = "b292f15", features = ["host", "memory", "cpu"] }
 async-std = "1.6"
 blake2s_simd = "1.0.0"
@@ -48,6 +47,9 @@ structopt = "0.3.12"
 humansize = "1.1.0"
 blstrs = "0.6.0"
 time = "0.3.9"
+
+[build-dependencies]
+vergen = { version = "8.1.1", features = ["build", "git", "gitcl"] }
 
 [features]
 default = ["opencl", "measurements"]

--- a/fil-proofs-tooling/build.rs
+++ b/fil-proofs-tooling/build.rs
@@ -1,0 +1,8 @@
+use std::error::Error;
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    // Emits the `VERGEN_GIT_SHA` and `VERGEN_GIT_COMMIT_TIMESTAMP` environment variables.
+    EmitBuilder::builder().all_git().emit()?;
+    Ok(())
+}

--- a/fil-proofs-tooling/src/metadata.rs
+++ b/fil-proofs-tooling/src/metadata.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Result};
-use chrono::{DateTime, TimeZone, Utc};
-use git2::Repository;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 /// Captures metadata about the current setup.
@@ -32,19 +31,12 @@ pub struct GitMetadata {
 
 impl GitMetadata {
     pub fn new() -> Result<Self> {
-        let repo_path = if let Ok(mdir) = std::env::var("CARGO_MANIFEST_DIR") {
-            std::path::Path::new(&mdir).into()
-        } else {
-            std::env::current_dir()?
-        };
-        let repo = Repository::discover(repo_path)?;
-        let head = repo.head()?;
-        let commit = head.peel_to_commit()?;
-        // Unwrap is OK as the given seconds won't be out of range.
-        let date = Utc.timestamp_opt(commit.time().seconds(), 0).unwrap();
-
+        // Unwrap is OK as vergen returns a valid timestamp.
+        let date = env!("VERGEN_GIT_COMMIT_TIMESTAMP")
+            .parse::<DateTime<Utc>>()
+            .expect("VERGEN_GIT_COMMIT_TIMESTAMP error");
         Ok(GitMetadata {
-            hash: commit.id().to_string(),
+            hash: env!("VERGEN_GIT_SHA").to_string(),
             date,
         })
     }


### PR DESCRIPTION
Description: When the benchy program is generated on the compilation server and copied to a non-git code server for testing, the report result cannot be output.