### PR TITLE
feat: properly remove temporary files leftover after running tests

### DIFF
--- a/fil-proofs-param/tests/paramfetch/session.rs
+++ b/fil-proofs-param/tests/paramfetch/session.rs
@@ -112,7 +112,7 @@ impl ParamFetchSessionBuilder {
 /// An active pseudoterminal (pty) used to interact with paramfetch.
 pub struct ParamFetchSession {
     pty_session: PtyReplSession,
-    _cache_dir: TempDir,
+    pub _cache_dir: TempDir,
 }
 
 impl ParamFetchSession {

--- a/fil-proofs-param/tests/parampublish/prompts_to_publish.rs
+++ b/fil-proofs-param/tests/parampublish/prompts_to_publish.rs
@@ -22,6 +22,8 @@ fn ignores_files_unrecognized_extensions() -> Result<(), FailureError> {
     session.send_line("")?;
     session.exp_string("no params selected, exiting")?;
 
+    std::fs::remove_dir_all(session._cache_dir.path())?;
+
     Ok(())
 }
 
@@ -47,6 +49,8 @@ fn displays_sector_size_in_prompt() -> Result<(), FailureError> {
     session.send_line("")?;
     session.exp_string("no params selected, exiting")?;
 
+    std::fs::remove_dir_all(session._cache_dir.path())?;
+
     Ok(())
 }
 
@@ -58,6 +62,8 @@ fn no_assets_no_prompt() -> Result<(), FailureError> {
 
     session.exp_string("found 0 param files in cache dir")?;
     session.exp_string("no file triples found, exiting")?;
+
+    std::fs::remove_dir_all(session._cache_dir.path())?;
 
     Ok(())
 }

--- a/fil-proofs-param/tests/parampublish/read_metadata_files.rs
+++ b/fil-proofs-param/tests/parampublish/read_metadata_files.rs
@@ -15,6 +15,8 @@ fn fails_if_missing_metadata_file() -> Result<(), FailureError> {
     session.exp_string("found 2 param files in cache dir")?;
     session.exp_string("no file triples found, exiting")?;
 
+    std::fs::remove_dir_all(session._cache_dir.path())?;
+
     Ok(())
 }
 
@@ -33,6 +35,8 @@ fn fails_if_malformed_metadata_file() -> Result<(), FailureError> {
     session.exp_string("found 1 file triples")?;
     session.exp_string("failed to parse .meta file")?;
     session.exp_string("exiting")?;
+
+    std::fs::remove_dir_all(session._cache_dir.path())?;
 
     Ok(())
 }

--- a/fil-proofs-param/tests/parampublish/support/session.rs
+++ b/fil-proofs-param/tests/parampublish/support/session.rs
@@ -159,7 +159,7 @@ impl ParamPublishSessionBuilder {
 /// An active pseudoterminal (pty) used to interact with parampublish.
 pub struct ParamPublishSession {
     pty_session: PtyReplSession,
-    _cache_dir: TempDir,
+    pub _cache_dir: TempDir,
 }
 
 impl ParamPublishSession {

--- a/fil-proofs-param/tests/parampublish/write_json_manifest.rs
+++ b/fil-proofs-param/tests/parampublish/write_json_manifest.rs
@@ -62,6 +62,13 @@ fn writes_json_manifest() -> Result<(), failure::Error> {
         }
     }
 
+    let parent_dir = std::path::Path::new(&manifest_path)
+        .parent()
+        .expect("failed to get parent dir");
+    std::fs::remove_file(&manifest_path)?;
+    std::fs::remove_dir(parent_dir)?;
+    std::fs::remove_dir_all(session._cache_dir.path())?;
+
     Ok(())
 }
 

--- a/storage-proofs-porep/tests/common.rs
+++ b/storage-proofs-porep/tests/common.rs
@@ -1,8 +1,40 @@
-use std::path::PathBuf;
+use std::fs::remove_file;
+use std::io::Result;
+use std::path::{Path, PathBuf};
 
 use filecoin_hashers::Hasher;
-use storage_proofs_core::{data::Data, merkle::MerkleTreeTrait};
+use merkletree::store::StoreConfig;
+use storage_proofs_core::{
+    cache_key::CacheKey,
+    data::Data,
+    merkle::{get_base_tree_count, split_config, MerkleTreeTrait},
+};
 use storage_proofs_porep::stacked::{PersistentAux, PublicParams, StackedDrg, Tau, TemporaryAux};
+
+// This method should ONLY be used in purposed test code.
+#[allow(dead_code)]
+pub fn remove_replica_and_tree_r<Tree: MerkleTreeTrait + 'static>(cache_path: &Path) -> Result<()> {
+    let replica_path = cache_path.join("replica-path");
+    let tree_r_last_config = StoreConfig {
+        path: cache_path.to_path_buf(),
+        id: CacheKey::CommRLastTree.to_string(),
+        size: Some(0),
+        rows_to_discard: 0,
+    };
+    let tree_count = get_base_tree_count::<Tree>();
+    if tree_count > 1 {
+        let configs =
+            split_config(tree_r_last_config, tree_count).expect("Failed to split configs");
+        for config in configs {
+            let cur_path = StoreConfig::data_path(&config.path, &config.id);
+            remove_file(cur_path).expect("Failed to remove TreeR");
+        }
+    } else {
+        let cur_path = StoreConfig::data_path(&tree_r_last_config.path, &tree_r_last_config.id);
+        remove_file(cur_path).expect("Failed to remove TreeR");
+    }
+    remove_file(replica_path)
+}
 
 #[allow(clippy::type_complexity)]
 pub fn transform_and_replicate_layers<Tree: 'static + MerkleTreeTrait, G: 'static + Hasher>(

--- a/storage-proofs-porep/tests/stacked_compound.rs
+++ b/storage-proofs-porep/tests/stacked_compound.rs
@@ -170,6 +170,10 @@ fn test_stacked_compound<Tree: 'static + MerkleTreeTrait>() {
     // Discard cached MTs that are no longer needed.
     stacked::clear_cache_dir(cache_dir.path()).expect("cached files delete failed");
 
+    // Discard normally permanent files no longer needed in testing.
+    common::remove_replica_and_tree_r::<Tree>(cache_dir.path())
+        .expect("failed to remove replica and tree_r");
+
     let proofs = StackedCompound::prove(
         &public_params,
         &public_inputs,
@@ -200,5 +204,7 @@ fn test_stacked_compound<Tree: 'static + MerkleTreeTrait>() {
 
     assert!(verified);
 
-    cache_dir.close().expect("Failed to remove cache dir");
+    if std::fs::remove_dir(cache_dir.path()).is_ok() && cache_dir.path().exists() {
+        let _ = cache_dir.close();
+    }
 }

--- a/storage-proofs-porep/tests/stacked_vanilla.rs
+++ b/storage-proofs-porep/tests/stacked_vanilla.rs
@@ -164,7 +164,16 @@ fn test_extract_all<Tree: 'static + MerkleTreeTrait>() {
 
     assert_eq!(data, mmapped_data.as_ref());
 
-    cache_dir.close().expect("Failed to remove cache dir");
+    // Discard cached MTs that are no longer needed.
+    stacked::clear_cache_dir(cache_dir.path()).expect("cached files delete failed");
+
+    // Discard normally permanent files no longer needed in testing.
+    common::remove_replica_and_tree_r::<Tree>(cache_dir.path())
+        .expect("failed to remove replica and tree_r");
+
+    if std::fs::remove_dir(cache_dir.path()).is_ok() && cache_dir.path().exists() {
+        let _ = cache_dir.close();
+    }
 }
 
 #[test]
@@ -281,7 +290,9 @@ fn test_stacked_porep_resume_seal() {
 
     assert_eq!(data, mmapped_data1.as_ref());
 
-    cache_dir.close().expect("Failed to remove cache dir");
+    if std::fs::remove_dir(cache_dir.path()).is_ok() && cache_dir.path().exists() {
+        let _ = cache_dir.close();
+    }
 }
 
 table_tests! {
@@ -405,9 +416,15 @@ fn test_prove_verify<Tree: 'static + MerkleTreeTrait>(n: usize, challenges: Chal
     // Discard cached MTs that are no longer needed.
     stacked::clear_cache_dir(cache_dir.path()).expect("cached files delete failed");
 
+    // Discard normally permanent files no longer needed in testing.
+    common::remove_replica_and_tree_r::<Tree>(cache_dir.path())
+        .expect("failed to remove replica and tree_r");
+
     assert!(proofs_are_valid);
 
-    cache_dir.close().expect("Failed to remove cache dir");
+    if std::fs::remove_dir(cache_dir.path()).is_ok() && cache_dir.path().exists() {
+        let _ = cache_dir.close();
+    }
 }
 
 // We are seeing a bug, in which setup never terminates for some sector sizes. This test is to


### PR DESCRIPTION
Take 2: It took a while to track down which tests were leaving around .tmp* directories and files in the TEMPDIR after the test suite was run, but it appears that this resolves them all across normal and 'ignored' tests.

In short, if there are any open files/dirs remaining when [TempDir is scoped out](https://docs.rs/tempfile/latest/tempfile/struct.TempDir.html#resource-leaking), a deletion is silently omitted. This code more explicitly cleans up some temporary artifacts in order to ensure everything is removed and closed before that happens.