### PR TITLE
refactor: get number of layers from private inputs

### DIFF
--- a/storage-proofs-porep/src/stacked/circuit/column.rs
+++ b/storage-proofs-porep/src/stacked/circuit/column.rs
@@ -52,13 +52,13 @@ impl Column {
 
         Ok(AllocatedColumn { rows })
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.rows.len()
+    }
 }
 
 impl AllocatedColumn {
-    pub fn len(&self) -> usize {
-        self.rows.len()
-    }
-
     /// Creates the column hash of this column.
     pub fn hash<CS: ConstraintSystem<Fr>>(
         &self,
@@ -76,5 +76,9 @@ impl AllocatedColumn {
             self.rows.len()
         );
         &self.rows[layer - 1]
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.rows.len()
     }
 }

--- a/storage-proofs-porep/src/stacked/circuit/column_proof.rs
+++ b/storage-proofs-porep/src/stacked/circuit/column_proof.rs
@@ -57,6 +57,10 @@ impl<
 
         Ok((column, inclusion_path))
     }
+
+    pub(crate) fn len(&self) -> usize {
+        self.column.len()
+    }
 }
 
 impl<Proof: MerkleProofTrait> From<VanillaColumnProof<Proof>>

--- a/storage-proofs-porep/src/stacked/circuit/params.rs
+++ b/storage-proofs-porep/src/stacked/circuit/params.rs
@@ -99,7 +99,6 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
     pub fn synthesize<CS: ConstraintSystem<Fr>>(
         self,
         mut cs: CS,
-        layers: usize,
         comm_d: &AllocatedNum<Fr>,
         comm_c: &AllocatedNum<Fr>,
         comm_r_last: &AllocatedNum<Fr>,
@@ -137,12 +136,13 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
         // -- verify replica column openings
 
         // Private Inputs for the DRG parent nodes.
-        let mut drg_parents = Vec::with_capacity(layers);
+        let num_layers = drg_parents_proofs[0].len();
+        let mut drg_parents = Vec::with_capacity(num_layers);
 
         for (i, parent) in drg_parents_proofs.into_iter().enumerate() {
             let (parent_col, inclusion_path) =
                 parent.alloc(cs.namespace(|| format!("drg_parent_{}_num", i)))?;
-            assert_eq!(layers, parent_col.len());
+            assert_eq!(num_layers, parent_col.len());
 
             // calculate column hash
             let val = parent_col.hash(cs.namespace(|| format!("drg_parent_{}_constraint", i)))?;
@@ -162,7 +162,7 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
         for (i, parent) in exp_parents_proofs.into_iter().enumerate() {
             let (parent_col, inclusion_path) =
                 parent.alloc(cs.namespace(|| format!("exp_parent_{}_num", i)))?;
-            assert_eq!(layers, parent_col.len());
+            assert_eq!(num_layers, parent_col.len());
 
             // calculate column hash
             let val = parent_col.hash(cs.namespace(|| format!("exp_parent_{}_constraint", i)))?;
@@ -185,7 +185,7 @@ impl<Tree: MerkleTreeTrait, G: 'static + Hasher> Proof<Tree, G> {
         let challenge_num = UInt64::alloc(cs.namespace(|| "challenge"), challenge)?;
         challenge_num.pack_into_input(cs.namespace(|| "challenge input"))?;
 
-        for layer in 1..=layers {
+        for layer in 1..=num_layers {
             let layer_num = UInt32::constant(layer as u32);
 
             let mut cs = cs.namespace(|| format!("labeling_{}", layer));


### PR DESCRIPTION
Instead of passing in the number of layers through the public params, get the number of layers from the private inputs that are required anyway. The number of layers equals the number of columns of a columns proof.

---

I first wasn't really convinced that it makes sense, but after seeing that now [`circuit()` doesn't need the public params anymore](https://github.com/filecoin-project/rust-fil-proofs/compare/stacked-circuit-num-layers...stacked-circuit-remove-num-layers?expand=1#diff-ffb695bda5cb5ab675888466cd786c2dd9f6d1e9e60d52ce0aa4300c3020170bL296) it looks like a win to me.