### PR TITLE
fix: use a fixed seed for Non-interactive PoRep

### DIFF
--- a/filecoin-proofs/src/constants.rs
+++ b/filecoin-proofs/src/constants.rs
@@ -56,6 +56,9 @@ pub const PUBLISHED_SECTOR_SIZES: [u64; 5] = [
     SECTOR_SIZE_64_GIB,
 ];
 
+/// The seed that is used to generate the Non-interactive PoRep proof.
+pub const POREP_NON_INTERACTIVE_FIXED_SEED: [u8; 32] = [0; 32];
+
 lazy_static! {
     pub static ref POREP_PARTITIONS: RwLock<HashMap<u64, u8>> = RwLock::new(
         [

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -30,10 +30,10 @@ use filecoin_proofs::{
     PoRepConfig, PoStConfig, PoStType, PrivateReplicaInfo, ProverId, PublicReplicaInfo,
     SealCommitOutput, SealPreCommitOutput, SealPreCommitPhase1Output, SectorShape16KiB,
     SectorShape2KiB, SectorShape32GiB, SectorShape32KiB, SectorShape4KiB, SectorUpdateConfig,
-    SectorUpdateProofInputs, UnpaddedByteIndex, UnpaddedBytesAmount, SECTOR_SIZE_16_KIB,
-    SECTOR_SIZE_2_KIB, SECTOR_SIZE_32_GIB, SECTOR_SIZE_32_KIB, SECTOR_SIZE_4_KIB,
-    WINDOW_POST_CHALLENGE_COUNT, WINDOW_POST_SECTOR_COUNT, WINNING_POST_CHALLENGE_COUNT,
-    WINNING_POST_SECTOR_COUNT,
+    SectorUpdateProofInputs, UnpaddedByteIndex, UnpaddedBytesAmount,
+    POREP_NON_INTERACTIVE_FIXED_SEED, SECTOR_SIZE_16_KIB, SECTOR_SIZE_2_KIB, SECTOR_SIZE_32_GIB,
+    SECTOR_SIZE_32_KIB, SECTOR_SIZE_4_KIB, WINDOW_POST_CHALLENGE_COUNT, WINDOW_POST_SECTOR_COUNT,
+    WINNING_POST_CHALLENGE_COUNT, WINNING_POST_SECTOR_COUNT,
 };
 use fr32::bytes_into_fr;
 use log::{info, trace};
@@ -2099,7 +2099,11 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
     let cache_dir = tempdir().expect("failed to create temp dir");
 
     let ticket = rng.gen();
-    let seed = rng.gen();
+    let seed = if porep_config.feature_enabled(ApiFeature::NonInteractivePoRep) {
+        POREP_NON_INTERACTIVE_FIXED_SEED
+    } else {
+        rng.gen()
+    };
     let sector_id = rng.gen::<u64>().into();
 
     let (piece_infos, phase1_output) = run_seal_pre_commit_phase1::<Tree>(


### PR DESCRIPTION
The Interactive PoRep requires a seed for the proof. The Non-interactive PoRep does not. In order to keep the public APIs simple, just make sure that the passed in seed in case of a Non-interactive PoRep is a fixed one. It was choosen to be all zeros as such a byte array is easy to generate.

That fixed seed is used for the proving (and the internal aggregation) as well as the verification.

This commit also removes the restriction that a seed cannot be all zeros, which it also totally could be by coincidence (it's randomly generated in case of the Interactive PoRep).