### PR TITLE
fix: replace heim with sysinfo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,3 @@ members = [
   "filecoin-hashers",
   "storage-proofs-update",
 ]
-
-[patch.crates-io]
-# rustix v.0.37.14 cannot be compiled due to this error:
-# no method named `difference` found for struct `backend::fs::types::AtFlags` in the current scope
-# Hence use the previous version as a  temporary workaround.
-rustix = { git = "https://github.com/bytecodealliance/rustix", tag = "v0.37.13" }

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -26,8 +26,6 @@ bellperson = "0.24.0"
 rand = "0.8"
 tempfile = "3.0.8"
 cpu-time = "1.0.0"
-heim = { git = "https://github.com/heim-rs/heim", rev = "b292f15", features = ["host", "memory", "cpu"] }
-async-std = "1.6"
 blake2s_simd = "1.0.0"
 fil_logger = "0.1.6"
 log = "0.4.8"
@@ -47,6 +45,7 @@ structopt = "0.3.12"
 humansize = "1.1.0"
 blstrs = "0.6.0"
 time = "0.3.9"
+sysinfo = { version = "0.28.4", default-features = false }
 
 [build-dependencies]
 vergen = { version = "8.1.1", features = ["build", "git", "gitcl"] }

--- a/fil-proofs-tooling/src/metadata.rs
+++ b/fil-proofs-tooling/src/metadata.rs
@@ -1,6 +1,9 @@
-use anyhow::{anyhow, Result};
+use std::env::consts::ARCH;
+
+use anyhow::Result;
 use chrono::{DateTime, Utc};
 use serde::Serialize;
+use sysinfo::{RefreshKind, System, SystemExt};
 
 /// Captures metadata about the current setup.
 #[derive(Debug, Serialize)]
@@ -53,22 +56,18 @@ pub struct SystemMetadata {
     processor_base_frequency_hz: u16,
     processor_max_frequency_hz: u16,
     processor_features: String,
-    processor_cores_logical: u64,
-    processor_cores_physical: u64,
+    processor_cores_logical: usize,
+    processor_cores_physical: usize,
     memory_total_bytes: u64,
 }
 
 impl SystemMetadata {
     pub fn new() -> Result<Self> {
-        use async_std::task::block_on;
-        let host = block_on(async { heim::host::platform().await })
-            .map_err(|_| anyhow!("Failed to retrieve host information"))?;
-        let memory = block_on(async { heim::memory::memory().await })
-            .map_err(|_| anyhow!("Failed to retrieve memory information"))?;
-        let cpu_logical = block_on(async { heim::cpu::logical_count().await })
-            .map_err(|_| anyhow!("Failed to retrieve cpu logical count information"))?;
-        let cpu_physical = block_on(async { heim::cpu::physical_count().await })
-            .map_err(|_| anyhow!("Failed to retrieve cpu physical count information"))?;
+        let system = System::new_with_specifics(
+            RefreshKind::new()
+                .with_cpu(Default::default())
+                .with_memory(),
+        );
 
         let (processor, base, max, features) = {
             #[cfg(target_arch = "x86_64")]
@@ -104,17 +103,17 @@ impl SystemMetadata {
         };
 
         Ok(SystemMetadata {
-            system: host.system().into(),
-            release: host.release().into(),
-            version: host.version().into(),
-            architecture: host.architecture().as_str().into(),
+            system: system.long_os_version().unwrap_or_default(),
+            release: system.kernel_version().unwrap_or_default(),
+            version: system.os_version().unwrap_or_default(),
+            architecture: ARCH.to_string(),
             processor,
             processor_base_frequency_hz: base,
             processor_max_frequency_hz: max,
             processor_features: features,
-            processor_cores_logical: cpu_logical,
-            processor_cores_physical: cpu_physical.unwrap_or_default(),
-            memory_total_bytes: memory.total().get::<heim::units::information::byte>(),
+            processor_cores_logical: system.cpus().len(),
+            processor_cores_physical: system.physical_core_count().unwrap_or_default(),
+            memory_total_bytes: system.total_memory(),
         })
     }
 }


### PR DESCRIPTION
`heim` isn't maintained anymore. With the most recent rustix release, `bitflags` >= v1.3.1 is needed. But `heim` restrictits it to at most 1.2.x. This means that we cannot build the project anymore.

This commmit replace `heim` with `sysinfo`. The information it provides is not equal, but similar enough. Here is some example output before and after this change:

With `heim`:

    SystemMetadata {
        system: "Linux",
        release: "6.1.0-5-amd64",
        version: "#1 SMP PREEMPT_DYNAMIC Debian 6.1.12-1 (2023-02-15)",
        architecture: "x86_64",
        processor: "Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz",
        processor_base_frequency_hz: 2000,
        processor_max_frequency_hz: 4000,
        processor_features: "FeatureInfo { extended_family_id: 0, extended_model_id: 8, family_id: 6, model_id: 142, stepping_id: 10, brand_index: 0, cflush_cache_line_size: 8, initial_local_apic_id: 6, max_logical_processor_ids: 16, edx_ecx: FeatureInfoFlags(SSE3 | PCLMULQDQ | DTES64 | MONITOR | DSCPL | VMX | EIST | TM2 | SSSE3 | FMA | CMPXCHG16B | PDCM | PCID | SSE41 | SSE42 | X2APIC | MOVBE | POPCNT | TSC_DEADLINE | AESNI | XSAVE | OSXSAVE | AVX | F16C | RDRAND | FPU | VME | DE | PSE | TSC | MSR | PAE | MCE | CX8 | APIC | SEP | MTRR | PGE | MCA | CMOV | PAT | PSE36 | CLFSH | DS | ACPI | MMX | FXSR | SSE | SSE2 | SS | HTT | TM | PBE) }",
        processor_cores_logical: 8,
        processor_cores_physical: 4,
        memory_total_bytes: 32801624000,
    }

With `sysinfo`:

    SystemMetadata {
        system: "Linux  Debian GNU/Linux",
        release: "6.1.0-5-amd64",
        version: "",
        architecture: "x86_64",
        processor: "Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz",
        processor_base_frequency_hz: 2000,
        processor_max_frequency_hz: 4000,
        processor_features: "FeatureInfo { extended_family_id: 0, extended_model_id: 8, family_id: 6, model_id: 142, stepping_id: 10, brand_index: 0, cflush_cache_line_size: 8, initial_local_apic_id: 6, max_logical_processor_ids: 16, edx_ecx: FeatureInfoFlags(SSE3 | PCLMULQDQ | DTES64 | MONITOR | DSCPL | VMX | EIST | TM2 | SSSE3 | FMA | CMPXCHG16B | PDCM | PCID | SSE41 | SSE42 | X2APIC | MOVBE | POPCNT | TSC_DEADLINE | AESNI | XSAVE | OSXSAVE | AVX | F16C | RDRAND | FPU | VME | DE | PSE | TSC | MSR | PAE | MCE | CX8 | APIC | SEP | MTRR | PGE | MCA | CMOV | PAT | PSE36 | CLFSH | DS | ACPI | MMX | FXSR | SSE | SSE2 | SS | HTT | TM | PBE) }",
        processor_cores_logical: 8,
        processor_cores_physical: 4,
        memory_total_bytes: 33588862976,
    }

As this output is only used for the tooling, those small differences aren't a problem.

---

This PR fixes the problem with rustix that came up yesterday.