### PR TITLE
fix: upgrade hwloc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
-#on: [pull_request, push]
-on: [push]
+on: [pull_request, push]
+#on: [push]
 
 # Cancel a job if there's a new on on the same branch started.
 # Based on https://stackoverflow.com/questions/58895283/stop-already-running-workflow-job-in-github-actions/67223051#67223051

--- a/storage-proofs-porep/Cargo.toml
+++ b/storage-proofs-porep/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/filecoin-project/rust-fil-proofs"
 readme = "README.md"
 
 [dependencies]
-filecoin-hashers = { workspace = true, features = ["poseidon", "sha256"]}
+filecoin-hashers = { workspace = true, features = ["poseidon", "sha256"] }
 fr32.workspace = true
 sha2raw.workspace = true
 storage-proofs-core.workspace = true
@@ -28,7 +28,7 @@ ff.workspace = true
 generic-array.workspace = true
 glob = "0.3.0"
 hex.workspace = true
-hwloc = { version = "0.5.0", optional = true }
+hwloc = { version = "2.2.0", optional = true, package = "hwloc2" }
 lazy_static.workspace = true
 libc = "0.2"
 log.workspace = true
@@ -53,7 +53,11 @@ sha2 = { workspace = true, features = ["compress", "asm"] }
 sha2 = { workspace = true, features = ["compress"] }
 
 [dev-dependencies]
-filecoin-hashers = { workspace = true, features = ["poseidon", "sha256", "blake2s"]}
+filecoin-hashers = { workspace = true, features = [
+    "poseidon",
+    "sha256",
+    "blake2s",
+] }
 # Sorted alphabetically
 criterion.workspace = true
 fil_logger.workspace = true
@@ -63,8 +67,18 @@ tempfile.workspace = true
 
 [features]
 default = ["opencl", "multicore-sdr"]
-cuda = ["storage-proofs-core/cuda", "filecoin-hashers/cuda", "neptune/cuda", "bellperson/cuda"]
-opencl = ["storage-proofs-core/opencl", "filecoin-hashers/opencl", "neptune/opencl", "bellperson/opencl"]
+cuda = [
+    "storage-proofs-core/cuda",
+    "filecoin-hashers/cuda",
+    "neptune/cuda",
+    "bellperson/cuda",
+]
+opencl = [
+    "storage-proofs-core/opencl",
+    "filecoin-hashers/opencl",
+    "neptune/opencl",
+    "bellperson/opencl",
+]
 isolated-testing = []
 multicore-sdr = ["hwloc"]
 # This feature enables a fixed number of discarded rows for TreeR. The `FIL_PROOFS_ROWS_TO_DISCARD`


### PR DESCRIPTION
When running `rust-fil-proofs` under Rust 1.81 the following warning is issued:

```
warning: the following packages contain code that will be rejected by a future version of Rust: bitflags v0.7.0
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

The package depending on `bitflags` 0.7.0 is `hwloc`, which has been replaced by `hwloc2`.
Understandably, `hwloc` (the original library) has suffered  changes as well, which are reflected in `hwloc2`.

The main one being the removal of `allowed_cpuset`, according to the `hwloc` upgrading guide (https://www.open-mpi.org/projects/hwloc/doc/v2.8.0/a00374.php#upgrade_to_api_2x_allowed) these `cpuset` should be enough given that the [`INCLUDE_DISALLOWED`](https://docs.rs/hwloc2/latest/hwloc2/enum.TopologyFlag.html#variant.IncludeDisallowed) flag hasn't been passed (and as far as I know, it isn't a default).

This PR attempts to address these issues.