### PR TITLE
refactor: Challenges enum

### DIFF
--- a/fil-proofs-tooling/src/bin/gen_graph_cache/main.rs
+++ b/fil-proofs-tooling/src/bin/gen_graph_cache/main.rs
@@ -12,7 +12,7 @@ use filecoin_proofs::{
 };
 use serde::{Deserialize, Serialize};
 use storage_proofs_core::{api_version::ApiVersion, merkle::MerkleTreeTrait, proof::ProofScheme};
-use storage_proofs_porep::stacked::{LayerChallenges, SetupParams, StackedDrg};
+use storage_proofs_porep::stacked::{Challenges, SetupParams, StackedDrg};
 
 const PARENT_CACHE_JSON_OUTPUT: &str = "./parent_cache.json";
 
@@ -36,7 +36,7 @@ fn gen_graph_cache<Tree: 'static + MerkleTreeTrait>(
     // we just use dummy values of 1 for the setup params.
     let num_layers = 1;
     let challenge_count = 1;
-    let challenges = LayerChallenges::new(challenge_count);
+    let challenges = Challenges::new_interactive(challenge_count);
 
     let sp = SetupParams {
         nodes,

--- a/storage-proofs-porep/src/stacked/circuit/proof.rs
+++ b/storage-proofs-porep/src/stacked/circuit/proof.rs
@@ -326,7 +326,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher>
             comm_r: None,
             comm_r_last: None,
             comm_c: None,
-            proofs: (0..public_params.challenges.challenges_count_all())
+            proofs: (0..public_params.challenges.num_challenges_per_partition())
                 .map(|_challenge_index| Proof::empty(public_params))
                 .collect(),
         }

--- a/storage-proofs-porep/src/stacked/vanilla/challenges.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/challenges.rs
@@ -156,7 +156,7 @@ pub struct ChallengeRequirements {
     pub minimum_challenges: usize,
 }
 
