### PR TITLE
fix: remove challenge seed from NI-PoRep SnarkPack transcript

### DIFF
--- a/filecoin-proofs/src/api/seal.rs
+++ b/filecoin-proofs/src/api/seal.rs
@@ -352,6 +352,8 @@ pub fn seal_commit_phase1<T: AsRef<Path>, Tree: 'static + MerkleTreeTrait>(
     prover_id: ProverId,
     sector_id: SectorId,
     ticket: Ticket,
+    // Note: when using NI-PoRep the PoRep challenge generation seed is ignored, thus any value can
+    // be passed in here for `seed`.
     seed: Ticket,
     pre_commit: SealPreCommitOutput,
     piece_infos: &[PieceInfo],


### PR DESCRIPTION
Alternative to #1754. This PR proposes that any PoRep challenge seed(s) (provided as API arguments) not be included in NI-PoRep's SnarkPack transcript, as opposed to using a constant value for NI-PoRep's challenge seed.

Imho, merging of either PR should be held off until a decision is made during the NI-PoRep audit.