### PR TITLE
Allow sealing without t_aux files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,11 @@ jobs:
   test_release:
     executor: default
     environment: *setup-env
+    parameters:
+      cargo-args:
+        description: Addtional arguments for the cargo command
+        type: string
+        default: ""
     steps:
       - checkout
       - attach_workspace:
@@ -86,10 +91,10 @@ jobs:
             ulimit -n 20000
             ulimit -u 20000
             ulimit -n 20000
-            cargo test --verbose --release --workspace --all-targets
+            cargo test --verbose --release --workspace --all-targets << parameters.cargo-args >>
             # Some `storage-proofs-update` tests need to run sequentially due
             # to their high memory usage.
-            cargo test -p storage-proofs-update --features isolated-testing --release -- --test-threads=1
+            cargo test -p storage-proofs-update --features isolated-testing --release << parameters.cargo-args >> -- --test-threads=1
           no_output_timeout: 30m
 
   test_ignored_release:
@@ -431,7 +436,14 @@ workflows:
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
-            
+
+      - test_release:
+          name: test_release (fixed-rows-to-discard)
+          cargo-args: "--features fixed-rows-to-discard"
+          requires:
+            - cargo_fetch
+            - ensure_groth_parameters_and_keys_linux
+
       - test_ignored_release:
           name: test_ignored_release_storage_proofs_post
           crate: "storage-proofs-post"

--- a/fil-proofs-param/Cargo.toml
+++ b/fil-proofs-param/Cargo.toml
@@ -50,3 +50,6 @@ simd = ["storage-proofs-core/simd"]
 asm = ["storage-proofs-core/asm"]
 cuda = ["storage-proofs-core/cuda", "storage-proofs-porep/cuda", "storage-proofs-post/cuda", "storage-proofs-update/cuda"]
 opencl = ["storage-proofs-core/opencl", "storage-proofs-porep/opencl", "storage-proofs-post/opencl", "storage-proofs-update/opencl"]
+# This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
+# setting is ignored, no `TemporaryAux` file will be written.
+fixed-rows-to-discard = ["filecoin-proofs/fixed-rows-to-discard", "storage-proofs-core/fixed-rows-to-discard", "storage-proofs-porep/fixed-rows-to-discard", "storage-proofs-post/fixed-rows-to-discard", "storage-proofs-update/fixed-rows-to-discard"]

--- a/fil-proofs-tooling/Cargo.toml
+++ b/fil-proofs-tooling/Cargo.toml
@@ -70,6 +70,14 @@ opencl = [
 ]
 measurements = ["storage-proofs-core/measurements"]
 profile = ["storage-proofs-core/profile", "measurements"]
+# This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
+# setting is ignored, no `TemporaryAux` file will be written.
+fixed-rows-to-discard = [
+    "filecoin-proofs/fixed-rows-to-discard",
+    "storage-proofs-core/fixed-rows-to-discard",
+    "storage-proofs-porep/fixed-rows-to-discard",
+    "storage-proofs-post/fixed-rows-to-discard",
+]
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 raw-cpuid = "10.3.0"

--- a/filecoin-proofs/Cargo.toml
+++ b/filecoin-proofs/Cargo.toml
@@ -76,6 +76,14 @@ opencl = [
 ]
 multicore-sdr = ["storage-proofs-porep/multicore-sdr"]
 big-tests = []
+# This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
+# setting is ignored, no `TemporaryAux` file will be written.
+fixed-rows-to-discard = [
+    "storage-proofs-core/fixed-rows-to-discard",
+    "storage-proofs-porep/fixed-rows-to-discard",
+    "storage-proofs-post/fixed-rows-to-discard",
+    "storage-proofs-update/fixed-rows-to-discard",
+]
 
 [[bench]]
 name = "preprocessing"

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -739,8 +739,7 @@ where
     // Make sure p_aux exists and is valid.
     let _ = util::get_p_aux::<Tree>(cache)?;
 
-    // Make sure t_aux exists and is valid.
-    let t_aux = util::get_t_aux::<Tree>(cache)?;
+    let t_aux = util::get_t_aux::<Tree>(cache, metadata.len())?;
 
     // Verify all stores/labels within the Labels object.
     let cache = cache_path.as_ref().to_path_buf();

