### PR TITLE
refactor: make configuration more obvious

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -1930,16 +1930,12 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         let tree_count = get_base_tree_count::<Tree>();
         let nodes_count = leaf_count / tree_count;
 
-        let config = StoreConfig::new(
-            cache_path.as_ref(),
-            CacheKey::CommRLastTree.to_string(),
-            default_rows_to_discard(nodes_count, Tree::Arity::to_usize()),
-        );
-        let tree_r_last_config = StoreConfig::from_config(
-            &config,
-            CacheKey::CommRLastTree.to_string(),
-            Some(get_merkle_tree_len(nodes_count, Tree::Arity::to_usize())?),
-        );
+        let tree_r_last_config = StoreConfig {
+            path: cache_path.as_ref().into(),
+            id: CacheKey::CommRLastTree.to_string(),
+            size: Some(get_merkle_tree_len(nodes_count, Tree::Arity::to_usize())?),
+            rows_to_discard: default_rows_to_discard(nodes_count, Tree::Arity::to_usize()),
+        };
 
         // Encode original data into the last layer.
         info!("building tree_r_last");


### PR DESCRIPTION
Instead of creating two configs, that depend on each other, create a single one in the most straightforward way.

---

Now that we had a release I'm trying to push general useful changes from my proofs bin work onto master piece by piece, so that I don't have to rebase them in the future.