### PR TITLE
ci: use gen2 macos executors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,8 +288,8 @@ jobs:
   test_darwin:
     macos:
       xcode: "13.4.1"
+    resource_class: macos.x86.medium.gen2
     working_directory: ~/crate
-    resource_class: large
     environment: *setup-env
     steps:
       - run:
@@ -421,28 +421,28 @@ workflows:
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
-            
+
       - test_ignored_release:
           name: test_ignored_release_storage_proofs_post
           crate: "storage-proofs-post"
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
-            
+
       - test_ignored_release:
           name: test_ignored_release_storage_proofs_core
           crate: "storage-proofs-core"
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
-            
+
       - test_ignored_release:
           name: test_ignored_release_storage_proofs_porep
           crate: "storage-proofs-porep"
           requires:
             - cargo_fetch
             - ensure_groth_parameters_and_keys_linux
-            
+
       - test_ignored_release:
           name: test_ignored_release_filecoin_proofs
           crate: "filecoin-proofs"


### PR DESCRIPTION
This PR ensure the repo continues to build on Apple Intel executors beyond October 2. Gen 1 executors are getting deprecated. See https://discuss.circleci.com/t/macos-intel-support-deprecation-in-january-2024/48718.

In January 2024, Apple Intel executors will be getting deprecated altogether. This repository is not ready to be switched to Apple Silicon runners because `test_darwin` fails with:
```
/bin/bash: /tmp/paramcache.awesome: Bad CPU type in executable
```

**NOTE** Some workflows in this repo currently fail but `test_darwin` is not one of them.