### PR TITLE
fix: Arc can be an Rc

### DIFF
--- a/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
+++ b/storage-proofs-porep/src/stacked/vanilla/create_label/multi.rs
@@ -2,9 +2,10 @@ use std::convert::TryInto;
 use std::marker::PhantomData;
 use std::mem::{self, size_of};
 use std::path::Path;
+use std::rc::Rc;
 use std::sync::{
     atomic::{AtomicU64, Ordering::SeqCst},
-    Arc, MutexGuard,
+    MutexGuard,
 };
 use std::thread;
 use std::time::Duration;
@@ -208,7 +209,7 @@ fn create_layer_labels(
     exp_labels: Option<&mut MmapMut>,
     num_nodes: u64,
     cur_layer: u32,
-    core_group: Arc<Option<MutexGuard<'_, Vec<CoreIndex>>>>,
+    core_group: Rc<Option<MutexGuard<'_, Vec<CoreIndex>>>>,
 ) {
     info!("Creating labels for layer {}", cur_layer);
     // num_producers is the number of producer threads
@@ -458,7 +459,7 @@ pub fn create_labels_for_encoding<
 
     let default_cache_size = DEGREE * 4 * cache_window_nodes;
 
-    let core_group = Arc::new(checkout_core_group());
+    let core_group = Rc::new(checkout_core_group());
 
     // When `_cleanup_handle` is dropped, the previous binding of thread will be restored.
     let _cleanup_handle = (*core_group).as_ref().map(|group| {
@@ -556,7 +557,7 @@ pub fn create_labels_for_decoding<Tree: 'static + MerkleTreeTrait, T: AsRef<[u8]
 
     let default_cache_size = DEGREE * 4 * cache_window_nodes;
 
-    let core_group = Arc::new(checkout_core_group());
+    let core_group = Rc::new(checkout_core_group());
 
     // When `_cleanup_handle` is dropped, the previous binding of thread will be restored.
     let _cleanup_handle = (*core_group).as_ref().map(|group| {


### PR DESCRIPTION
In this case the value isn't shared across threads, hence it can be an `Rc` instead of an `Arc`.

This was found via a newly introduced Clippy warning.