### PR TITLE
chore: fix Clippy warnings

### DIFF
--- a/fil-proofs-param/tests/support/mod.rs
+++ b/fil-proofs-param/tests/support/mod.rs
@@ -88,7 +88,7 @@ pub fn tmp_manifest(
     opt_manifest: Option<BTreeMap<String, ParameterData>>,
 ) -> Result<PathBuf, failure::Error> {
     let manifest_dir = tempdir()?;
-    let mut pbuf = manifest_dir.into_path();
+    let mut pbuf = manifest_dir.keep();
     pbuf.push("parameters.json");
 
     let mut file = File::create(&pbuf)?;

--- a/fil-proofs-tooling/src/shared.rs
+++ b/fil-proofs-tooling/src/shared.rs
@@ -303,7 +303,7 @@ pub fn create_replicas<Tree: 'static + MerkleTreeTrait>(
             PrivateReplicaInfo::new(
                 sealed_file.to_path_buf(),
                 seal_pre_commit_output.comm_r,
-                cache_dir.into_path(),
+                cache_dir.keep(),
             )
             .expect("failed to create PrivateReplicaInfo")
         });


### PR DESCRIPTION
On a fresh checkout, there's no a warning on some `tempfile` usage. This commit fixes it.