### PR TITLE
Rename and separate published and supported sector sizes

### DIFF
--- a/fil-proofs-param/src/bin/paramcache.rs
+++ b/fil-proofs-param/src/bin/paramcache.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 use dialoguer::{theme::ColorfulTheme, MultiSelect};
 use filecoin_proofs::{
     constants::{
-        DefaultPieceHasher, PUBLISHED_SECTOR_SIZES, WINDOW_POST_CHALLENGE_COUNT,
+        DefaultPieceHasher, SUPPORTED_SECTOR_SIZES, WINDOW_POST_CHALLENGE_COUNT,
         WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT,
     },
     parameters::{public_params, window_post_public_params, winning_post_public_params},
@@ -230,7 +230,7 @@ pub fn main() {
     // If no sector-sizes were given provided via. the CLI, display an interactive menu. Otherwise,
     // filter out invalid CLI sector-size arguments.
     if opts.sector_sizes.is_empty() {
-        let sector_size_strings: Vec<String> = PUBLISHED_SECTOR_SIZES
+        let sector_size_strings: Vec<String> = SUPPORTED_SECTOR_SIZES
             .iter()
             .map(|sector_size| {
                 let human_size = sector_size
@@ -250,11 +250,11 @@ pub fn main() {
             .interact()
             .expect("interaction failed")
             .into_iter()
-            .map(|i| PUBLISHED_SECTOR_SIZES[i])
+            .map(|i| SUPPORTED_SECTOR_SIZES[i])
             .collect();
     } else {
         opts.sector_sizes.retain(|size| {
-            if PUBLISHED_SECTOR_SIZES.contains(size) {
+            if SUPPORTED_SECTOR_SIZES.contains(size) {
                 true
             } else {
                 let human_size = size

--- a/fil-proofs-tooling/src/bin/circuitinfo/main.rs
+++ b/fil-proofs-tooling/src/bin/circuitinfo/main.rs
@@ -6,7 +6,7 @@ use dialoguer::{theme::ColorfulTheme, MultiSelect};
 use filecoin_proofs::{
     parameters::{public_params, window_post_public_params, winning_post_public_params},
     with_shape, DefaultPieceHasher, PoRepConfig, PoRepProofPartitions, PoStConfig, PoStType,
-    SectorSize, POREP_PARTITIONS, PUBLISHED_SECTOR_SIZES, WINDOW_POST_CHALLENGE_COUNT,
+    SectorSize, POREP_PARTITIONS, SUPPORTED_SECTOR_SIZES, WINDOW_POST_CHALLENGE_COUNT,
     WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT,
 };
 use humansize::{file_size_opts, FileSize};
@@ -153,7 +153,7 @@ pub fn main() {
 
     // Display interactive menu if no sizes are given
     let sizes: Vec<u64> = if opts.constraints_for_sector_sizes.is_empty() {
-        let sector_sizes = PUBLISHED_SECTOR_SIZES
+        let sector_sizes = SUPPORTED_SECTOR_SIZES
             .iter()
             .map(|sector_size| {
                 // Right aligning the numbers makes them easier to read
@@ -173,7 +173,7 @@ pub fn main() {
             .expect("interaction failed");
 
         // Extract the selected sizes
-        PUBLISHED_SECTOR_SIZES
+        SUPPORTED_SECTOR_SIZES
             .iter()
             .enumerate()
             .filter_map(|(index, size)| {
@@ -188,7 +188,7 @@ pub fn main() {
         opts.constraints_for_sector_sizes
             .into_iter()
             .filter(|size| {
-                if PUBLISHED_SECTOR_SIZES.contains(size) {
+                if SUPPORTED_SECTOR_SIZES.contains(size) {
                     return true;
                 }
 

--- a/filecoin-proofs/src/caches.rs
+++ b/filecoin-proofs/src/caches.rs
@@ -19,7 +19,7 @@ use storage_proofs_update::{
 };
 
 use crate::{
-    constants::{DefaultPieceHasher, PUBLISHED_SECTOR_SIZES},
+    constants::{DefaultPieceHasher, SUPPORTED_SECTOR_SIZES},
     parameters::{public_params, window_post_public_params, winning_post_public_params},
     types::{PoRepConfig, PoStConfig, PoStType},
 };
@@ -68,7 +68,7 @@ impl<G> SRSCache<G> {
         let mut num_proofs_to_aggregate = PROOFS_TESTS_MIN_SNARKS;
 
         loop {
-            for sector_size in &PUBLISHED_SECTOR_SIZES {
+            for sector_size in &SUPPORTED_SECTOR_SIZES {
                 let key = format!(
                     "STACKED[{}-{}]-{}",
                     sector_size, num_proofs_to_aggregate, identifier,

--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -33,8 +33,8 @@ pub const WINDOW_POST_CHALLENGE_COUNT: usize = 10;
 
 pub const MAX_LEGACY_REGISTERED_SEAL_PROOF_ID: u64 = MAX_LEGACY_POREP_REGISTERED_PROOF_ID;
 
-/// Sector sizes for which parameters have been published.
-pub const PUBLISHED_SECTOR_SIZES: [u64; 10] = [
+/// Sector sizes for which parameters are supported.
+pub const SUPPORTED_SECTOR_SIZES: [u64; 10] = [
     SECTOR_SIZE_2_KIB,
     SECTOR_SIZE_4_KIB,
     SECTOR_SIZE_16_KIB,
@@ -43,6 +43,15 @@ pub const PUBLISHED_SECTOR_SIZES: [u64; 10] = [
     SECTOR_SIZE_16_MIB,
     SECTOR_SIZE_512_MIB,
     SECTOR_SIZE_1_GIB,
+    SECTOR_SIZE_32_GIB,
+    SECTOR_SIZE_64_GIB,
+];
+
+/// Sector sizes for which parameters have been published.
+pub const PUBLISHED_SECTOR_SIZES: [u64; 5] = [
+    SECTOR_SIZE_2_KIB,
+    SECTOR_SIZE_8_MIB,
+    SECTOR_SIZE_512_MIB,
     SECTOR_SIZE_32_GIB,
     SECTOR_SIZE_64_GIB,
 ];


### PR DESCRIPTION
Most tests rely on sector sizes being supported, but the constant we're using is named 'published sector sizes'.  This wouldn't normally matter, but the distinction is required for a future update and the naming is more clear (since not all supported sector sizes have published parameters).