--- a/filecoin-proofs/src/api/update.rs
+++ b/filecoin-proofs/src/api/update.rs
@@ -95,7 +95,8 @@ pub fn encode_into<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
     let config = SectorUpdateConfig::from_porep_config(porep_config);
 
     let p_aux = util::get_p_aux::<Tree>(sector_key_cache_path)?;
-    let t_aux = util::get_t_aux::<Tree>(sector_key_cache_path)?;
+    let t_aux =
+        util::get_t_aux::<Tree>(sector_key_cache_path, u64::from(porep_config.sector_size))?;
 
     let (tree_d_new_config, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux, new_cache_path, config.nodes_count)?;
@@ -138,6 +139,7 @@ pub fn encode_into<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
     let mut p_aux = p_aux;
     p_aux.comm_r_last = comm_r_last_domain;
     util::persist_p_aux::<Tree>(&p_aux, new_cache_path)?;
+    #[cfg(not(feature = "fixed-rows-to-discard"))]
     util::persist_t_aux::<Tree>(&t_aux, new_cache_path)?;
 
     info!("encode_into:finish");
@@ -272,7 +274,7 @@ pub fn remove_encoded_data<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>
     info!("remove_data:start");
 
     let p_aux = util::get_p_aux::<Tree>(replica_cache_path)?;
-    let t_aux = util::get_t_aux::<Tree>(replica_cache_path)?;
+    let t_aux = util::get_t_aux::<Tree>(replica_cache_path, u64::from(config.sector_size))?;
 
     let (_, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux, sector_key_cache_path, config.nodes_count)?;
@@ -295,6 +297,7 @@ pub fn remove_encoded_data<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>
     let mut p_aux = p_aux;
     p_aux.comm_r_last = tree_r_last_new;
     util::persist_p_aux::<Tree>(&p_aux, sector_key_cache_path)?;
+    #[cfg(not(feature = "fixed-rows-to-discard"))]
     util::persist_t_aux::<Tree>(&t_aux, sector_key_cache_path)?;
 
     info!("remove_data:finish");
@@ -337,7 +340,7 @@ pub fn generate_single_partition_proof<Tree: 'static + MerkleTreeTrait<Hasher = 
         h: config.h,
     };
 
-    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path)?;
+    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path, u64::from(config.sector_size))?;
 
     let (tree_d_new_config, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux_old, replica_cache_path, config.nodes_count)?;
@@ -429,7 +432,7 @@ pub fn generate_partition_proofs<Tree: 'static + MerkleTreeTrait<Hasher = TreeRH
         h: config.h,
     };
 
-    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path)?;
+    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path, u64::from(config.sector_size))?;
 
     let (tree_d_new_config, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux_old, replica_cache_path, config.nodes_count)?;
@@ -571,7 +574,7 @@ pub fn generate_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher
         h: config.h,
     };
 
-    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path)?;
+    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path, u64::from(config.sector_size))?;
 
     let (tree_d_new_config, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux_old, replica_cache_path, config.nodes_count)?;

