### PR TITLE
refactor: replicate_phase2 needs cache dir only

### DIFF
--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -305,7 +305,7 @@ where
         labels,
         data,
         data_tree,
-        config,
+        cache_path.as_ref().to_path_buf(),
         replica_path.as_ref().to_path_buf(),
     )?;
 

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -1247,7 +1247,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             layer_challenges,
             data,
             data_tree,
-            config,
+            config.path,
             replica_path,
             labels,
         )
@@ -1259,7 +1259,8 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         layer_challenges: &LayerChallenges,
         mut data: Data<'_>,
         data_tree: Option<BinaryMerkleTree<G>>,
-        config: StoreConfig,
+        // The directory where the files we operate on are stored.
+        cache_path: PathBuf,
         replica_path: PathBuf,
         label_configs: Labels<Tree>,
     ) -> Result<TransformedLayers<Tree, G>> {
@@ -1294,38 +1295,39 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
 
         // Generate all store configs that we need based on the
         // cache_path in the specified config.
-        let mut tree_d_config = StoreConfig::from_config(
-            &config,
-            CacheKey::CommDTree.to_string(),
-            Some(get_merkle_tree_len(total_nodes_count, BINARY_ARITY)?),
-        );
-        tree_d_config.rows_to_discard = default_rows_to_discard(total_nodes_count, BINARY_ARITY);
+        let tree_d_config = StoreConfig {
+            path: cache_path.clone(),
+            id: CacheKey::CommDTree.to_string(),
+            size: Some(get_merkle_tree_len(total_nodes_count, BINARY_ARITY)?),
+            rows_to_discard: default_rows_to_discard(total_nodes_count, BINARY_ARITY),
+        };
 
-        let mut tree_r_last_config = StoreConfig::from_config(
-            &config,
-            CacheKey::CommRLastTree.to_string(),
-            Some(get_merkle_tree_len(nodes_count, Tree::Arity::to_usize())?),
-        );
+        let rows_to_discard = default_rows_to_discard(nodes_count, Tree::Arity::to_usize());
+        let size = Some(get_merkle_tree_len(nodes_count, Tree::Arity::to_usize())?);
 
-        // A default 'rows_to_discard' value will be chosen for tree_r_last, unless the user overrides this value via the
-        // environment setting (FIL_PROOFS_ROWS_TO_DISCARD).  If this value is specified, no checking is done on it and it may
-        // result in a broken configuration.  Use with caution.  It must be noted that if/when this unchecked value is passed
-        // through merkle_light, merkle_light now does a check that does not allow us to discard more rows than is possible
-        // to discard.
-        tree_r_last_config.rows_to_discard =
-            default_rows_to_discard(nodes_count, Tree::Arity::to_usize());
+        let tree_r_last_config = StoreConfig {
+            path: cache_path.clone(),
+            id: CacheKey::CommRLastTree.to_string(),
+            size,
+            // A default 'rows_to_discard' value will be chosen for tree_r_last, unless the user
+            // overrides this value via the environment setting (FIL_PROOFS_ROWS_TO_DISCARD). If
+            // this value is specified, no checking is done on it and it may result in a broken
+            // configuration. *Use with caution*. It must be noted that if/when this unchecked
+            // value is passed through merkle_light, merkle_light now does a check that does not
+            // allow us to discard more rows than is possible to discard.
+            rows_to_discard,
+        };
         trace!(
             "tree_r_last using rows_to_discard={}",
             tree_r_last_config.rows_to_discard
         );
 
-        let mut tree_c_config = StoreConfig::from_config(
-            &config,
-            CacheKey::CommCTree.to_string(),
-            Some(get_merkle_tree_len(nodes_count, Tree::Arity::to_usize())?),
-        );
-        tree_c_config.rows_to_discard =
-            default_rows_to_discard(nodes_count, Tree::Arity::to_usize());
+        let tree_c_config = StoreConfig {
+            path: cache_path,
+            id: CacheKey::CommCTree.to_string(),
+            size,
+            rows_to_discard,
+        };
 
         let labels =
             LabelsCache::<Tree>::new(&label_configs).context("failed to create labels cache")?;
@@ -1466,7 +1468,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         label_configs: Labels<Tree>,
         data: Data<'a>,
         data_tree: BinaryMerkleTree<G>,
-        config: StoreConfig,
+        cache_path: PathBuf,
         replica_path: PathBuf,
     ) -> Result<(
         <Self as PoRep<'a, Tree::Hasher, G>>::Tau,
@@ -1479,7 +1481,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             &pp.layer_challenges,
             data,
             Some(data_tree),
-            config,
+            cache_path,
             replica_path,
             label_configs,
         )?;


### PR DESCRIPTION
Instead of passing a whole config, which is then modified later on, just pass in the cache directory, which is the only thing that is used from the config. This change make it more obvious which values are actually modified.