### PR TITLE
feat: add fallback option if no t_aux file exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ FIL_PROOFS_VERIFY_PRODUCTION_PARAMS=1
 
 By default, this verification is disabled.
 
+```
+FIL_PROOFS_T_AUX_IMPLICIT_FALLBACK=1
+```
+
+By default, the `t_aux` file must exist after a successful Precommit Phase 2. With enabling this setting, the system will use a `t_aux` based on the default values and passed in parameters, if the `t_aux` file cannot be read.
+
 ## Optimizing for either speed or memory during replication
 
 While replicating and generating the Merkle Trees (MT) for the proof at the same time there will always be a time-memory trade-off to consider, we present here strategies to optimize one at the cost of the other.

--- a/storage-proofs-core/src/settings.rs
+++ b/storage-proofs-core/src/settings.rs
@@ -30,6 +30,7 @@ pub struct Settings {
     pub multicore_sdr_producers: usize,
     pub multicore_sdr_producer_stride: u64,
     pub multicore_sdr_lookahead: usize,
+    pub t_aux_implicit_fallback: bool,
 }
 
 impl Default for Settings {
@@ -54,6 +55,7 @@ impl Default for Settings {
             multicore_sdr_producers: 3,
             multicore_sdr_producer_stride: 128,
             multicore_sdr_lookahead: 800,
+            t_aux_implicit_fallback: false,
         }
     }
 }


### PR DESCRIPTION
The only information from the `t_aux` file that is used during Commitphase 1 (C1) is the number of rows that are discarded from TreeC. If that value is either the default, or set via `FIL_PROOFS_ROWS_TO_DISCARD` accordingly, then all other parts of `t_aux` can be inferred from the function call.

When `FIL_PROOFS_T_AUX_IMPLICIT_FALLBACK=1` is set, then those inferred values will be used, in case the `t_aux` file cannot be read or doesn't exist.