### PR TITLE
Add API to do only SDR

### DIFF
--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -202,7 +202,7 @@ where
     let labels = StackedDrg::<Tree, DefaultPieceHasher>::replicate_phase1(
         &compound_public_params.vanilla_params,
         &replica_id,
-        config.clone(),
+        &config.path,
     )?;
 
     let out = SealPreCommitPhase1Output {
@@ -1260,15 +1260,6 @@ pub fn sdr<P, Tree: 'static + MerkleTreeTrait>(
 where
     P: AsRef<Path>,
 {
-    let base_tree_size = get_base_tree_size::<DefaultBinaryTree>(porep_config.sector_size)?;
-    let base_tree_leafs = get_base_tree_leafs::<DefaultBinaryTree>(base_tree_size)?;
-
-    let config = StoreConfig::new(
-        cache_path.as_ref(),
-        CacheKey::CommDTree.to_string(),
-        default_rows_to_discard(base_tree_leafs, BINARY_ARITY),
-    );
-
     let setup_params = setup_params(
         porep_config.padded_bytes_amount(),
         usize::from(porep_config.partitions),
@@ -1277,7 +1268,11 @@ where
     )?;
     let public_params = StackedDrg::<Tree, DefaultPieceHasher>::setup(&setup_params)?;
 
-    StackedDrg::<Tree, DefaultPieceHasher>::replicate_phase1(&public_params, replica_id, config)?;
+    StackedDrg::<Tree, DefaultPieceHasher>::replicate_phase1(
+        &public_params,
+        replica_id,
+        &cache_path,
+    )?;
 
     Ok(())
 }

--- a/storage-proofs-porep/src/stacked/vanilla/create_label/mod.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/mod.rs
@@ -1,5 +1,6 @@
 use std::fs::{self, create_dir_all, remove_file, rename, File};
 use std::io::{self, BufReader};
+use std::path::Path;
 
 use anyhow::Context;
 use filecoin_hashers::Hasher;
@@ -7,9 +8,10 @@ use log::{info, warn};
 use merkletree::{merkle::Element, store::StoreConfig};
 use storage_proofs_core::{
     cache_key::CacheKey, drgraph::Graph, error::Result, merkle::MerkleTreeTrait,
+    util::default_rows_to_discard,
 };
 
-use crate::stacked::vanilla::{proof::LayerState, StackedBucketGraph};
+use crate::stacked::vanilla::{proof::LayerState, StackedBucketGraph, BINARY_ARITY};
 
 #[cfg(feature = "multicore-sdr")]
 pub mod multi;
@@ -17,13 +19,19 @@ pub mod single;
 
 /// Prepares the necessary `StoreConfig`s with which the layers are stored.
 /// Also checks for already existing layers and marks them as such.
-pub fn prepare_layers<Tree: 'static + MerkleTreeTrait>(
+pub fn prepare_layers<P, Tree: 'static + MerkleTreeTrait>(
     graph: &StackedBucketGraph<Tree::Hasher>,
-    config: &StoreConfig,
+    cache_path: P,
     layers: usize,
-) -> Vec<LayerState> {
-    let label_configs = (1..=layers).map(|layer| {
-        StoreConfig::from_config(config, CacheKey::label_layer(layer), Some(graph.size()))
+) -> Vec<LayerState>
+where
+    P: AsRef<Path>,
+{
+    let label_configs = (1..=layers).map(|layer| StoreConfig {
+        path: cache_path.as_ref().to_path_buf(),
+        id: CacheKey::label_layer(layer),
+        size: Some(graph.size()),
+        rows_to_discard: default_rows_to_discard(graph.size(), BINARY_ARITY),
     });
 
     let mut states = Vec::with_capacity(layers);

--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -1,6 +1,7 @@
 use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::mem::{self, size_of};
+use std::path::Path;
 use std::sync::{
     atomic::{AtomicU64, Ordering::SeqCst},
     Arc, MutexGuard,
@@ -436,16 +437,20 @@ fn create_layer_labels(
 }
 
 #[allow(clippy::type_complexity)]
-pub fn create_labels_for_encoding<Tree: 'static + MerkleTreeTrait, T: AsRef<[u8]>>(
+pub fn create_labels_for_encoding<
+    Tree: 'static + MerkleTreeTrait,
+    T: AsRef<[u8]>,
+    P: AsRef<Path>,
+>(
     graph: &StackedBucketGraph<Tree::Hasher>,
     parents_cache: &ParentCache,
     layers: usize,
     replica_id: T,
-    config: StoreConfig,
+    cache_path: P,
 ) -> Result<(Labels<Tree>, Vec<LayerState>)> {
     info!("create labels");
 
-    let layer_states = prepare_layers::<Tree>(graph, &config, layers);
+    let layer_states = prepare_layers::<_, Tree>(graph, &cache_path, layers);
 
     let sector_size = graph.size() * NODE_SIZE;
     let node_count = graph.size() as u64;

--- a/storage-proofs-porep/src/stacked/vanilla/create_label/single.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/single.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 use std::mem;
+use std::path::Path;
 
 use anyhow::{Context, Result};
 use filecoin_hashers::Hasher;
@@ -21,16 +22,20 @@ use crate::stacked::vanilla::{
 };
 
 #[allow(clippy::type_complexity)]
-pub fn create_labels_for_encoding<Tree: 'static + MerkleTreeTrait, T: AsRef<[u8]>>(
+pub fn create_labels_for_encoding<
+    Tree: 'static + MerkleTreeTrait,
+    T: AsRef<[u8]>,
+    P: AsRef<Path>,
+>(
     graph: &StackedBucketGraph<Tree::Hasher>,
     parents_cache: &mut ParentCache,
     layers: usize,
     replica_id: T,
-    config: StoreConfig,
+    cache_path: P,
 ) -> Result<(Labels<Tree>, Vec<LayerState>)> {
     info!("generate labels");
 
-    let layer_states = prepare_layers::<Tree>(graph, &config, layers);
+    let layer_states = prepare_layers::<_, Tree>(graph, &cache_path, layers);
 
     let layer_size = graph.size() * NODE_SIZE;
     // NOTE: this means we currently keep 2x sector size around, to improve speed.

--- a/storage-proofs-porep/tests/stacked_vanilla.rs
+++ b/storage-proofs-porep/tests/stacked_vanilla.rs
@@ -136,7 +136,7 @@ fn test_extract_all<Tree: 'static + MerkleTreeTrait>() {
         &pp.graph,
         &layer_challenges,
         &replica_id,
-        config.clone(),
+        &config.path,
     )
     .expect("label generation failed");
     for state in &label_states {
@@ -154,7 +154,7 @@ fn test_extract_all<Tree: 'static + MerkleTreeTrait>() {
         &pp.graph,
         &layer_challenges,
         &replica_id,
-        config.clone(),
+        &config.path,
     )
     .expect("label generation failed");
     for state in &label_states[..off] {
@@ -267,7 +267,7 @@ fn test_stacked_porep_resume_seal() {
         &pp.graph,
         &layer_challenges,
         &replica_id,
-        config.clone(),
+        &config.path,
     )
     .expect("label generation failed");
     let off = label_states.len() - 3;


### PR DESCRIPTION
This PR adds an API to do SDR without doing anything else.

Please note that it's split into two commits. The first one adds the API, the second one is a refacoring, which makes the API a bit clearer IMHO. It passes only on the path, which is the only thing that's really needed.