--- a/filecoin-proofs/src/api/util.rs
+++ b/filecoin-proofs/src/api/util.rs
@@ -167,17 +167,16 @@ mod tests {
 
     use storage_proofs_core::util::{self, NODE_SIZE};
 
-    use crate::SectorShape32GiB;
+    use crate::{SectorShape32GiB, SECTOR_SIZE_32_GIB};
 
     /// Testing whether the default values are set if there's no `t_aux` file.
     #[test]
     fn test_get_t_aux_defaults() {
         let dir_does_not_exist = Path::new("/path/does/not/exist");
-        let sector_size: usize = 34359738368;
-        let t_aux = get_t_aux::<SectorShape32GiB>(dir_does_not_exist, sector_size as u64)
+        let t_aux = get_t_aux::<SectorShape32GiB>(dir_does_not_exist, SECTOR_SIZE_32_GIB)
             .expect("t_aux should have been read");
         let expected_rows_to_discard = util::default_rows_to_discard(
-            sector_size / NODE_SIZE,
+            SECTOR_SIZE_32_GIB as usize / NODE_SIZE,
             <SectorShape32GiB as MerkleTreeTrait>::Arity::to_usize(),
         );
         assert_eq!(
@@ -189,18 +188,17 @@ mod tests {
     /// Testing whether the values from the `t_aux` file are used in case there is any.
     #[test]
     fn test_get_t_aux_file_exists() {
-        let sector_size = 34359738368;
         let cache_dir = tempfile::tempdir()
             .expect("tempdir should have been created")
             .into_path();
 
         // Check if getting t_aux if no such file exists returns the default values.
         let default_t_aux = TemporaryAux::<SectorShape32GiB, DefaultPieceHasher>::new(
-            sector_size / NODE_SIZE,
+            SECTOR_SIZE_32_GIB as usize / NODE_SIZE,
             11,
             cache_dir.clone(),
         );
-        let t_aux = get_t_aux::<SectorShape32GiB>(&cache_dir, sector_size as u64)
+        let t_aux = get_t_aux::<SectorShape32GiB>(&cache_dir, SECTOR_SIZE_32_GIB)
             .expect("t_aux should have been read");
         assert_eq!(
             t_aux.tree_r_last_config.rows_to_discard,
@@ -212,7 +210,7 @@ mod tests {
         custom_t_aux.tree_r_last_config.rows_to_discard = 5;
         persist_t_aux::<SectorShape32GiB>(&custom_t_aux, &cache_dir)
             .expect("t_aux should have been persisted");
-        let read_t_aux = get_t_aux::<SectorShape32GiB>(&cache_dir, sector_size as u64)
+        let read_t_aux = get_t_aux::<SectorShape32GiB>(&cache_dir, SECTOR_SIZE_32_GIB)
             .expect("t_aux should have been read");
         assert_ne!(
             read_t_aux.tree_r_last_config.rows_to_discard,

--- a/storage-proofs-core/Cargo.toml
+++ b/storage-proofs-core/Cargo.toml
@@ -59,6 +59,9 @@ asm = ["sha2/sha2-asm"]
 big-sector-sizes-bench = []
 measurements = ["cpu-time", "gperftools"]
 profile = ["measurements"]
+# This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
+# setting is ignored, no `TemporaryAux` file will be written.
+fixed-rows-to-discard = []
 
 cuda = ["bellperson/cuda", "filecoin-hashers/cuda"]
 cuda-supraseal = ["bellperson/cuda-supraseal", "filecoin-hashers/cuda"]

--- a/storage-proofs-core/src/settings.rs
+++ b/storage-proofs-core/src/settings.rs
@@ -10,6 +10,7 @@ lazy_static! {
 
 const SETTINGS_PATH: &str = "./rust-fil-proofs.config.toml";
 const PREFIX: &str = "FIL_PROOFS";
+pub const DEFAULT_ROWS_TO_DISCARD: u32 = 2;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(default)]
@@ -42,7 +43,7 @@ impl Default for Settings {
             column_write_batch_size: 262_144,
             use_gpu_tree_builder: false,
             max_gpu_tree_batch_size: 700_000,
-            rows_to_discard: 2,
+            rows_to_discard: DEFAULT_ROWS_TO_DISCARD,
             sdr_parents_cache_size: 2_048,
             window_post_synthesis_num_cpus: num_cpus::get() as u32,
             // `parameter_cache` does not use the cache() mechanism because it is now used

--- a/storage-proofs-core/src/util.rs
+++ b/storage-proofs-core/src/util.rs
@@ -8,7 +8,7 @@ use bellperson::{
 use ff::PrimeField;
 use merkletree::merkle::get_merkle_tree_row_count;
 
-use crate::{error::Error, settings::SETTINGS};
+use crate::{error::Error, settings};
 
 pub const NODE_SIZE: usize = 32;
 
@@ -163,9 +163,13 @@ pub fn default_rows_to_discard(leafs: usize, arity: usize) -> usize {
     // row_count - 2 discounts the base layer (1) and root (1)
     let max_rows_to_discard = row_count - 2;
 
-    // This configurable setting is for a default oct-tree
-    // rows_to_discard value, which defaults to 2.
-    let rows_to_discard = SETTINGS.rows_to_discard as usize;
+    // When `fixed-rows-to-discard` is set, then the number of rows to discard for the tree_r_last
+    // is hard-coded to 2. If the feature is not set it can be configured with the
+    // `ROWS_TO_DISCARD` setting.
+    #[cfg(feature = "fixed-rows-to-discard")]
+    let rows_to_discard = settings::DEFAULT_ROWS_TO_DISCARD as usize;
+    #[cfg(not(feature = "fixed-rows-to-discard"))]
+    let rows_to_discard = settings::SETTINGS.rows_to_discard as usize;
 
     // Discard at most 'constant value' rows (coded below,
     // differing by arity) while respecting the max number that

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -65,6 +65,9 @@ cuda = ["storage-proofs-core/cuda", "filecoin-hashers/cuda", "neptune/cuda", "be
 opencl = ["storage-proofs-core/opencl", "filecoin-hashers/opencl", "neptune/opencl", "bellperson/opencl"]
 isolated-testing = []
 multicore-sdr = ["hwloc"]
+# This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
+# setting is ignored, no `TemporaryAux` file will be written.
+fixed-rows-to-discard = ["storage-proofs-core/fixed-rows-to-discard"]
 
 [[bench]]
 name = "encode"

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -1524,12 +1524,13 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             path: cache_path.clone(),
             id: CacheKey::CommRLastTree.to_string(),
             size,
-            // A default 'rows_to_discard' value will be chosen for tree_r_last, unless the user
-            // overrides this value via the environment setting (FIL_PROOFS_ROWS_TO_DISCARD). If
-            // this value is specified, no checking is done on it and it may result in a broken
-            // configuration. *Use with caution*. It must be noted that if/when this unchecked
-            // value is passed through merkle_light, merkle_light now does a check that does not
-            // allow us to discard more rows than is possible to discard.
+            // A default 'rows_to_discard' value will be chosen for tree_r_last, unless the
+            // `fixed-rows-to-discard` feature is not enabled and the user overrides this value
+            // via the environment setting (FIL_PROOFS_ROWS_TO_DISCARD). If this value is
+            // specified, no checking is done on it and it may result in a broken configuration.
+            // *Use with caution*. It must be noted that if/when this unchecked value is passed
+            // through merkle_light, merkle_light now does a check that does not allow us to
+            // discard more rows than is possible to discard.
             rows_to_discard: default_rows_to_discard(nodes_count, Tree::Arity::to_usize()),
         };
         trace!(

--- a/storage-proofs-post/Cargo.toml
+++ b/storage-proofs-post/Cargo.toml
@@ -36,3 +36,6 @@ rand_xorshift = "0.3.0"
 default = ["opencl"]
 cuda = ["storage-proofs-core/cuda", "filecoin-hashers/cuda"]
 opencl = ["storage-proofs-core/opencl", "filecoin-hashers/opencl"]
+# This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
+# setting is ignored, no `TemporaryAux` file will be written.
+fixed-rows-to-discard = ["storage-proofs-core/fixed-rows-to-discard"]

--- a/storage-proofs-update/Cargo.toml
+++ b/storage-proofs-update/Cargo.toml
@@ -51,3 +51,6 @@ cuda = [
 multicore-sdr = [
     "storage-proofs-porep/multicore-sdr",
 ]
+# This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`
+# setting is ignored, no `TemporaryAux` file will be written.
+fixed-rows-to-discard = ["storage-proofs-core/fixed-rows-to-discard", "storage-proofs-porep/fixed-rows-to-discard"]


### PR DESCRIPTION
This PR introduces a new feature called `fixed-rows-to-discard`, when enabled, no `t_aux` files are written or read. It contains quite a lot of changes as some refactorings lead to less `StoreConfig`s and hence make it easier to reason about the whole change that it still does the correct thing.

This PR supersedes https://github.com/filecoin-project/rust-fil-proofs/pull/1715.