### PR TITLE
refactor: remove superfluous generic

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -919,7 +919,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     }
 
     #[cfg(any(feature = "cuda", feature = "opencl"))]
-    pub fn generate_tree_r_last<TreeArity>(
+    pub fn generate_tree_r_last(
         data: &mut Data<'_>,
         nodes_count: usize,
         tree_count: usize,
@@ -927,17 +927,14 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         replica_path: PathBuf,
         source: &DiskStore<<Tree::Hasher as Hasher>::Domain>,
         callback: Option<PrepareTreeRDataCallback<Tree>>,
-    ) -> Result<LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>>
-    where
-        TreeArity: PoseidonArity,
-    {
+    ) -> Result<LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>> {
         let encode_data = match callback {
             Some(x) => x,
             None => Self::prepare_tree_r_data,
         };
 
         if Self::use_gpu_tree_builder() {
-            Self::generate_tree_r_last_gpu::<TreeArity>(
+            Self::generate_tree_r_last_gpu(
                 data,
                 nodes_count,
                 tree_count,
@@ -947,7 +944,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                 encode_data,
             )
         } else {
-            Self::generate_tree_r_last_cpu::<TreeArity>(
+            Self::generate_tree_r_last_cpu(
                 data,
                 nodes_count,
                 tree_count,
@@ -960,7 +957,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     }
 
     #[cfg(not(any(feature = "cuda", feature = "opencl")))]
-    pub fn generate_tree_r_last<TreeArity>(
+    pub fn generate_tree_r_last(
         data: &mut Data<'_>,
         nodes_count: usize,
         tree_count: usize,
@@ -968,16 +965,13 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         replica_path: PathBuf,
         source: &DiskStore<<Tree::Hasher as Hasher>::Domain>,
         callback: Option<PrepareTreeRDataCallback<Tree>>,
-    ) -> Result<LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>>
-    where
-        TreeArity: PoseidonArity,
-    {
+    ) -> Result<LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>> {
         let encode_data = match callback {
             Some(x) => x,
             None => Self::prepare_tree_r_data,
         };
 
-        Self::generate_tree_r_last_cpu::<TreeArity>(
+        Self::generate_tree_r_last_cpu(
             data,
             nodes_count,
             tree_count,
@@ -989,7 +983,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     }
 
     #[cfg(any(feature = "cuda", feature = "opencl"))]
-    fn generate_tree_r_last_gpu<TreeArity>(
+    fn generate_tree_r_last_gpu(
         data: &mut Data<'_>,
         nodes_count: usize,
         tree_count: usize,
@@ -997,10 +991,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         replica_path: PathBuf,
         source: &DiskStore<<Tree::Hasher as Hasher>::Domain>,
         callback: PrepareTreeRDataCallback<Tree>,
-    ) -> Result<LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>>
-    where
-        TreeArity: PoseidonArity,
-    {
+    ) -> Result<LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>> {
         use std::cmp::min;
         use std::fs::OpenOptions;
         use std::io::Write;
@@ -1168,7 +1159,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         )
     }
 
-    fn generate_tree_r_last_cpu<TreeArity>(
+    fn generate_tree_r_last_cpu(
         data: &mut Data<'_>,
         nodes_count: usize,
         tree_count: usize,
@@ -1176,10 +1167,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         replica_path: PathBuf,
         source: &DiskStore<<Tree::Hasher as Hasher>::Domain>,
         callback: PrepareTreeRDataCallback<Tree>,
-    ) -> Result<LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>>
-    where
-        TreeArity: PoseidonArity,
-    {
+    ) -> Result<LCTree<Tree::Hasher, Tree::Arity, Tree::SubTreeArity, Tree::TopTreeArity>> {
         let (configs, replica_config) = split_config_and_replica(
             tree_r_last_config.clone(),
             replica_path,
@@ -1414,7 +1402,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
 
         info!("building tree_r_last");
         let tree_r_last = measure_op(Operation::GenerateTreeRLast, || {
-            Self::generate_tree_r_last::<Tree::Arity>(
+            Self::generate_tree_r_last(
                 &mut data,
                 nodes_count,
                 tree_count,

--- a/storage-proofs-update/src/vanilla.rs
+++ b/storage-proofs-update/src/vanilla.rs
@@ -924,7 +924,7 @@ where
         // This argument is currently unused by this invocation, but required for the API.
         let mut unused_data = Data::empty();
 
-        let tree_r_last = StackedDrg::<TreeR, TreeDHasher>::generate_tree_r_last::<TreeR::Arity>(
+        let tree_r_last = StackedDrg::<TreeR, TreeDHasher>::generate_tree_r_last(
             &mut unused_data,
             base_tree_nodes_count,
             tree_count,
@@ -1187,7 +1187,7 @@ where
         // This argument is currently unused by this invocation, but required for the API.
         let mut unused_data = Data::empty();
 
-        let tree_r_last = StackedDrg::<TreeR, TreeDHasher>::generate_tree_r_last::<TreeR::Arity>(
+        let tree_r_last = StackedDrg::<TreeR, TreeDHasher>::generate_tree_r_last(
             &mut unused_data,
             base_tree_nodes_count,
             tree_count,


### PR DESCRIPTION
The TreeRLast generation is bound to the arity of the `Tree` anyway, so it doesn't need an extra generic.