### PR TITLE
refactor: use new_groth16_with_feature

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/porep.rs
+++ b/fil-proofs-tooling/src/bin/benchy/porep.rs
@@ -6,10 +6,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::{ensure, Context};
 use bincode::{deserialize, serialize};
 use fil_proofs_tooling::measure::FuncMeasurement;
-use fil_proofs_tooling::shared::{PROVER_ID, TICKET_BYTES};
+use fil_proofs_tooling::shared::{self, PROVER_ID, TICKET_BYTES};
 use fil_proofs_tooling::{measure, Metadata};
 use filecoin_proofs::types::{
-    PaddedBytesAmount, PieceInfo, PoRepConfig, SealCommitPhase1Output, SealPreCommitOutput,
+    PaddedBytesAmount, PieceInfo, SealCommitPhase1Output, SealPreCommitOutput,
     SealPreCommitPhase1Output, UnpaddedBytesAmount,
 };
 use filecoin_proofs::{
@@ -72,18 +72,6 @@ impl Report {
     }
 }
 
-fn get_porep_config(sector_size: u64, api_version: ApiVersion, use_synthetic: bool) -> PoRepConfig {
-    let arbitrary_porep_id = [99; 32];
-
-    // Replicate the staged sector, write the replica file to `sealed_path`.
-    let mut config = PoRepConfig::new_groth16(sector_size, arbitrary_porep_id, api_version);
-    if use_synthetic {
-        config.enable_feature(ApiFeature::SyntheticPoRep);
-    }
-
-    config
-}
-
 #[allow(clippy::too_many_arguments)]
 fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
     sector_size: u64,
@@ -93,7 +81,7 @@ fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
     skip_precommit_phase2: bool,
     test_resume: bool,
     skip_staging: bool,