-pub mod synthetic {
+pub(crate) mod synthetic {
     use super::*;
 
     use std::cmp::min;
@@ -204,7 +204,7 @@ pub mod synthetic {
         ChaCha20::new(key.as_bytes().into(), CHACHA20_NONCE.into())
     }
 
-    pub struct SynthChallenges {
+    pub(crate) struct SynthChallenges {
         sector_nodes: usize,
         replica_id: [u8; 32],
         comm_r: [u8; 32],
@@ -340,6 +340,7 @@ pub mod synthetic {
 
         /// Returns all porep challenges selected from the synthetic challenges.
         #[inline]
+        #[cfg(test)]
         pub fn gen_porep_challenges(
             &self,
             num_porep_challenges: usize,
@@ -350,7 +351,7 @@ pub mod synthetic {
     }
 }
 
-pub use synthetic::SynthChallenges;
+use synthetic::SynthChallenges;
 
 #[cfg(test)]
 mod test {

--- a/storage-proofs-porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/mod.rs
@@ -24,7 +24,7 @@ mod utils;
 
 pub use challenges::{
     synthetic::SYNTHETIC_POREP_VANILLA_PROOFS_EXT, synthetic::SYNTHETIC_POREP_VANILLA_PROOFS_KEY,
-    ChallengeRequirements, LayerChallenges, SynthChallenges,
+    ChallengeRequirements, LayerChallenges,
 };
 pub use clear_files::{clear_cache_dir, clear_synthetic_proofs};
 pub use column::Column;

--- a/storage-proofs-porep/src/stacked/vanilla/mod.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/mod.rs
@@ -24,7 +24,7 @@ mod utils;
 
 pub use challenges::{
     synthetic::SYNTHETIC_POREP_VANILLA_PROOFS_EXT, synthetic::SYNTHETIC_POREP_VANILLA_PROOFS_KEY,
-    ChallengeRequirements, LayerChallenges,
+    ChallengeRequirements, Challenges,
 };
 pub use clear_files::{clear_cache_dir, clear_synthetic_proofs};
 pub use column::Column;

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -394,7 +394,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         num_layers: usize,
         path: PathBuf,
     ) -> Result<()> {
-        use crate::stacked::vanilla::challenges::synthetic::SynthChallenges;
+        use crate::stacked::vanilla::challenges::synthetic::SynthChallengeGenerator;
 
         ensure!(
             pub_inputs.tau.is_some(),
@@ -413,7 +413,8 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                 .as_ref()
                 .map(|tau| tau.comm_r.into())
                 .expect("unwrapping should not fail");
-            let synth_challenges = SynthChallenges::default(graph.size(), &replica_id, &comm_r);
+            let synth_challenges =
+                SynthChallengeGenerator::default(graph.size(), &replica_id, &comm_r);
             assert_eq!(synth_proofs.len(), synth_challenges.num_synth_challenges);
             for (challenge, proof) in synth_challenges.zip(synth_proofs) {
                 let proof_inner = proof.clone();

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -394,7 +394,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         num_layers: usize,
         path: PathBuf,
     ) -> Result<()> {
-        use crate::stacked::vanilla::SynthChallenges;
+        use crate::stacked::vanilla::challenges::synthetic::SynthChallenges;
 
         ensure!(
             pub_inputs.tau.is_some(),

--- a/storage-proofs-porep/tests/stacked_circuit.rs
+++ b/storage-proofs-porep/tests/stacked_circuit.rs
@@ -19,7 +19,7 @@ use storage_proofs_core::{
     TEST_SEED,
 };
 use storage_proofs_porep::stacked::{
-    self, LayerChallenges, PrivateInputs, PublicInputs, SetupParams, StackedCompound, StackedDrg,
+    self, Challenges, PrivateInputs, PublicInputs, SetupParams, StackedCompound, StackedDrg,
     TemporaryAuxCache, EXP_DEGREE,
 };
 use tempfile::tempdir;
@@ -54,7 +54,7 @@ fn test_stacked_porep_circuit<Tree: MerkleTreeTrait + 'static>(
     let degree = BASE_DEGREE;
     let expansion_degree = EXP_DEGREE;
     let num_layers = 2;
-    let challenges = LayerChallenges::new(1);
+    let challenges = Challenges::new_interactive(1);
 
     let mut rng = XorShiftRng::from_seed(TEST_SEED);
 

--- a/storage-proofs-porep/tests/stacked_compound.rs
+++ b/storage-proofs-porep/tests/stacked_compound.rs
@@ -20,7 +20,7 @@ use storage_proofs_core::{
     TEST_SEED,
 };
 use storage_proofs_porep::stacked::{
-    self, ChallengeRequirements, LayerChallenges, PrivateInputs, PublicInputs, SetupParams,
+    self, ChallengeRequirements, Challenges, PrivateInputs, PublicInputs, SetupParams,
     StackedCompound, StackedDrg, TemporaryAuxCache, EXP_DEGREE,
 };
 use tempfile::tempdir;
@@ -51,7 +51,7 @@ fn test_stacked_compound<Tree: 'static + MerkleTreeTrait>() {
     let degree = BASE_DEGREE;
     let expansion_degree = EXP_DEGREE;
     let num_layers = 2;
-    let challenges = LayerChallenges::new(1);
+    let challenges = Challenges::new_interactive(1);
     let partition_count = 1;
 
     let mut rng = XorShiftRng::from_seed(TEST_SEED);

--- a/storage-proofs-porep/tests/stacked_vanilla.rs
+++ b/storage-proofs-porep/tests/stacked_vanilla.rs
@@ -23,8 +23,8 @@ use storage_proofs_core::{
     TEST_SEED,
 };
 use storage_proofs_porep::stacked::{
-    self, LayerChallenges, PrivateInputs, PublicInputs, SetupParams, StackedBucketGraph,
-    StackedDrg, TemporaryAuxCache, EXP_DEGREE,
+    self, Challenges, PrivateInputs, PublicInputs, SetupParams, StackedBucketGraph, StackedDrg,
+    TemporaryAuxCache, EXP_DEGREE,
 };
 use tempfile::tempdir;
 
@@ -101,7 +101,7 @@ fn test_extract_all<Tree: 'static + MerkleTreeTrait>() {
     let replica_path = cache_dir.path().join("replica-path");
     let mut mmapped_data = setup_replica(&data, &replica_path);
 
-    let challenges = LayerChallenges::new(5);
+    let challenges = Challenges::new_interactive(5);
 
     let sp = SetupParams {
         nodes,
@@ -197,7 +197,7 @@ fn test_stacked_porep_resume_seal() {
     let mut mmapped_data2 = setup_replica(&data, &replica_path2);
     let mut mmapped_data3 = setup_replica(&data, &replica_path3);
 
-    let challenges = LayerChallenges::new(5);
+    let challenges = Challenges::new_interactive(5);
 
     let sp = SetupParams {
         nodes,
@@ -291,7 +291,7 @@ table_tests! {
 }
 
 fn test_prove_verify_fixed(n: usize) {
-    let challenges = LayerChallenges::new(5);
+    let challenges = Challenges::new_interactive(5);
 
     test_prove_verify::<DiskTree<Sha256Hasher, U8, U0, U0>>(n, challenges.clone());
     test_prove_verify::<DiskTree<Sha256Hasher, U8, U2, U0>>(n, challenges.clone());
@@ -318,7 +318,7 @@ fn test_prove_verify_fixed(n: usize) {
     test_prove_verify::<DiskTree<PoseidonHasher, U8, U8, U2>>(n, challenges);
 }
 
-fn test_prove_verify<Tree: 'static + MerkleTreeTrait>(n: usize, challenges: LayerChallenges) {
+fn test_prove_verify<Tree: 'static + MerkleTreeTrait>(n: usize, challenges: Challenges) {
     // This will be called multiple times, only the first one succeeds, and that is ok.
     // femme::pretty::Logger::new()
     //     .start(log::LevelFilter::Trace)
@@ -417,7 +417,7 @@ fn test_stacked_porep_setup_terminates() {
     let degree = BASE_DEGREE;
     let expansion_degree = EXP_DEGREE;
     let nodes = 1024 * 1024 * 32 * 8; // This corresponds to 8GiB sectors (32-byte nodes)
-    let challenges = LayerChallenges::new(333);
+    let challenges = Challenges::new_interactive(333);
     let num_layers = 10;
     let sp = SetupParams {
         nodes,


### PR DESCRIPTION
This PR is a preparation for the non-interactive PoRep, where a new type of challenges will be introduced.

Though it also makes sense outside of this. A new `Challenges` enum is introduced, which add a bit more type safety. This way you cannot accidentally use e.g. the interactive PoRep challenges with the synthetic PoRep.

For more consistency the `SynthChallenges` struct renamed to `SynthChallengeGenerator`, so that we can have a `SynthChallenges` struct which corresponds to the `InteractiveChallenges` and upcoming `NiChallenges` struct.

For testing purpose it's now possible to add any feature (not just the Synthetic PoRep one). This is something that is needed for the NonInteractive PoRep, as well as the Resnaps work.

I've keep the individual commits for easier reviewing, the major change is the `introduce Challenges enum` commit.