### PR TITLE
opt: force version for v14.0.0

### DIFF
--- a/filecoin-proofs/src/force_commitment_reader.rs
+++ b/filecoin-proofs/src/force_commitment_reader.rs
@@ -1,0 +1,312 @@
+use std::{io, mem, slice};
+
+use crate::{constants::DefaultPieceHasher, PaddedBytesAmount};
+use filecoin_hashers::{HashFunction, Hasher};
+use rayon::{
+    prelude::{IndexedParallelIterator, ParallelIterator},
+    slice::{ParallelSlice, ParallelSliceMut},
+};
+
+type PieceHashDomain = <DefaultPieceHasher as Hasher>::Domain;
+
+const PIECE_HASH_SIZE: usize = mem::size_of::<PieceHashDomain>() * 2;
+
+const fn align_to(size: usize, align: usize) -> usize {
+    (size + (align - 1)) & !(align - 1)
+}
+
+const fn align_down_to(size: usize, align: usize) -> usize {
+    size & !(align - 1)
+}
+
+const fn align_down_to_pow2(x: usize) -> usize {
+    (usize::MAX >> (x.leading_zeros() + 1)) + 1
+}
+
+struct ChunkTree {
+    leaf_nodes: Box<[PieceHashDomain]>,
+    leaf_nodes_len: usize,
+    par_chunk_size: usize,
+    chunk_roots: Vec<PieceHashDomain>,
+}
+
+impl ChunkTree {
+    fn new(chunk_len: usize) -> Self {
+        debug_assert!(chunk_len.is_power_of_two());
+
+        let leaf_nodes = vec![Default::default(); chunk_len];
+
+        Self {
+            leaf_nodes: leaf_nodes.into_boxed_slice(),
+            leaf_nodes_len: 0,
+            par_chunk_size: align_down_to_pow2(2.max(chunk_len / rayon::current_num_threads())),
+            chunk_roots: Vec::new(),
+        }
+    }
+
+    fn hash_one(&mut self, buf: &[u8; PIECE_HASH_SIZE]) {
+        let domain = <DefaultPieceHasher as Hasher>::Function::hash(buf);
+        self.leaf_nodes[self.leaf_nodes_len] = domain;
+        self.leaf_nodes_len += 1;
+        self.try_compute_chunk_root();
+    }
+
+    #[inline]
+    fn try_hash_many(&mut self, buf: &[u8]) {
+        if buf.len() < PIECE_HASH_SIZE {
+            return;
+        }
+        self.hash_many(buf);
+    }
+
+    fn hash_many(&mut self, buf: &[u8]) {
+        let max_len = self.leaf_nodes.len() - self.leaf_nodes_len;
+        let len = max_len.min(buf.len() / PIECE_HASH_SIZE);
+
+        let slots = &mut self.leaf_nodes[self.leaf_nodes_len..];
+        self.leaf_nodes_len += len;
+        buf.par_chunks(PIECE_HASH_SIZE)
+            .zip(slots)
+            .for_each(|(chunk, slot)| {
+                *slot = <DefaultPieceHasher as Hasher>::Function::hash(chunk)
+            });
+
+        self.try_compute_chunk_root();
+
+        self.try_hash_many(&buf[PIECE_HASH_SIZE * len..]);
+    }
+
+    fn try_compute_chunk_root(&mut self) {
+        if self.leaf_nodes_len < self.leaf_nodes.len() {
+            return;
+        }
+
+        self.chunk_roots
+            .push(par_compute_root(self.par_chunk_size, &mut self.leaf_nodes));
+
+        self.leaf_nodes_len = 0;
+    }
+
+    fn finish(mut self) -> PieceHashDomain {
+        compute_root(&mut self.chunk_roots)
+    }
+}
+
+fn par_compute_root(par_chunk_size: usize, row: &mut [PieceHashDomain]) -> PieceHashDomain {
+    let mut res = row
+        .par_chunks_mut(par_chunk_size)
+        .map(compute_root)
+        .collect::<Vec<_>>();
+    compute_root(&mut res)
+}
+
+/// Computes slice root hash
+/// Note: For the purpose of reusing memory, this function will change the content of the `row`
+fn compute_root(mut row: &mut [PieceHashDomain]) -> PieceHashDomain {
+    #[inline]
+    fn compute_next_row(row: &mut [PieceHashDomain]) -> &mut [PieceHashDomain] {
+        debug_assert!(row.len() % 2 == 0);
+        unsafe {
+            for i in (0..row.len()).step_by(2) {
+                let p = row.get_unchecked(i);
+                // Safety: continuous memory can be directly hashed without copies
+                let buf = slice::from_raw_parts(p as *const _ as *const u8, PIECE_HASH_SIZE);
+                *row.get_unchecked_mut(i / 2) = <DefaultPieceHasher as Hasher>::Function::hash(buf);
+            }
+
+            row.get_unchecked_mut(..row.len() / 2)
+        }
+    }
+
+    while row.len() > 1 {
+        row = compute_next_row(row);
+    }
+
+    debug_assert_eq!(row.len(), 1);
+
+    row.first()
+        .cloned()
+        .expect("should have been caught by debug build: len==1")
+}
+
+/// Calculates comm-d of the data piped through to it.
+/// Data must be bit padded and power of 2 bytes.
+pub struct CommitmentReader<R> {
+    source: R,
+
+    remainder_bytes: [u8; PIECE_HASH_SIZE],
+    remainder_bytes_pos: usize,
+
+    chunk_tree: ChunkTree,
+}
+
+impl<R: io::Read> CommitmentReader<R> {
+    const SIZE_64_MIB: usize = 1 << 26;
+    const SIZE_128_MIB: usize = 1 << 27;
+    const SIZE_8_GIB: usize = 1 << 33;
+
+    /// Creates a CommitmentReader. `padded_piece_size` must power of 2
+    pub fn new(padded_piece_size: PaddedBytesAmount, source: R) -> Self {
+        let padded_piece_size: usize = padded_piece_size.into();
+        debug_assert!(padded_piece_size.is_power_of_two());
+
+        let chunk_size_in_bytes = match padded_piece_size {
+            x if x >= Self::SIZE_8_GIB => Self::SIZE_128_MIB,
+            x if x >= Self::SIZE_64_MIB => Self::SIZE_64_MIB,
+            x => x,
+        };
+
+        CommitmentReader {
+            source,
+            remainder_bytes: [0; PIECE_HASH_SIZE],
+            remainder_bytes_pos: 0,
+            chunk_tree: ChunkTree::new(chunk_size_in_bytes / PIECE_HASH_SIZE),
+        }
+    }
+
+    pub fn finish(self) -> PieceHashDomain {
+        self.chunk_tree.finish()
+    }
+
+    fn try_append_to_remainder_bytes(&mut self, buf: &[u8]) {
+        if buf.is_empty() {
+            return;
+        }
+        self.append_to_remainder_bytes(buf);
+    }
+
+    fn append_to_remainder_bytes(&mut self, buf: &[u8]) {
+        let Self {
+            remainder_bytes,
+            remainder_bytes_pos,
+            chunk_tree,
+            ..
+        } = self;
+
+        let can_be_copy = remainder_bytes.len() - *remainder_bytes_pos;
+        let will_copy = buf.len().min(can_be_copy);
+
+        unsafe {
+            remainder_bytes
+                .get_unchecked_mut(*remainder_bytes_pos..*remainder_bytes_pos + will_copy)
+                .copy_from_slice(buf.get_unchecked(..will_copy))
+        }
+        *remainder_bytes_pos += will_copy;
+
+        if *remainder_bytes_pos == remainder_bytes.len() {
+            *remainder_bytes_pos = 0;
+            chunk_tree.hash_one(remainder_bytes);
+        }
+
+        self.try_append_to_remainder_bytes(&buf[will_copy..]);
+    }
+}
+
+impl<R: io::Read> io::Read for CommitmentReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let r = self.source.read(buf)?;
+        let mut buf = &buf[..r];
+
+        let start = if self.remainder_bytes_pos != 0 {
+            PIECE_HASH_SIZE - self.remainder_bytes_pos
+        } else {
+            0
+        };
+
+        // copy head
+        let head_len = start.min(buf.len());
+        self.try_append_to_remainder_bytes(&buf[..head_len]);
+        buf = &buf[head_len..];
+
+        let can_be_hash_len = align_down_to(r.checked_sub(start).unwrap_or(0), PIECE_HASH_SIZE);
+
+        let tail = &buf[can_be_hash_len..];
+
+        // try to hash
+        self.chunk_tree.try_hash_many(&buf[..can_be_hash_len]);
+
+        // copy tail
+        self.try_append_to_remainder_bytes(tail);
+        Ok(r)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::io::Cursor;
+
+    use crate::types::UnpaddedBytesAmount;
+    use anyhow::Result;
+    use fr32::Fr32Reader;
+
+    fn origin_compute_comm(src: impl io::Read) -> Result<PieceHashDomain> {
+        let mut reader = crate::commitment_reader::CommitmentReader::new(src);
+        io::copy(&mut reader, &mut io::sink()).expect("io copy failed");
+        reader.finish()
+    }
+
+    #[test]
+    fn test_commitment_reader() {
+        let piece_size = 127 * 8;
+        let source = vec![255u8; piece_size];
+
+        let fr32_reader = Fr32Reader::new(Cursor::new(&source));
+        let expect = origin_compute_comm(fr32_reader).expect("compute comm failed");
+
+        let fr32_reader = Fr32Reader::new(Cursor::new(&source));
+        let mut commitment_reader =
+            CommitmentReader::new(UnpaddedBytesAmount(piece_size as u64).into(), fr32_reader);
+        io::copy(&mut commitment_reader, &mut io::sink()).expect("io copy failed");
+
+        let commitment2 = commitment_reader.finish();
+
+        assert_eq!(expect, commitment2);
+    }
+
+    #[test]
+    fn test_align_to() {
+        let cases = vec![
+            (33, 32, 64),
+            (1, 32, 32),
+            (32, 32, 32),
+            (31, 32, 32),
+            (63, 32, 64),
+        ];
+
+        for (size, align, expect) in cases {
+            assert_eq!(align_to(size, align), expect);
+        }
+    }
+
+    #[test]
+    fn test_align_down_to() {
+        let cases = vec![
+            (33, 32, 32),
+            (1, 32, 0),
+            (32, 32, 32),
+            (31, 32, 0),
+            (63, 32, 32),
+        ];
+
+        for (size, align, expect) in cases {
+            assert_eq!(align_down_to(size, align), expect);
+        }
+    }
+
+    #[test]
+    fn test_align_down_to_pow2() {
+        let cases = vec![
+            (1024, 1024),
+            (1025, 1024),
+            (2047, 1024),
+            (2049, 2048),
+            (3, 2),
+        ];
+
+        for (size, expect) in cases {
+            assert_eq!(align_down_to_pow2(size), expect);
+        }
+    }
+}

