### PR TITLE
refactor: refactor p_aux/t_aux handling into the util module

### DIFF
--- a/filecoin-proofs/src/api/update.rs
+++ b/filecoin-proofs/src/api/update.rs
@@ -1,26 +1,23 @@
 use std::cmp;
-use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::Path;
 
 use anyhow::{ensure, Context, Result};
-use bincode::{deserialize, serialize};
 use ff::PrimeField;
 use filecoin_hashers::{Domain, Hasher};
 use fr32::bytes_into_fr;
 use generic_array::typenum::Unsigned;
-use log::{info, trace};
+use log::info;
 use merkletree::merkle::get_merkle_tree_len;
 use merkletree::store::StoreConfig;
 use storage_proofs_core::{
-    cache_key::CacheKey,
     compound_proof::{self, CompoundProof},
     merkle::{get_base_tree_count, MerkleTreeTrait},
     multi_proof::MultiProof,
     proof::ProofScheme,
     util::NODE_SIZE,
 };
-use storage_proofs_porep::stacked::{PersistentAux, TemporaryAux};
+use storage_proofs_porep::stacked::TemporaryAux;
 use storage_proofs_update::{
     constants::{h_default, TreeDArity, TreeDDomain, TreeRDomain, TreeRHasher},
     phi,
@@ -40,66 +37,6 @@ use crate::{
         SectorUpdateConfig,
     },
 };
-
-// Instantiates p_aux from the specified cache_dir for access to comm_c and comm_r_last
-fn get_p_aux<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    cache_path: &Path,
-) -> Result<PersistentAux<<Tree::Hasher as Hasher>::Domain>> {
-    let p_aux_path = cache_path.join(CacheKey::PAux.to_string());
-    let p_aux_bytes = fs::read(&p_aux_path)
-        .with_context(|| format!("could not read file p_aux={:?}", p_aux_path))?;
-
-    let p_aux = deserialize(&p_aux_bytes)?;
-
-    Ok(p_aux)
-}
-
-fn persist_p_aux<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    p_aux: &PersistentAux<<Tree::Hasher as Hasher>::Domain>,
-    cache_path: &Path,
-) -> Result<()> {
-    let p_aux_path = cache_path.join(CacheKey::PAux.to_string());
-    let mut f_p_aux = File::create(&p_aux_path)
-        .with_context(|| format!("could not create file p_aux={:?}", p_aux_path))?;
-    let p_aux_bytes = serialize(&p_aux)?;
-    f_p_aux
-        .write_all(&p_aux_bytes)
-        .with_context(|| format!("could not write to file p_aux={:?}", p_aux_path))?;
-
-    Ok(())
-}
-
-// Instantiates t_aux from the specified cache_dir for access to
-// labels and tree_d, tree_c, tree_r_last store configs
-fn get_t_aux<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    cache_path: &Path,
-) -> Result<TemporaryAux<Tree, DefaultPieceHasher>> {
-    let t_aux_path = cache_path.join(CacheKey::TAux.to_string());
-    trace!("Instantiating TemporaryAux from {:?}", cache_path);
-    let t_aux_bytes = fs::read(&t_aux_path)
-        .with_context(|| format!("could not read file t_aux={:?}", t_aux_path))?;
-
-    let mut res: TemporaryAux<Tree, DefaultPieceHasher> = deserialize(&t_aux_bytes)?;
-    res.set_cache_path(cache_path);
-    trace!("Set TemporaryAux cache_path to {:?}", cache_path);
-
-    Ok(res)
-}
-
-fn persist_t_aux<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
-    t_aux: &TemporaryAux<Tree, DefaultPieceHasher>,
-    cache_path: &Path,
-) -> Result<()> {
-    let t_aux_path = cache_path.join(CacheKey::TAux.to_string());
-    let mut f_t_aux = File::create(&t_aux_path)
-        .with_context(|| format!("could not create file t_aux={:?}", t_aux_path))?;
-    let t_aux_bytes = serialize(&t_aux)?;
-    f_t_aux
-        .write_all(&t_aux_bytes)
-        .with_context(|| format!("could not write to file t_aux={:?}", t_aux_path))?;
-
-    Ok(())
-}
 
 // Re-instantiate a t_aux with the new cache path, then use the tree_d
 // and tree_r_last configs from it.  This is done to preserve the
@@ -157,8 +94,8 @@ pub fn encode_into<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
     info!("encode_into:start");
     let config = SectorUpdateConfig::from_porep_config(porep_config);
 
-    let p_aux = get_p_aux::<Tree>(sector_key_cache_path)?;
-    let t_aux = get_t_aux::<Tree>(sector_key_cache_path)?;
+    let p_aux = util::get_p_aux::<Tree>(sector_key_cache_path)?;
+    let t_aux = util::get_t_aux::<Tree>(sector_key_cache_path)?;
 
     let (tree_d_new_config, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux, new_cache_path, config.nodes_count)?;
@@ -200,8 +137,8 @@ pub fn encode_into<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
     // Persist p_aux and t_aux into the new_cache_path here
     let mut p_aux = p_aux;
     p_aux.comm_r_last = comm_r_last_domain;