-    use_synthetic: bool,
+    features: Vec<ApiFeature>,
 ) -> anyhow::Result<((u64, u64), (u64, u64), (u64, u64))> {
     let (seal_pre_commit_phase1_measurement_cpu_time, seal_pre_commit_phase1_measurement_wall_time): (u64, u64) = if skip_precommit_phase1 {
             // generate no-op measurements
@@ -153,7 +141,7 @@ fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
 
         let piece_infos = vec![piece_info];
         let sector_id = SectorId::from(SECTOR_ID);
-        let porep_config = get_porep_config(sector_size, api_version, use_synthetic);
+        let porep_config = shared::get_porep_config(sector_size, api_version, features.clone());
 
         let seal_pre_commit_phase1_measurement: FuncMeasurement<SealPreCommitPhase1Output<Tree>> = measure(|| {
             seal_pre_commit_phase1::<_, _, _, Tree>(
@@ -191,7 +179,7 @@ fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
             info!("Test resume requested.  Removing last layer {:?}", layers[layers.len() - 1]);
             std::fs::remove_file(&layers[layers.len() - 1])?;
 
-            return run_pre_commit_phases::<Tree>(sector_size, api_version, cache_dir, skip_precommit_phase1, skip_precommit_phase2, false, true, use_synthetic);
+            return run_pre_commit_phases::<Tree>(sector_size, api_version, cache_dir, skip_precommit_phase1, skip_precommit_phase2, false, true, features);
         }
 
         // Persist piece_infos here
@@ -245,7 +233,7 @@ fn run_pre_commit_phases<Tree: 'static + MerkleTreeTrait>(
         };
 
         let sealed_file_path = cache_dir.join(SEALED_FILE);
-        let porep_config = get_porep_config(sector_size, api_version, use_synthetic);
+        let porep_config = shared::get_porep_config(sector_size, api_version, features);
 
         let validate_cache_for_precommit_phase2_measurement: FuncMeasurement<()> = measure(|| {
             validate_cache_for_precommit_phase2::<_, _, Tree>(
@@ -335,6 +323,12 @@ pub fn run_porep_bench<Tree: 'static + MerkleTreeTrait>(
     test_resume: bool,
     use_synthetic: bool,
 ) -> anyhow::Result<()> {
+    let features = if use_synthetic {
+        vec![ApiFeature::SyntheticPoRep]
+    } else {
+        Vec::new()
+    };
+
     let (
         (seal_pre_commit_phase1_cpu_time_ms, seal_pre_commit_phase1_wall_time_ms),
         (
@@ -354,7 +348,7 @@ pub fn run_porep_bench<Tree: 'static + MerkleTreeTrait>(
             skip_precommit_phase2,
             test_resume,
             false, // skip staging
-            use_synthetic,
+            features.clone(),
         )
     }?;
 
@@ -390,7 +384,7 @@ pub fn run_porep_bench<Tree: 'static + MerkleTreeTrait>(
 
     let seed = [1u8; 32];
     let sector_id = SectorId::from(SECTOR_ID);
-    let porep_config = get_porep_config(sector_size, api_version, use_synthetic);
+    let porep_config = shared::get_porep_config(sector_size, api_version, features);
 
     let sealed_file_path = cache_dir.join(SEALED_FILE);
 

--- a/fil-proofs-tooling/src/bin/benchy/window_post_fake.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post_fake.rs
@@ -55,20 +55,14 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
     api_version: ApiVersion,
     api_features: Vec<ApiFeature>,
 ) -> anyhow::Result<()> {
-    let arbitrary_porep_id = [66; 32];
     let sector_count = *WINDOW_POST_SECTOR_COUNT
         .read()
         .expect("WINDOW_POST_SECTOR_COUNT poisoned")
         .get(&sector_size)
         .expect("unknown sector size");
 
-    let (sector_id, replica_output) = create_replica::<Tree>(
-        sector_size,
-        arbitrary_porep_id,
-        fake_replica,
-        api_version,
-        api_features,
-    );
+    let (sector_id, replica_output) =
+        create_replica::<Tree>(sector_size, fake_replica, api_version, api_features);
 
     // Store the replica's private and publicly facing info for proving and verifying respectively.
     let mut pub_replica_info: BTreeMap<SectorId, PublicReplicaInfo> = BTreeMap::new();

--- a/fil-proofs-tooling/src/bin/benchy/winning_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/winning_post.rs
@@ -59,14 +59,8 @@ pub fn run_fallback_post_bench<Tree: 'static + MerkleTreeTrait>(
             "This benchmark only works with WINNING_POST_SECTOR_COUNT == 1"
         ));
     }
-    let arbitrary_porep_id = [66; 32];
-    let (sector_id, replica_output) = create_replica::<Tree>(
-        sector_size,
-        arbitrary_porep_id,
-        fake_replica,
-        api_version,
-        api_features,
-    );
+    let (sector_id, replica_output) =
+        create_replica::<Tree>(sector_size, fake_replica, api_version, api_features);
 
     // Store the replica's private and publicly facing info for proving and verifying respectively.
     let pub_replica_info = vec![(sector_id, replica_output.public_replica_info.clone())];

--- a/fil-proofs-tooling/src/bin/gpu-cpu-test/main.rs
+++ b/fil-proofs-tooling/src/bin/gpu-cpu-test/main.rs
@@ -153,16 +153,10 @@ fn threads_mode(parallel: u8, gpu_stealing: bool) {
     let mut senders = Vec::new();
     // All thread handles that get terminated
     let mut threads: Vec<Option<thread::JoinHandle<_>>> = Vec::new();
-    let arbitrary_porep_id = [234; 32];
 
     // Create fixtures only once for both threads
-    let (sector_id, replica_output) = create_replica::<MerkleTree>(
-        SECTOR_SIZE,
-        arbitrary_porep_id,
-        false,
-        FIXED_API_VERSION,
-        FIXED_API_FEATURES,
-    );
+    let (sector_id, replica_output) =
+        create_replica::<MerkleTree>(SECTOR_SIZE, false, FIXED_API_VERSION, FIXED_API_FEATURES);
     let priv_replica_info = (sector_id, replica_output.private_replica_info);
 
     // Put each proof into it's own scope (the other one is due to the if statement)

--- a/fil-proofs-tooling/src/shared.rs
+++ b/fil-proofs-tooling/src/shared.rs
@@ -79,7 +79,6 @@ pub fn create_piece(piece_bytes: UnpaddedBytesAmount, use_random: bool) -> Named
 /// Create a replica for a single sector
 pub fn create_replica<Tree: 'static + MerkleTreeTrait>(
     sector_size: u64,
-    porep_id: [u8; 32],
     fake_replica: bool,
     api_version: ApiVersion,
     api_features: Vec<ApiFeature>,
@@ -89,7 +88,6 @@ pub fn create_replica<Tree: 'static + MerkleTreeTrait>(
         1,
         false,
         fake_replica,
-        porep_id,
         api_version,
         api_features,
     );
@@ -107,7 +105,6 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
     qty_sectors: usize,
     only_add: bool,
     fake_replicas: bool,
-    porep_id: [u8; 32],
     api_version: ApiVersion,
     api_features: Vec<ApiFeature>,
 ) -> (
@@ -121,10 +118,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
     let sector_size_unpadded_bytes_ammount =
         UnpaddedBytesAmount::from(PaddedBytesAmount::from(sector_size));
 
-    let mut porep_config = PoRepConfig::new_groth16(u64::from(sector_size), porep_id, api_version);
-    for feature in api_features {
-        porep_config.enable_feature(feature);
-    }
+    let porep_config = get_porep_config(u64::from(sector_size), api_version, api_features);
 
     let mut out: Vec<(SectorId, PreCommitReplicaOutput<Tree>)> = Default::default();
     let mut sector_ids = Vec::new();
@@ -336,4 +330,13 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
     }
 
     (porep_config, Some((out, seal_pre_commit_outputs)))
+}
+
+pub fn get_porep_config(
+    sector_size: u64,
+    api_version: ApiVersion,
+    features: Vec<ApiFeature>,
+) -> PoRepConfig {
+    let arbitrary_porep_id = [99; 32];
+    PoRepConfig::new_groth16_with_features(sector_size, arbitrary_porep_id, api_version, features)
 }


### PR DESCRIPTION
All users were using a hard-coded PoRep ID for `create_replica()` already, hence we can remove that parameter and use `get_porep_config()` directly.