### PR TITLE
ci: update macos runner to Apple silicon

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -289,7 +289,7 @@ jobs:
     macos:
       xcode: "13.4.1"
     working_directory: ~/crate
-    resource_class: large
+    resource_class: macos.x86.medium.gen2
     environment: *setup-env
     steps:
       - run:


### PR DESCRIPTION
CircleCI is removing support for Apple Intel executors on Oct 2 - see https://discuss.circleci.com/t/macos-resource-deprecation-update/46891. After that date only Apple Silicon executors will be available. This PR ensures the macos builds are executed on Apple Silicon executors only.