### PR TITLE
refactor: introduce new from trait for PoseidonDomain

### DIFF
--- a/filecoin-hashers/src/poseidon.rs
+++ b/filecoin-hashers/src/poseidon.rs
@@ -57,7 +57,7 @@ impl Hashable<PoseidonFunction> for PoseidonDomain {
 }
 
 #[derive(Default, Copy, Clone, Debug, Serialize, Deserialize)]
-pub struct PoseidonDomain(pub <Fr as PrimeField>::Repr);
+pub struct PoseidonDomain(<Fr as PrimeField>::Repr);
 
 impl AsRef<PoseidonDomain> for PoseidonDomain {
     fn as_ref(&self) -> &PoseidonDomain {
@@ -362,6 +362,13 @@ impl From<[u8; 32]> for PoseidonDomain {
     #[inline]
     fn from(val: [u8; 32]) -> Self {
         PoseidonDomain(val)
+    }
+}
+
+impl From<PoseidonDomain> for [u8; 32] {
+    #[inline]
+    fn from(val: PoseidonDomain) -> Self {
+        val.0
     }
 }
 

--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -754,6 +754,9 @@ mod tests {
             .read_at(final_labels.len() - 1)
             .expect("read_at");
         dbg!(&last_label);
-        assert_eq!(expected_last_label.to_repr(), last_label.0);
+        assert_eq!(
+            expected_last_label.to_repr(),
+            <<Fr as PrimeField>::Repr>::from(last_label)
+        );
     }
 }

--- a/storage-proofs-porep/tests/stacked_vanilla.rs
+++ b/storage-proofs-porep/tests/stacked_vanilla.rs
@@ -577,5 +577,8 @@ fn test_generate_labels_aux(
     let final_labels = labels.labels_for_last_layer().unwrap();
     let last_label = final_labels.read_at(nodes - 1).unwrap();
 
-    assert_eq!(expected_last_label.to_repr(), last_label.0);
+    assert_eq!(
+        expected_last_label.to_repr(),
+        <<Fr as PrimeField>::Repr>::from(last_label)
+    );
 }


### PR DESCRIPTION
Add a new `From` conversion into the field element repr representation. This makes it also possible to hide the internal representation.