### PR TITLE
Improve error handling for threaded verification errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,18 @@ The main benchmarking tool is called `benchy`.  `benchy` has several subcommands
 > cargo run --release --bin benchy -- window-post --size 2KiB
 > cargo run --release --bin benchy -- window-post-fake --size 2KiB --fake
 > cargo run --release --bin benchy -- prodbench
-# After a preserved cache is generated, this command tests *only* synthetic proof generation
-> cargo run --release --bin benchy -- porep --size 2KiB --synthetic --cache /d1/nemo/tmp/cache-2k --skip-precommit-phase1 --skip-precommit-phase2 --skip-commit-phase1 --skip-commit-phase2
+#
+# Synthetic PoRep examples (for both 2KiB test and 32GiB production sector sizes)
+#
+# Preserve a cache using synthetic-porep (2KiB sectors)
+> cargo run --release --bin benchy -- porep --size 2KiB --cache /tmp/cache-2k-synthetic --preserve-cache --api-features synthetic-porep
+# Preserve a cache using synthetic-porep (32GiB sectors)
+> cargo run --release --bin benchy -- porep --size 32GiB --cache /tmp/cache-32g-synthetic --preserve-cache --api-features synthetic-porep
+#
+# After a preserved cache is generated, this command tests *only* synthetic proof generation (2KiB sectors)
+> cargo run --release --bin benchy -- porep --size 2KiB --cache /tmp/cache-2k-synthetic --api-features synthetic-porep --skip-precommit-phase1 --skip-precommit-phase2 --skip-commit-phase1 --skip-commit-phase2
+# After a preserved cache is generated, this command tests *only* synthetic proof generation (32GiB sectors)
+> cargo run --release --bin benchy -- porep --size 32GiB --cache /tmp/cache-32g-synthetic --api-features synthetic-porep --skip-precommit-phase1 --skip-precommit-phase2 --skip-commit-phase1 --skip-commit-phase2
 ```
 
 ### Window PoSt Bench usages

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -3,7 +3,7 @@ use std::io::{BufReader, BufWriter};
 use std::marker::PhantomData;
 use std::panic::panic_any;
 use std::path::{Path, PathBuf};
-use std::sync::{mpsc::sync_channel as channel, Arc, Mutex, RwLock};
+use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, ensure, Context};
 use bincode::deserialize;
@@ -31,7 +31,6 @@ use storage_proofs_core::{
         split_config_and_replica, BinaryMerkleTree, DiskTree, LCTree, MerkleProofTrait,
         MerkleTreeTrait,
     },
-    settings::SETTINGS,
     util::{default_rows_to_discard, NODE_SIZE},
 };
 use yastl::Pool;
@@ -699,6 +698,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
 
         #[cfg(feature = "multicore-sdr")]
         {
+            use storage_proofs_core::settings::SETTINGS;
             if SETTINGS.use_multicore_sdr {
                 info!("multi core replication");
                 create_label::multi::create_labels_for_encoding(
@@ -744,6 +744,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
 
         #[cfg(feature = "multicore-sdr")]
         {
+            use storage_proofs_core::settings::SETTINGS;
             if SETTINGS.use_multicore_sdr {
                 info!("multi core replication");
                 create_label::multi::create_labels_for_decoding(
@@ -812,6 +813,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         ColumnArity: 'static + PoseidonArity,
         TreeArity: PoseidonArity,
     {
+        use storage_proofs_core::settings::SETTINGS;
         if SETTINGS.use_gpu_column_builder::<Tree>() {
             Self::generate_tree_c_gpu::<ColumnArity, TreeArity>(
                 nodes_count,
@@ -851,6 +853,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         TreeArity: PoseidonArity,
     {
         use std::cmp::min;
+        use std::sync::{mpsc::sync_channel as channel, RwLock};
 
         use fr32::fr_into_bytes;
         use generic_array::GenericArray;
@@ -859,6 +862,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             batch_hasher::Batcher,
             column_tree_builder::{ColumnTreeBuilder, ColumnTreeBuilderTrait},
         };
+        use storage_proofs_core::settings::SETTINGS;
 
         info!("generating tree c using the GPU");
         // Build the tree for CommC
@@ -1201,6 +1205,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         start: usize,
         end: usize,
     ) -> Result<TreeRElementData<Tree>> {
+        use storage_proofs_core::settings::SETTINGS;
         if SETTINGS.use_gpu_tree_builder::<Tree>() {
             use ff::PrimeField;
             use fr32::bytes_into_fr;
@@ -1309,6 +1314,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             None => Self::prepare_tree_r_data,
         };
 
+        use storage_proofs_core::settings::SETTINGS;
         if SETTINGS.use_gpu_tree_builder::<Tree>() {
             Self::generate_tree_r_last_gpu(
                 data,
@@ -1371,6 +1377,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         use std::cmp::min;
         use std::fs::OpenOptions;
         use std::io::Write;
+        use std::sync::mpsc::sync_channel as channel;
 
         use fr32::fr_into_bytes;
         use log::warn;
@@ -1379,6 +1386,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             batch_hasher::Batcher,
             tree_builder::{TreeBuilder, TreeBuilderTrait},
         };
+        use storage_proofs_core::settings::SETTINGS;
 
         let (configs, replica_config) = split_config_and_replica(
             tree_r_last_config.clone(),
@@ -1848,6 +1856,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             batch_hasher::Batcher,
             tree_builder::{TreeBuilder, TreeBuilderTrait},
         };
+        use storage_proofs_core::settings::SETTINGS;
 
         let (configs, replica_config) = split_config_and_replica(
             tree_r_last_config.clone(),

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -421,15 +421,6 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                         );
 
                         {
-                            /*
-                            //FIXME: For testing, this adds a bug on purpose
-                            let labeled_node =
-                                *rcp.c_x.get_node_at_layer(if layer >= num_layers {
-                                    1
-                                } else {
-                                    layer + 1
-                        })?;
-                             */
                             let labeled_node = *rcp.c_x.get_node_at_layer(layer)?;
                             let replica_id = &pub_inputs.replica_id;
                             let proof_inner = proof.clone();

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -150,8 +150,7 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
             Challenges::Synth(synth_challenges) => {
                 // If there are no synthetic vanilla proofs stored on disk yet, generate them.
                 if pub_inputs.seed.is_none() {
-                    info!("generating synthetic vanilla proofs in a single partition");
-                    assert_eq!(partition_count, 1);
+                    info!("generating all required synthetic vanilla proofs");
 
                     let comm_r = pub_inputs.tau.as_ref().expect("tau is set").comm_r;
                     // Derive the set of challenges we are proving over.

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -5,7 +5,7 @@ use std::panic::panic_any;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
-use anyhow::{anyhow, ensure, Context};
+use anyhow::{ensure, Context};
 use bincode::deserialize;
 use blstrs::Scalar as Fr;
 use fdlimit::raise_fd_limit;
@@ -548,12 +548,11 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
         let invalid_synth_porep_proof_coordinate = invalid_synth_porep_proof
             .lock()
             .expect("failed to get lock on invalid_synth_porep_proof");
-        if invalid_synth_porep_proof_coordinate.failure_detected {
-            return Err(anyhow!(
-                "Invalid synth_porep proof generated at challenge_index {}",
-                invalid_synth_porep_proof_coordinate.challenge_index
-            ));
-        }
+        ensure!(
+            !invalid_synth_porep_proof_coordinate.failure_detected,
+            "Invalid synth_porep proof generated at challenge_index {}",
+            invalid_synth_porep_proof_coordinate.challenge_index
+        );
         info!("writing synth-porep vanilla proofs to file: {:?}", path);
         let file = File::create(&path).map(BufWriter::new).with_context(|| {
             format!(

--- a/storage-proofs-update/src/vanilla.rs
+++ b/storage-proofs-update/src/vanilla.rs
@@ -32,7 +32,6 @@ use storage_proofs_core::{
     },
     parameter_cache::ParameterSetMetadata,
     proof::ProofScheme,
-    settings::SETTINGS,
 };
 use storage_proofs_porep::stacked::{StackedDrg, TreeRElementData};
 
@@ -356,6 +355,7 @@ pub fn prepare_tree_r_data<Tree: 'static + MerkleTreeTrait>(
     start: usize,
     end: usize,
 ) -> Result<TreeRElementData<Tree>> {
+    use storage_proofs_core::settings::SETTINGS;
     let tree_data = source
         .read_range(start..end)
         .expect("failed to read from source");


### PR DESCRIPTION
For synth porep, we switch to threaded/parallel proof verification as an optimization.  This takes it a step further and now allows errors to be propagated/returned properly.

Note: There is a FIXME in the code that will be removed after it's properly tested via filecoin-ffi testing.