### PR TITLE
fix: remove wrong assert in Synth PoRep code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ The main benchmarking tool is called `benchy`.  `benchy` has several subcommands
 > cargo run --release --bin benchy -- window-post-fake --size 2KiB --fake
 > cargo run --release --bin benchy -- prodbench
 # After a preserved cache is generated, this command tests *only* synthetic proof generation
-> cargo run --release --bin benchy -- porep --size 2KiB --synthetic --cache /d1/nemo/tmp/cache-2k --skip-precommit-phase1 --skip-precommit-phase2 --skip-commit-phase1 --skip-commit-phase2
+> cargo run --release --bin benchy -- porep --size 2KiB -api-features=synthetic-porep --cache /d1/nemo/tmp/cache-2k --skip-precommit-phase1 --skip-precommit-phase2 --skip-commit-phase1 --skip-commit-phase2
 ```
 
 ### Window PoSt Bench usages

--- a/storage-proofs-porep/src/stacked/vanilla/proof.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/proof.rs
@@ -141,7 +141,6 @@ impl<'a, Tree: 'static + MerkleTreeTrait, G: 'static + Hasher> StackedDrg<'a, Tr
                 // If there are no synthetic vanilla proofs stored on disk yet, generate them.
                 if pub_inputs.seed.is_none() {
                     info!("generating synthetic vanilla proofs in a single partition");
-                    assert_eq!(partition_count, 1);
 
                     let comm_r = pub_inputs.tau.as_ref().expect("tau is set").comm_r;
                     // Derive the set of challenges we are proving over.


### PR DESCRIPTION
Due to me understanding the code wrongly during the refactoring at https://github.com/filecoin-project/rust-fil-proofs/pull/1720, there was a wrong assert inserted into the code. With removing this assert the lifecycle 32GiB test as well as the benchy synthetic proofs generation works as expected again.

This commit also updates the README with the correct command to run benchy for synthetic proofs generation.

Fixes #1749.