### PR TITLE
docs: document the TreeRLast generation

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -921,7 +921,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
     /// Generate the TreeRLast.
     ///
     /// `nodes_count` is the number of nodes per sector, practically is the sector size in bytes
-    /// devided by the 32 bytes node size.
+    /// divided by the 32 bytes node size.
     ///
     /// TreeRLast is split into several sub-trees. The exact number `tree_count` depends on the
     /// sector size.


### PR DESCRIPTION
The TreeRLast generation is doing more things when called during the PoRep, than during the empty sector update (aka SnapDeals). Document those differences.