### PR TITLE
feat: benchy: add API features flag

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/window_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post.rs
@@ -329,14 +329,8 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
     skip_commit_phase1: bool,
     skip_commit_phase2: bool,
     test_resume: bool,
-    use_synthetic: bool,
+    api_features: Vec<ApiFeature>,
 ) -> anyhow::Result<()> {
-    let features = if use_synthetic {
-        vec![ApiFeature::SyntheticPoRep]
-    } else {
-        Vec::new()
-    };
-
     let (
         (seal_pre_commit_phase1_cpu_time_ms, seal_pre_commit_phase1_wall_time_ms),
         (
@@ -356,7 +350,7 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
             skip_precommit_phase2,
             test_resume,
             false, // skip staging
-            features.clone(),
+            api_features.clone(),
         )
     }?;
 
@@ -394,7 +388,7 @@ pub fn run_window_post_bench<Tree: 'static + MerkleTreeTrait>(
     let comm_r = seal_pre_commit_output.comm_r;
 
     let sector_id = SectorId::from(SECTOR_ID);
-    let porep_config = shared::get_porep_config(sector_size, api_version, features);
+    let porep_config = shared::get_porep_config(sector_size, api_version, api_features);
 
     let sealed_file_path = cache_dir.join(SEALED_FILE);
 
@@ -603,9 +597,14 @@ pub fn run(
     skip_commit_phase1: bool,
     skip_commit_phase2: bool,
     test_resume: bool,
-    use_synthetic: bool,
+    api_features: Vec<ApiFeature>,
 ) -> anyhow::Result<()> {
-    info!("Benchy Window PoSt: sector-size={}, api_version={}, preserve_cache={}, skip_precommit_phase1={}, skip_precommit_phase2={}, skip_commit_phase1={}, skip_commit_phase2={}, test_resume={}, use_synthetic={}", sector_size, api_version, preserve_cache, skip_precommit_phase1, skip_precommit_phase2, skip_commit_phase1, skip_commit_phase2, test_resume, use_synthetic);
+    let api_features_str = api_features
+        .iter()
+        .map(|api_feature| api_feature.to_string())
+        .collect::<Vec<String>>()
+        .join(",");
+    info!("Benchy Window PoSt: sector-size={}, api_version={}, preserve_cache={}, skip_precommit_phase1={}, skip_precommit_phase2={}, skip_commit_phase1={}, skip_commit_phase2={}, test_resume={}, api_features={}", sector_size, api_version, preserve_cache, skip_precommit_phase1, skip_precommit_phase2, skip_commit_phase1, skip_commit_phase2, test_resume, api_features_str);
 
     let cache_dir_specified = !cache.is_empty();
 
@@ -656,6 +655,6 @@ pub fn run(
         skip_commit_phase1,
         skip_commit_phase2,
         test_resume,
-        use_synthetic,
+        api_features,
     )
 }

--- a/fil-proofs-tooling/src/bin/benchy/window_post_fake.rs
+++ b/fil-proofs-tooling/src/bin/benchy/window_post_fake.rs
@@ -127,18 +127,12 @@ pub fn run(
     sector_size: usize,
     fake_replica: bool,
     api_version: ApiVersion,
-    use_synthetic_porep: bool,
+    api_features: Vec<ApiFeature>,
 ) -> anyhow::Result<()> {
     info!(
         "Benchy Window PoSt Fake: sector-size={}, fake_replica={}, api_version={}",
         sector_size, fake_replica, api_version
     );
-
-    let api_features = if use_synthetic_porep {
-        vec![ApiFeature::SyntheticPoRep]
-    } else {
-        Vec::new()
-    };
 
     with_shape!(
         sector_size as u64,

--- a/fil-proofs-tooling/src/bin/benchy/winning_post.rs
+++ b/fil-proofs-tooling/src/bin/benchy/winning_post.rs
@@ -140,18 +140,12 @@ pub fn run(
     sector_size: usize,
     fake_replica: bool,
     api_version: ApiVersion,
-    use_synthetic: bool,
+    api_features: Vec<ApiFeature>,
 ) -> anyhow::Result<()> {
     info!(
         "Benchy Winning PoSt: sector-size={}, fake_replica={}, api_version={}",
         sector_size, fake_replica, api_version
     );
-
-    let api_features = if use_synthetic {
-        vec![ApiFeature::SyntheticPoRep]
-    } else {
-        Vec::new()
-    };
 
     with_shape!(
         sector_size as u64,

--- a/storage-proofs-core/src/api_version.rs
+++ b/storage-proofs-core/src/api_version.rs
@@ -132,6 +132,20 @@ impl Display for ApiFeature {
     }
 }
 
+impl FromStr for ApiFeature {
+    type Err = Error;
+    fn from_str(api_feature_str: &str) -> Result<Self> {
+        match api_feature_str {
+            "synthetic-porep" => Ok(ApiFeature::SyntheticPoRep),
+            "non-interactive-porep" => Ok(ApiFeature::NonInteractivePoRep),
+            _ => Err(format_err!(
+                "'{}' cannot be parsed as valid API feature",
+                api_feature_str
+            )),
+        }
+    }
+}
+
 #[test]
 fn test_fmt() {
     assert_eq!(format!("{}", ApiVersion::V1_0_0), "1.0.0");
@@ -161,6 +175,13 @@ fn test_api_version_order() {
 #[test]
 fn test_api_feature_synthetic_porep() {
     let feature = ApiFeature::SyntheticPoRep;
+
+    assert_eq!(format!("{}", feature), "synthetic-porep");
+    assert_eq!(
+        ApiFeature::from_str("synthetic-porep").expect("can be parsed"),
+        feature
+    );
+
     assert!(feature.first_supported_version() == ApiVersion::V1_2_0);
     assert!(feature.last_supported_version().is_none());
 }


### PR DESCRIPTION
Instead of passing in a boolean whether it's Synthetic PoRep or not, make it possible to pass in any supported feature.

This is a follow up of https://github.com/filecoin-project/rust-fil-proofs/pull/1742#discussion_r1430175595.