### PR TITLE
Fix: Correct typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The dependencies between those crates look like this:
        └────────────────────────────────────────────────────────────────────┘
 ```
 
-Things shared between crates, should go into `storage-proofs-core`. An exception is the `storage-proofs-update`, which needs the needs the stacked DRG from `storage-proofs-porep`. All crates are free to use other crates for the workspace like [`filecoin-hashers`](./filecoin-hashers) or [`fr32`](./fr32).
+Things shared between crates, should go into `storage-proofs-core`. An exception is the `storage-proofs-update`, which needs the stacked DRG from `storage-proofs-porep`. All crates are free to use other crates for the workspace like [`filecoin-hashers`](./filecoin-hashers) or [`fr32`](./fr32).
 
 ## Security Audits
 


### PR DESCRIPTION
Hey, our tool caught a few typos in your repository.

Also, a few typos on your site like 'datas'. Here is your error report:
 https://triplechecker.com/s/z7oeMh/filecoin.io

Hope it's helpful!
