### PR TITLE
fix: clean up public API for clearing files

### DIFF
--- a/fil-proofs-tooling/src/bin/benchy/porep.rs
+++ b/fil-proofs-tooling/src/bin/benchy/porep.rs
@@ -431,7 +431,7 @@ pub fn run_porep_bench<Tree: 'static + MerkleTreeTrait>(
             let phase1_output = seal_commit_phase1_measurement.return_value;
 
             if porep_config.feature_enabled(ApiFeature::SyntheticPoRep) {
-                clear_synthetic_proofs::<Tree>(&cache_dir)?;
+                clear_synthetic_proofs(&cache_dir)?;
             }
 
             // Persist commit phase1_output here

--- a/fil-proofs-tooling/src/shared.rs
+++ b/fil-proofs-tooling/src/shared.rs
@@ -278,7 +278,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
                             piece_infos[i].as_slice(),
                         )
                         .expect("failed to generate synthetic proofs");
-                        clear_cache::<Tree>(cache_dirs[i].path())
+                        clear_cache(cache_dirs[i].path())
                             .expect("failed to clear synthetic porep layer data");
                     } else {
                         info!("SyntheticPoRep is NOT enabled");

--- a/filecoin-proofs/src/api/mod.rs
+++ b/filecoin-proofs/src/api/mod.rs
@@ -1,4 +1,3 @@
-use std::collections::BTreeMap;
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
@@ -28,8 +27,8 @@ use crate::{
     parameters::public_params,
     pieces::{get_piece_alignment, sum_piece_bytes_with_alignment},
     types::{
-        Commitment, MerkleTreeTrait, PaddedBytesAmount, PieceInfo, PoRepConfig, PrivateReplicaInfo,
-        ProverId, SealPreCommitPhase1Output, Ticket, UnpaddedByteIndex, UnpaddedBytesAmount,
+        Commitment, MerkleTreeTrait, PaddedBytesAmount, PieceInfo, PoRepConfig, ProverId,
+        SealPreCommitPhase1Output, Ticket, UnpaddedByteIndex, UnpaddedBytesAmount,
     },
 };
 
@@ -51,10 +50,7 @@ pub use winning_post::*;
 
 pub use storage_proofs_update::constants::{partition_count, TreeRHasher};
 
-// TODO vmx 2023-09-26: The `Tree` generic is not needed, it's only there in order to not breaking
-// the public API. Once we break the API, remove that generic.
-// Ensure that any associated cached data persisted is discarded.
-pub fn clear_cache<Tree>(cache_dir: &Path) -> Result<()> {
+pub fn clear_cache(cache_dir: &Path) -> Result<()> {
     info!("clear_cache:start");
 
     let result = stacked::clear_cache_dir(cache_dir);
@@ -64,40 +60,7 @@ pub fn clear_cache<Tree>(cache_dir: &Path) -> Result<()> {
     result
 }
 
-// TODO vmx 2023-09-26: The `Tree` generic is not needed, it's only there in order to not breaking
-// the public API. Once we break the API, remove that generic.
-// Ensure that any associated cached data persisted is discarded.
-pub fn clear_caches<Tree: MerkleTreeTrait>(
-    replicas: &BTreeMap<SectorId, PrivateReplicaInfo<Tree>>,
-) -> Result<()> {
-    info!("clear_caches:start");
-
-    for replica in replicas.values() {
-        clear_cache::<Tree>(replica.cache_dir.as_path())?;
-    }
-
-    info!("clear_caches:finish");
-
-    Ok(())
-}
-
-// TODO vmx 2023-09-26: The `Tree` generic is not needed, it's only there in order to not breaking
-// the public API. Once we break the API, remove that generic.
-// Ensure that any persisted layer data generated from porep are discarded.
-pub fn clear_layer_data<Tree>(cache_dir: &Path) -> Result<()> {
-    info!("clear_layer_data:start");
-
-    let result = stacked::clear_cache_dir(cache_dir);
-
-    info!("clear_layer_data:finish");
-
-    result
-}
-
-// TODO vmx 2023-09-26: The `Tree` generic is not needed, it's only there in order to not breaking
-// the public API. Once we break the API, remove that generic.
-// Ensure that any persisted vanilla proofs generated from synthetic porep are discarded.
-pub fn clear_synthetic_proofs<Tree>(cache_dir: &Path) -> Result<()> {
+pub fn clear_synthetic_proofs(cache_dir: &Path) -> Result<()> {
     info!("clear_synthetic_proofs:start");
 
     let result = stacked::clear_synthetic_proofs(cache_dir);

--- a/filecoin-proofs/tests/api.rs
+++ b/filecoin-proofs/tests/api.rs
@@ -2122,7 +2122,7 @@ fn generate_proof<Tree: 'static + MerkleTreeTrait>(
             pre_commit_output.clone(),
             piece_infos,
         )?;
-        clear_cache::<Tree>(cache_dir_path)?;
+        clear_cache(cache_dir_path)?;
     } else {
         info!("SyntheticPoRep is NOT enabled");
         validate_cache_for_commit::<_, _, Tree>(cache_dir_path, sealed_sector_file.path())?;
@@ -2141,9 +2141,9 @@ fn generate_proof<Tree: 'static + MerkleTreeTrait>(
     )?;
 
     if config.feature_enabled(ApiFeature::SyntheticPoRep) {
-        clear_synthetic_proofs::<Tree>(cache_dir_path)?;
+        clear_synthetic_proofs(cache_dir_path)?;
     } else {
-        clear_cache::<Tree>(cache_dir_path)?;
+        clear_cache(cache_dir_path)?;
     }
 
     ensure!(
@@ -2363,9 +2363,9 @@ fn create_seal<R: Rng, Tree: 'static + MerkleTreeTrait>(
 
     if skip_proof {
         if porep_config.feature_enabled(ApiFeature::SyntheticPoRep) {
-            clear_synthetic_proofs::<Tree>(cache_dir.path())?;
+            clear_synthetic_proofs(cache_dir.path())?;
         }
-        clear_cache::<Tree>(cache_dir.path())?;
+        clear_cache(cache_dir.path())?;
     } else {
         proof_and_unseal::<Tree>(
             porep_config,
@@ -2592,7 +2592,7 @@ fn create_seal_for_upgrade<R: Rng, Tree: 'static + MerkleTreeTrait<Hasher = Tree
             pre_commit_output,
             &piece_infos,
         )?;
-        clear_cache::<Tree>(cache_dir.path())?;
+        clear_cache(cache_dir.path())?;
     } else {
         info!("SyntheticPoRep is NOT enabled");
         validate_cache_for_commit::<_, _, Tree>(cache_dir.path(), sealed_sector_file.path())?;
@@ -2804,10 +2804,10 @@ fn create_seal_for_upgrade<R: Rng, Tree: 'static + MerkleTreeTrait<Hasher = Tree
     remove_encoded_file.close()?;
 
     if porep_config.feature_enabled(ApiFeature::SyntheticPoRep) {
-        clear_synthetic_proofs::<Tree>(cache_dir.path())?;
+        clear_synthetic_proofs(cache_dir.path())?;
     }
-    clear_cache::<Tree>(cache_dir.path())?;
-    clear_cache::<Tree>(new_cache_dir.path())?;
+    clear_cache(cache_dir.path())?;
+    clear_cache(new_cache_dir.path())?;
 
     Ok((sector_id, sealed_sector_file, comm_r, cache_dir))
 }
@@ -2861,7 +2861,7 @@ fn create_seal_for_upgrade_aggregation<
             pre_commit_output,
             &piece_infos,
         )?;
-        clear_cache::<Tree>(cache_dir.path())?;
+        clear_cache(cache_dir.path())?;
     } else {
         info!("SyntheticPoRep is NOT enabled");
         validate_cache_for_commit::<_, _, Tree>(cache_dir.path(), sealed_sector_file.path())?;


### PR DESCRIPTION
`clear_layer_data()` and `clear_caches` are never called within `rust-fil-proofs` and also not used in `rust-filecoin-proofs-api`, hence remove them.

The `clear_cache()` and `clear_synthetic_proofs()` functions don't need to be generic over the tree as it's never used within those functions. This is a breaking change.

BREAKING CHANGE: signature of `clear_cache()` and `clear_synthetic_proofs()` changed. The generic parameter is no longer needed.

---

I've put this on master. I'll rebase it, once master is green.