### PR TITLE
refactor: StackedCircuit only needs the number of layers

### DIFF
--- a/filecoin-proofs/src/types/porep_config.rs
+++ b/filecoin-proofs/src/types/porep_config.rs
@@ -101,7 +101,7 @@ impl PoRepConfig {
 
         Ok(
             <StackedCompound<Tree, DefaultPieceHasher> as CacheableParameters<
-                StackedCircuit<'_, Tree, DefaultPieceHasher>,
+                StackedCircuit<Tree, DefaultPieceHasher>,
                 _,
             >>::cache_identifier(&params),
         )

--- a/storage-proofs-porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs-porep/src/stacked/circuit/proof.rs
@@ -25,13 +25,13 @@ use crate::stacked::{circuit::params::Proof, StackedDrg};
 ///
 /// * `params` - parameters for the curve
 ///
-pub struct StackedCircuit<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> {
-    public_params: <StackedDrg<'a, Tree, G> as ProofScheme<'a>>::PublicParams,
+pub struct StackedCircuit<Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> {
     replica_id: Option<<Tree::Hasher as Hasher>::Domain>,
     comm_d: Option<G::Domain>,
     comm_r: Option<<Tree::Hasher as Hasher>::Domain>,
     comm_r_last: Option<<Tree::Hasher as Hasher>::Domain>,
     comm_c: Option<<Tree::Hasher as Hasher>::Domain>,
+    num_layers: usize,
 
     // one proof per challenge
     proofs: Vec<Proof<Tree, G>>,
@@ -41,25 +41,25 @@ pub struct StackedCircuit<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hash
 // #[derive(Clone)]) because derive(Clone) will only expand for MerkleTreeTrait types that also
 // implement Clone. Not every MerkleTreeTrait type is Clone-able because not all merkel Store's are
 // Clone-able, therefore deriving Clone would impl Clone for less than all possible Tree types.
-impl<'a, Tree: MerkleTreeTrait, G: Hasher> Clone for StackedCircuit<'a, Tree, G> {
+impl<Tree: MerkleTreeTrait, G: Hasher> Clone for StackedCircuit<Tree, G> {
     fn clone(&self) -> Self {
         StackedCircuit {
-            public_params: self.public_params.clone(),
             replica_id: self.replica_id,
             comm_d: self.comm_d,
             comm_r: self.comm_r,
             comm_r_last: self.comm_r_last,
             comm_c: self.comm_c,
+            num_layers: self.num_layers,
             proofs: self.proofs.clone(),
         }
     }
 }
 
-impl<'a, Tree: MerkleTreeTrait, G: Hasher> CircuitComponent for StackedCircuit<'a, Tree, G> {
+impl<Tree: MerkleTreeTrait, G: Hasher> CircuitComponent for StackedCircuit<Tree, G> {
     type ComponentPrivateInputs = ();
 }
 
-impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedCircuit<'a, Tree, G> {
+impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedCircuit<Tree, G> {
     #[allow(clippy::too_many_arguments)]
     pub fn synthesize<CS>(
         mut cs: CS,
@@ -74,13 +74,13 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedCircuit<'a
     where
         CS: ConstraintSystem<Fr>,
     {
-        let circuit = StackedCircuit::<'a, Tree, G> {
-            public_params,
+        let circuit = StackedCircuit::<Tree, G> {
             replica_id,
             comm_d,
             comm_r,
             comm_r_last,
             comm_c,
+            num_layers: public_params.num_layers,
             proofs,
         };
 
@@ -88,17 +88,16 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedCircuit<'a
     }
 }
 
-impl<'a, Tree: MerkleTreeTrait, G: Hasher> Circuit<Fr> for StackedCircuit<'a, Tree, G> {
+impl<Tree: MerkleTreeTrait, G: Hasher> Circuit<Fr> for StackedCircuit<Tree, G> {
     fn synthesize<CS: ConstraintSystem<Fr>>(self, cs: &mut CS) -> Result<(), SynthesisError> {
         let StackedCircuit {
-            public_params,
             proofs,
             replica_id,
             comm_r,
             comm_d,
             comm_r_last,
             comm_c,
-            ..
+            num_layers,
         } = self;
 
         // Allocate replica_id
@@ -168,7 +167,7 @@ impl<'a, Tree: MerkleTreeTrait, G: Hasher> Circuit<Fr> for StackedCircuit<'a, Tr
         for (i, proof) in proofs.into_iter().enumerate() {
             proof.synthesize(
                 &mut cs.namespace(|| format!("challenge_{}", i)),
-                public_params.num_layers,
+                num_layers,
                 &comm_d_num,
                 &comm_c_num,
                 &comm_r_last_num,
@@ -200,7 +199,7 @@ impl<C: Circuit<Fr>, P: ParameterSetMetadata, Tree: MerkleTreeTrait, G: Hasher>
 }
 
 impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher>
-    CompoundProof<'a, StackedDrg<'a, Tree, G>, StackedCircuit<'a, Tree, G>>
+    CompoundProof<'a, StackedDrg<'a, Tree, G>, StackedCircuit<Tree, G>>
     for StackedCompound<Tree, G>
 {
     fn generate_public_inputs(
@@ -292,11 +291,11 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher>
 
     fn circuit<'b>(
         public_inputs: &'b <StackedDrg<'_, Tree, G> as ProofScheme<'_>>::PublicInputs,
-        _component_private_inputs: <StackedCircuit<'a, Tree, G> as CircuitComponent>::ComponentPrivateInputs,
+        _component_private_inputs: <StackedCircuit<Tree, G> as CircuitComponent>::ComponentPrivateInputs,
         vanilla_proof: &'b <StackedDrg<'_, Tree, G> as ProofScheme<'_>>::Proof,
         public_params: &'b <StackedDrg<'_, Tree, G> as ProofScheme<'_>>::PublicParams,
         _partition_k: Option<usize>,
-    ) -> Result<StackedCircuit<'a, Tree, G>> {
+    ) -> Result<StackedCircuit<Tree, G>> {
         ensure!(
             !vanilla_proof.is_empty(),
             "Cannot create a circuit with no vanilla proofs"
@@ -316,26 +315,26 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher>
         );
 
         Ok(StackedCircuit {
-            public_params: public_params.clone(),
             replica_id: Some(public_inputs.replica_id),
             comm_d: public_inputs.tau.as_ref().map(|t| t.comm_d),
             comm_r: public_inputs.tau.as_ref().map(|t| t.comm_r),
             comm_r_last: Some(comm_r_last),
             comm_c: Some(comm_c),
+            num_layers: public_params.num_layers,
             proofs: vanilla_proof.iter().cloned().map(|p| p.into()).collect(),
         })
     }
 
     fn blank_circuit(
         public_params: &<StackedDrg<'_, Tree, G> as ProofScheme<'_>>::PublicParams,
-    ) -> StackedCircuit<'a, Tree, G> {
+    ) -> StackedCircuit<Tree, G> {
         StackedCircuit {
-            public_params: public_params.clone(),
             replica_id: None,
             comm_d: None,
             comm_r: None,
             comm_r_last: None,
             comm_c: None,
+            num_layers: public_params.num_layers,
             proofs: (0..public_params.challenges.challenges_count_all())
                 .map(|_challenge_index| Proof::empty(public_params))
                 .collect(),


### PR DESCRIPTION
There's no need to store the full public parameters within the `StackedCircuit` struct, as it only needs the number of layers.