### PR TITLE
refactor: do not call circuit_proofs directly

### DIFF
--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -524,17 +524,12 @@ pub fn seal_commit_phase2<Tree: 'static + MerkleTreeTrait>(
         _,
     >>::setup(&compound_setup_params)?;
 
-    trace!("snark_proof:start");
-    let groth_proofs = StackedCompound::<Tree, DefaultPieceHasher>::circuit_proofs(
+    let proof = StackedCompound::<Tree, DefaultPieceHasher>::prove_with_vanilla(
+        &compound_public_params,
         &public_inputs,
         vanilla_proofs,
-        &compound_public_params.vanilla_params,
         &groth_params,
-        compound_public_params.priority,
     )?;
-    trace!("snark_proof:finish");
-
-    let proof = MultiProof::new(groth_proofs, &groth_params.pvk);
 
     let mut buf =
         Vec::with_capacity(SINGLE_PARTITION_PROOF_LEN * usize::from(porep_config.partitions));


### PR DESCRIPTION
`circuit_proofs` should not be called directly according to the comment at
 https://github.com/filecoin-project/rust-fil-proofs/blob/95e8c982540b14077d58ee9ddc076f7602b4805d/storage-proofs-core/src/compound_proof.rs#L228-L232

The correct call is `prove_with_vanilla`, use that instead.

This leads to a clearer call path, hence an easier to follow code.