-    persist_p_aux::<Tree>(&p_aux, new_cache_path)?;
-    persist_t_aux::<Tree>(&t_aux, new_cache_path)?;
+    util::persist_p_aux::<Tree>(&p_aux, new_cache_path)?;
+    util::persist_t_aux::<Tree>(&t_aux, new_cache_path)?;
 
     info!("encode_into:finish");
 
@@ -303,7 +240,7 @@ pub fn decode_from<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>>(
 ) -> Result<()> {
     info!("decode_from:start");
 
-    let p_aux = get_p_aux::<Tree>(sector_key_cache_path)?;
+    let p_aux = util::get_p_aux::<Tree>(sector_key_cache_path)?;
 
     EmptySectorUpdate::<Tree>::decode_from(
         config.nodes_count,
@@ -334,8 +271,8 @@ pub fn remove_encoded_data<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>
 ) -> Result<()> {
     info!("remove_data:start");
 
-    let p_aux = get_p_aux::<Tree>(replica_cache_path)?;
-    let t_aux = get_t_aux::<Tree>(replica_cache_path)?;
+    let p_aux = util::get_p_aux::<Tree>(replica_cache_path)?;
+    let t_aux = util::get_t_aux::<Tree>(replica_cache_path)?;
 
     let (_, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux, sector_key_cache_path, config.nodes_count)?;
@@ -357,8 +294,8 @@ pub fn remove_encoded_data<Tree: 'static + MerkleTreeTrait<Hasher = TreeRHasher>
     // Persist p_aux and t_aux into the sector_key_cache_path here
     let mut p_aux = p_aux;
     p_aux.comm_r_last = tree_r_last_new;
-    persist_p_aux::<Tree>(&p_aux, sector_key_cache_path)?;
-    persist_t_aux::<Tree>(&t_aux, sector_key_cache_path)?;
+    util::persist_p_aux::<Tree>(&p_aux, sector_key_cache_path)?;
+    util::persist_t_aux::<Tree>(&t_aux, sector_key_cache_path)?;
 
     info!("remove_data:finish");
     Ok(())
@@ -387,7 +324,7 @@ pub fn generate_single_partition_proof<Tree: 'static + MerkleTreeTrait<Hasher = 
     let public_params: storage_proofs_update::PublicParams =
         PublicParams::from_sector_size(u64::from(config.sector_size));
 
-    let p_aux_old = get_p_aux::<Tree>(sector_key_cache_path)?;
+    let p_aux_old = util::get_p_aux::<Tree>(sector_key_cache_path)?;
 
     let partitions = usize::from(config.update_partitions);
     ensure!(partition_index < partitions, "invalid partition index");
@@ -400,7 +337,7 @@ pub fn generate_single_partition_proof<Tree: 'static + MerkleTreeTrait<Hasher = 
         h: config.h,
     };
 
-    let t_aux_old = get_t_aux::<Tree>(sector_key_cache_path)?;
+    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path)?;
 
     let (tree_d_new_config, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux_old, replica_cache_path, config.nodes_count)?;
@@ -482,7 +419,7 @@ pub fn generate_partition_proofs<Tree: 'static + MerkleTreeTrait<Hasher = TreeRH
     let public_params: storage_proofs_update::PublicParams =
         PublicParams::from_sector_size(u64::from(config.sector_size));
 
-    let p_aux_old = get_p_aux::<Tree>(sector_key_cache_path)?;
+    let p_aux_old = util::get_p_aux::<Tree>(sector_key_cache_path)?;
 
     let public_inputs: storage_proofs_update::PublicInputs = PublicInputs {
         k: usize::from(config.update_partitions),
@@ -492,7 +429,7 @@ pub fn generate_partition_proofs<Tree: 'static + MerkleTreeTrait<Hasher = TreeRH
         h: config.h,
     };
 
-    let t_aux_old = get_t_aux::<Tree>(sector_key_cache_path)?;
+    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path)?;
 
     let (tree_d_new_config, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux_old, replica_cache_path, config.nodes_count)?;
@@ -623,7 +560,7 @@ pub fn generate_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher
 
     let config = SectorUpdateConfig::from_porep_config(porep_config);
 
-    let p_aux_old = get_p_aux::<Tree>(sector_key_cache_path)?;
+    let p_aux_old = util::get_p_aux::<Tree>(sector_key_cache_path)?;
 
     let partitions = usize::from(config.update_partitions);
     let public_inputs: storage_proofs_update::PublicInputs = PublicInputs {
@@ -634,7 +571,7 @@ pub fn generate_empty_sector_update_proof<Tree: 'static + MerkleTreeTrait<Hasher
         h: config.h,
     };
 
-    let t_aux_old = get_t_aux::<Tree>(sector_key_cache_path)?;
+    let t_aux_old = util::get_t_aux::<Tree>(sector_key_cache_path)?;
 
     let (tree_d_new_config, tree_r_last_new_config) =
         get_new_configs_from_t_aux_old::<Tree>(&t_aux_old, replica_cache_path, config.nodes_count)?;


### PR DESCRIPTION
`p_aux` and `t_aux` is dealt with throughout the code. In the update proofs API they are nicely put into functions. Move those functions into the common utility module and then use those in all places.

The update proofs API puts a restriction on using the Poseidon hasher. This restriction is kept as it makes sense for all cases where `p_aux` and `t_aux` is used.