--- a/filecoin-proofs/src/lib.rs
+++ b/filecoin-proofs/src/lib.rs
@@ -12,6 +12,7 @@ pub mod types;
 
 mod api;
 mod commitment_reader;
+mod force_commitment_reader;
 
 pub use api::*;
 pub use commitment_reader::*;

--- a/storage-proofs-core/Cargo.toml
+++ b/storage-proofs-core/Cargo.toml
@@ -41,6 +41,7 @@ semver = "1.0.6"
 fr32 = { path = "../fr32", version = "~7.0.0"}
 blstrs = "0.6.0"
 cbc = { version = "0.1.2", features = ["std"] }
+glob = "0.3.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -16,7 +16,6 @@ use generic_array::{
     GenericArray,
 };
 use log::{debug, info};
-use memmap2::MmapMut;
 use merkletree::store::{DiskStore, Store, StoreConfig};
 use storage_proofs_core::{
     cache_key::CacheKey,
@@ -203,8 +202,8 @@ fn create_label_runner(
 fn create_layer_labels(
     parents_cache: &CacheReader<u32>,
     replica_id: &[u8],
-    layer_labels: &mut MmapMut,
-    exp_labels: Option<&mut MmapMut>,
+    layer_labels: &mut [u8],
+    exp_labels: Option<&mut [u8]>,
     num_nodes: u64,
     cur_layer: u32,
     core_group: Arc<Option<MutexGuard<'_, Vec<CoreIndex>>>>,

--- a/storage-proofs-porep/src/stacked/vanilla/memory_handling/numa_mem_pool.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/memory_handling/numa_mem_pool.rs
@@ -1,0 +1,252 @@
+use std::{
+    collections::HashMap,
+    fs::OpenOptions,
+    path::Path,
+    sync::{Mutex, MutexGuard},
+};
+
+use log::{trace, warn};
+use memmap2::{MmapMut, MmapOptions};
+
+use crate::stacked::vanilla::numa::NumaNodeIndex;
+
+// memory_size -> memory
+type InnerPool = HashMap<usize, Vec<Mutex<MmapMut>>>;
+
+pub(super) struct NumaMemPool {
+    /// The index of the numa_groups vec is numa_node_index
+    numa_groups: Vec<InnerPool>,
+}
+
+impl NumaMemPool {
+    /// Create an empty NumaMemPool
+    pub const fn empty() -> Self {
+        Self {
+            numa_groups: Vec::new(),
+        }
+    }
+
+    /// Create NumaMemPool with the given `numa_memory_files`
+    ///
+    /// The index of the `numa_memory_files` vec is numa_node_index,
+    /// and each item of `numa_memory_files` is the memory file paths corresponding to numa_node_index
+    #[allow(dead_code)]
+    pub fn new(numa_memory_files: Vec<impl IntoIterator<Item = impl AsRef<Path>>>) -> Self {
+        let mut numa_mem_pool = Self::empty();
+        numa_mem_pool.init(numa_memory_files);
+        numa_mem_pool
+    }
+
+    /// Init NumaMemPool with the given `numa_memory_files`
+    ///
+    /// The index of the `numa_memory_files` vec is numa_node_index,
+    /// and each item of `numa_memory_files` is the memory file paths corresponding to numa_node_index
+    pub fn init(&mut self, numa_memory_files: Vec<impl IntoIterator<Item = impl AsRef<Path>>>) {
+        if !self.numa_groups.is_empty() {
+            warn!("The numa pool has already been initialized");
+            return;
+        }
+        let numa_groups: Vec<_> = numa_memory_files
+            .into_iter()
+            .map(Self::load_memory_files)
+            .collect();
+        trace!(
+            "number of loaded memory files: {}",
+            numa_groups
+                .iter()
+                .enumerate()
+                .map(|(numa_id, mems)| {
+                    format!(
+                        "numa_id: {}, loaded: {}",
+                        numa_id,
+                        mems.values().map(Vec::len).sum::<usize>()
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ")
+        );
+        self.numa_groups = numa_groups;
+    }
+
+    fn load_memory_files(memory_files: impl IntoIterator<Item = impl AsRef<Path>>) -> InnerPool {
+        let mut inner_pool: HashMap<usize, Vec<Mutex<MmapMut>>> = HashMap::new();
+
+        for p in memory_files.into_iter() {
+            let p = p.as_ref();
+            let memory_file = match OpenOptions::new().read(true).write(true).open(p) {
+                Ok(file) => file,
+                Err(e) => {
+                    warn!(
+                        "open memory file: '{}', {:?}. ignore this memory file.",
+                        p.display(),
+                        e
+                    );
+                    continue;
+                }
+            };
+
+            let file_size = match memory_file.metadata() {
+                Ok(meta) => meta.len(),
+                Err(e) => {
+                    warn!(
+                        "get the size of the '{}' file: {:?}. ignore this memory file.",
+                        p.display(),
+                        e,
+                    );
+                    continue;
+                }
+            };
+
+            let mmap = match unsafe { MmapOptions::new().map_mut(&memory_file) } {
+                Ok(mut mmap) => {
+                    if let Err(err) = mmap.lock() {
+                        warn!(
+                            "failed to lock mmap memory file '{}': {:?}",
+                            p.display(),
+                            err
+                        );
+                    }
+                    mmap
+                }
+                Err(err) => {
+                    warn!(
+                        "failed to mmap memory file '{}': {:?}. ignore this memory file.",
+                        p.display(),
+                        err
+                    );
+                    continue;
+                }
+            };
+            trace!("loaded memory file: {}", p.display());
+            let mmap = Mutex::new(mmap);
+            inner_pool
+                .entry(file_size as usize)
+                .or_insert_with(Vec::new)
+                .push(mmap);
+        }
+        inner_pool
+    }
+
+    /// Acquire the memory for the specified size
+    ///
+    /// Acquire returns the memory of the NUMA node where the caller thread is located
+    /// if there is enough memory.
+    /// Make sure that the caller thread and the thread that using the memory returned
+    /// by this function are in the same NUMA node and make sure the thread that using
+    /// the returned memory will not be dispatched to other NUMA nodes, To maintain high
+    /// performance of memory access
+    pub fn acquire(&self, size: usize) -> Option<MutexGuard<'_, MmapMut>> {
+        let numa_group = self
+            .numa_groups
+            .get(current_numa_node().unwrap_or_default().raw() as usize)?;
+        for l in numa_group.get(&size)? {
+            match l.try_lock() {
+                Ok(m) => return Some(m),
+                Err(_) => {}
+            }
+        }
+        None
+    }
+}
+
+#[cfg(not(test))]
+fn current_numa_node() -> Option<NumaNodeIndex> {
+    use crate::stacked::vanilla::numa;
+    numa::current_numa_node()
+}
+
+#[cfg(test)]
+fn current_numa_node() -> Option<NumaNodeIndex> {
+    *tests::CUR_NUMA_NODE.lock().unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::sync::Mutex;
+
+    use lazy_static::lazy_static;
+
+    use crate::stacked::vanilla::numa::NumaNodeIndex;
+
+    use super::NumaMemPool;
+
+    lazy_static! {
+        pub(super) static ref CUR_NUMA_NODE: Mutex<Option<NumaNodeIndex>> = Mutex::new(None);
+    }
+
+    /// set current numa node for testing
+    fn set_current_numa_node(curr: Option<NumaNodeIndex>) {
+        *CUR_NUMA_NODE.lock().unwrap() = curr;
+    }
+
+    #[test]
+    fn test_numa_mem_pool() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create tempdir");
+        let temp_dir_path = temp_dir.as_ref();
+
+        fn size_fn(numa_node_idx: usize) -> usize {
+            (numa_node_idx + 1) * 10
+        }
+
+        let numa_memory_files: Vec<_> = (0..2)
+            .map(|numa_node_idx| {
+                (0..2).map(move |i| {
+                    let path = temp_dir_path.join(format!("numa_{}_{}", numa_node_idx, i));
+
+                    fs::write(&path, " ".repeat(size_fn(numa_node_idx)))
+                        .expect("Failed to write data");
+                    path
+                })
+            })
+            .collect();
+        let numa_mem_pool = NumaMemPool::new(numa_memory_files);
+
+        let mut mems = Vec::new();
+        for numa_node_idx in 0..2 {
+            let size = size_fn(numa_node_idx);
+            let no_exist_size = size + 1;
+
+            set_current_numa_node(Some(NumaNodeIndex::new(numa_node_idx as u32)));
+
+            for _ in 0..2 {
+                // Test for normal memory acquire
+                let mem = numa_mem_pool.acquire(size);
+                assert!(mem.is_some());
+                mems.push(mem);
+
+                // Test to acquire the memory of non-existent memory size
+                assert!(
+                    numa_mem_pool.acquire(no_exist_size).is_none(),
+                    "acquire non-existent memory size should return None"
+                );
+            }
+        }
+
+        // Test when NumaMemPool is empty
+        for numa_node_idx in 0..2 {
+            let size = size_fn(numa_node_idx);
+            set_current_numa_node(Some(NumaNodeIndex::new(numa_node_idx as u32)));
+
+            for _ in 0..2 {
+                assert!(
+                    numa_mem_pool.acquire(size).is_none(),
+                    "acquire memory from empty NumaMemPool should return None"
+                );
+            }
+        }
+
+        drop(mems);
+
+        for numa_node_idx in 0..2 {
+            let size = size_fn(numa_node_idx);
+            set_current_numa_node(Some(NumaNodeIndex::new(numa_node_idx as u32)));
+
+            for _ in 0..2 {
+                // Test for normal memory acquire
+                let mem = numa_mem_pool.acquire(size);
+                assert!(mem.is_some());
+            }
+        }
+    }
+}

--- a/storage-proofs-porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/mod.rs
@@ -15,6 +15,8 @@ mod graph;
 mod labeling_proof;
 #[cfg(feature = "multicore-sdr")]
 mod memory_handling;
+#[cfg(feature = "multicore-sdr")]
+mod numa;
 mod params;
 mod porep;
 mod proof;
@@ -28,5 +30,6 @@ pub use column_proof::ColumnProof;
 pub use encoding_proof::EncodingProof;
 pub use graph::{StackedBucketGraph, StackedGraph, EXP_DEGREE};
 pub use labeling_proof::LabelingProof;
+pub use memory_handling::init_numa_mem_pool;
 pub use params::*;
 pub use proof::{StackedDrg, TreeRElementData, TOTAL_PARENTS};

--- a/storage-proofs-porep/src/stacked/vanilla/numa.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/numa.rs
@@ -1,0 +1,77 @@
+#[cfg(target_os = "linux")]
+pub use linux::*;
+
+#[cfg(not(target_os = "linux"))]
+pub use unsupported::*;
+
+use libc::c_int;
+
+/// Index of a NUMA node.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
+pub struct NumaNodeIndex(u32);
+
+impl NumaNodeIndex {
+    #[allow(dead_code)]
+    pub fn new(idx: u32) -> Self {
+        Self(idx)
+    }
+
+    /// Returns NUMA node index of c_int type
+    pub fn raw(&self) -> c_int {
+        self.0 as c_int
+    }
+}
+
+#[cfg(target_os = "linux")]
+mod linux {
+
+    use lazy_static::lazy_static;
+    use libc::{self, c_int};
+
+    use super::NumaNodeIndex;
+
+    #[link(name = "numa", kind = "dylib")]
+    extern "C" {
+        /// Check if NUMA support is enabled. Returns -1 if not enabled, in which case other functions will undefined
+        fn numa_available() -> c_int;
+        ///  Returns the NUMA node corresponding to a CPU core, or -1 if the CPU core is invalid
+        fn numa_node_of_cpu(cpu: c_int) -> c_int;
+    }
+
+    lazy_static! {
+        static ref NUMA_AVAILABLE: bool = unsafe { numa_available() >= 0 };
+    }
+
+    /// Returns the current NUMA node on which the thread is running.
+    ///
+    /// Since threads may migrate to another node with the scheduler,
+    /// you need to bind the current worker thread to the specified core when calling this function
+    #[allow(dead_code)]
+    pub fn current_numa_node() -> Option<NumaNodeIndex> {
+        if !*NUMA_AVAILABLE {
+            return None;
+        }
+        let cpu = unsafe { libc::sched_getcpu() };
+        // Return None if sched_getcpu call fails
+        if cpu < 0 {
+            return None;
+        }
+        let node = unsafe { numa_node_of_cpu(cpu) };
+        // If libnuma cannot find the appropriate node, then return None
+        if node < 0 {
+            return None;
+        }
+        Some(NumaNodeIndex(node as u32))
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod unsupported {
+
+    use super::NumaNodeIndex;
+
+    #[allow(dead_code)]
+    pub fn current_numa_node() -> Option<NumaNodeIndex> {
+        None
+    }
+}


### PR DESCRIPTION
升级 rust-fil-proofs 版本至 v14.0.0

v14.0.0 中把 mapr 替换位 memmap2  [#1624](https://github.com/filecoin-project/rust-fil-proofs/pull/1624)。 所以`numa_mem_pool.rs` 也有[细微变动](https://github.com/filecoin-project/rust-fil-proofs/compare/master...ipfs-force-community:rust-fil-proofs:chore/0x5459/upgrade_to_v14.0.0?expand=1#diff-c0ea1245d4ee32bb4bc63aa925ceee05f505e6464cf90ea2e021b0f6b0d191a8R100-R119)

参考 v12.0.0 升级  https://github.com/ipfs-force-community/rust-fil-proofs/pull/5